### PR TITLE
Implement FST drawing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- `write-text` function to serialize an `ExpandedFst` into text format (compatible with OpenFST).
+- `draw` to generate a file representing an `ExpandedFst` in dot format that can be displayed with GraphViz.
+- Implement `num_input_epsilons`, `num_output_expilons` and `relabel_pairs`.
+- `closure_plus` and `closure_star` are now also available as provided methods on a `MutabeFst`.
+- Add `is_one` and `is_zero` to `Semiring` API.
+- Asd `is_start` to `Fst` API.
+
+### Changed
+
+
+### Removed
+- `determinize` no longer public as the implementation is not satisfactory.
+
+## [0.1.7] - 2018-10-23
+### Added
+- First released version of rustfst
+
+[Unreleased]: https://github.com/garvys/rustfst/compare/0.1.7...HEAD
+[0.1.7]: https://github.com/garvys/rustfst/compare/0.1.2...0.1.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement `num_input_epsilons`, `num_output_expilons` and `relabel_pairs`.
 - `closure_plus` and `closure_star` are now also available as provided methods on a `MutabeFst`.
 - Add `is_one` and `is_zero` to `Semiring` API.
-- Asd `is_start` to `Fst` API.
+- Add `is_start` to `Fst` API.
 
 ### Changed
 

--- a/src/drawing_config.rs
+++ b/src/drawing_config.rs
@@ -1,14 +1,26 @@
+
+/// Struct to configure how the FST will be displayed
 #[derive(Debug, Clone, PartialEq)]
 pub struct DrawingConfig {
+    /// Draw bottom-to-top instead of left-to-right
     pub vertical: bool,
+    /// Set width
     pub width: f32,
+    /// Set height
     pub height: f32,
+    /// Set figure title
     pub title: String,
+    /// Portrait mode (def: landscape)
     pub portrait: bool,
+    /// Set minimum separation between ranks (see dot documentation)
     pub ranksep: f32,
+    /// Set minimum separation between nodes (see dot documentation)
     pub nodesep: f32,
+    /// Set fontsize
     pub fontsize: u32,
+    /// Input in acceptor format
     pub acceptor: bool,
+    /// Print/draw arc weights and final weights equal to Weight::One()
     pub show_weight_one: bool,
 }
 

--- a/src/drawing_config.rs
+++ b/src/drawing_config.rs
@@ -1,0 +1,30 @@
+#[derive(Debug, Clone, PartialEq)]
+pub struct DrawingConfig {
+    pub vertical: bool,
+    pub width: f32,
+    pub height: f32,
+    pub title: String,
+    pub portrait: bool,
+    pub ranksep: f32,
+    pub nodesep: f32,
+    pub fontsize: u32,
+    pub acceptor: bool,
+    pub show_weight_one: bool,
+}
+
+impl Default for DrawingConfig {
+    fn default() -> Self {
+        Self {
+            vertical: false,
+            width: 8.5,
+            height: 11.0,
+            title: "".to_string(),
+            portrait: false,
+            ranksep: 0.40,
+            nodesep: 0.25,
+            fontsize: 14,
+            acceptor: false,
+            show_weight_one: true,
+        }
+    }
+}

--- a/src/fst_traits/expanded_fst.rs
+++ b/src/fst_traits/expanded_fst.rs
@@ -39,6 +39,7 @@ pub trait ExpandedFst: Fst {
         Ok(())
     }
 
+    /// Serializes the FST as a DOT file compatible with GraphViz binaries
     fn draw<P: AsRef<Path>>(&self, path_output: P, config: &DrawingConfig) -> Result<()> {
         let buffer = File::create(path_output.as_ref())?;
         let mut f = LineWriter::new(buffer);

--- a/src/fst_traits/fst.rs
+++ b/src/fst_traits/fst.rs
@@ -1,10 +1,6 @@
 use arc::Arc;
-use fst_traits::final_states_iterator::FinalStatesIterator;
 use semirings::Semiring;
 use std::fmt::Display;
-use std::fs::File;
-use std::io::{LineWriter, Write};
-use std::path::Path;
 use Result;
 use StateId;
 use EPS_LABEL;
@@ -96,6 +92,10 @@ pub trait CoreFst {
     /// ```
     fn is_final(&self, state_id: &StateId) -> bool {
         self.final_weight(state_id).is_some()
+    }
+
+    fn is_start(&self, state_id: &StateId) -> bool {
+        Some(*state_id) == self.start()
     }
 
     //type Symtab: IntoIterator<Item=String>;
@@ -205,13 +205,5 @@ pub trait Fst:
             .arcs_iter(&state)?
             .filter(|v| v.olabel == EPS_LABEL)
             .count())
-    }
-
-    /// Serializes the FST as a text file in a format compatible with OpenFST.
-    fn write_text<P: AsRef<Path>>(&self, path_output: P) -> Result<()> {
-        let buffer = File::create(path_output.as_ref())?;
-        let mut line_writer = LineWriter::new(buffer);
-        write_fst!(self, line_writer);
-        Ok(())
     }
 }

--- a/src/fst_traits/macros.rs
+++ b/src/fst_traits/macros.rs
@@ -68,3 +68,39 @@ macro_rules! display_fst_trait {
         }
     };
 }
+
+macro_rules! draw_single_state {
+    ($fst:expr, $state_id:expr, $f: expr, $config:expr) => {
+        write!($f, "{}", $state_id)?;
+        write!($f, " [label = \"{}", $state_id)?;
+        if let Some(final_weight) = $fst.final_weight($state_id) {
+            if $config.show_weight_one || !final_weight.is_one() {
+                write!($f, "/{}", final_weight)?;
+            }
+            write!($f, "\", shape = doublecircle,")?;
+        } else {
+            write!($f, "\", shape = circle,")?;
+        }
+
+        if $fst.is_start($state_id) {
+            write!($f, " style = bold,")?;
+        } else {
+            write!($f, " style = solid,")?;
+        }
+
+        writeln!($f, " fontsize = {}]", $config.fontsize)?;
+
+        for arc in $fst.arcs_iter($state_id).unwrap() {
+            write!($f, "\t{} -> {}", $state_id, arc.nextstate)?;
+            write!($f, " [label = \"{}", arc.ilabel)?;
+            if !$config.acceptor {
+                write!($f, ":{}", arc.olabel)?;
+            }
+
+            if $config.show_weight_one || !arc.weight.is_one() {
+                write!($f, "/{}", arc.weight)?;
+            }
+            writeln!($f, "\", fontsize = {}];", $config.fontsize)?;
+        }
+    };
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,9 @@ pub type StateId = usize;
 /// Epsilon label representing the epsilon transition (empty transition).
 pub static EPS_LABEL: Label = 0;
 
+mod drawing_config;
+pub use drawing_config::DrawingConfig;
+
 /// Provides algorithms that are generic for all wFST.
 pub mod algorithms;
 /// Implementation of the transitions inside a wFST.

--- a/src/semirings/semiring.rs
+++ b/src/semirings/semiring.rs
@@ -18,6 +18,12 @@ pub trait Semiring:
     fn one() -> Self;
     fn value(&self) -> Self::Type;
     fn set_value(&mut self, Self::Type);
+    fn is_one(&self) -> bool {
+        *self == Self::one()
+    }
+    fn is_zero(&self) -> bool {
+        *self == Self::zero()
+    }
 }
 
 /// A semiring is said to be divisible if all non-0 elements admit an inverse,


### PR DESCRIPTION
- Add `is_one` and `is_zero` to `Semiring` API.
- Add `is_start` to `Fst` API.
- `draw` to generate a file representing an `ExpandedFst` in dot format that can be displayed with GraphViz.
