### PR TITLE
Task/update for release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement `isomorphic` operation to compare two FSTs without depending on the ordering of the states or the arcs.
 - Implement a `SymbolTable` data structure to handle the mapping symbol (string) / label (int) in a FST.
 - Add `symt!` macro to quickly create a `SymbolTable` from a list of strings.
-- Add `acceptor!` macro to quickly create an acceptor from a list of labels.
-- Add `transducer!` macro to quickly create an transducer from two list of labels.
+- Add `fst!` macro to quickly create an acceptor or a transducer from a list of labels.
 - Migrate to edition 2018 of Rust.
 - Add integration tests to compare the output of this crate directly with OpenFST (by using the pynini python wrapper).
 - Add weight quantization for f32 Semiring and use it in the PartialEq trait.
+- Add `fst_path!` macro to easily create a FstPath object.
 
 ### Changed
 - `new` method now present in the `Semiring` trait.
@@ -32,7 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `acceptor`, `transducer`, `inverse`, `project`, `closure_plus`, `closure_star` functions can't fail anymore (no Result in API).
 - Fix multiple issues when parsing an FST in text format.
 - The `num_arcs` function in the `Fst` trait now computes the number of arcs leaving a specific state instead of the number of arcs in the graph.
-- `algorithm` mod is now private, all the operations are exported to the root.
+- `acceptor` and `transducer` methods now take slices and weight instead of only iterator of labels.
+- Rename `Path` object to `FstPath` to avoid conflicts with the one from the standard library.
 
 ### Removed
 - `determinize` no longer public as the implementation is not satisfactory.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Add it to your `Cargo.toml`:
 
 ```
 [dependencies]
-rustfst = "0.1"
+rustfst = "*"
 ```
 
 Add `extern crate rustfst` to your crate root and you are good to go!

--- a/src/algorithms/all_pairs_shortest_distance.rs
+++ b/src/algorithms/all_pairs_shortest_distance.rs
@@ -5,7 +5,7 @@ use crate::semirings::{Semiring, StarSemiring};
 use crate::Result;
 
 /// This operation computes the shortest distance from each state to every other states.
-/// The shortest distance from `p` to `q `is the ⊕-sum of the weights
+/// The shortest distance from `p` to `q` is the ⊕-sum of the weights
 /// of all the paths between `p` and `q`.
 ///
 /// # Example
@@ -14,7 +14,7 @@ use crate::Result;
 /// # use rustfst::semirings::{Semiring, IntegerWeight};
 /// # use rustfst::fst_impls::VectorFst;
 /// # use rustfst::fst_traits::MutableFst;
-/// # use rustfst::all_pairs_shortest_distance;
+/// # use rustfst::algorithms::all_pairs_shortest_distance;
 /// # use rustfst::Arc;
 /// # use rustfst::Result;
 /// # fn main() -> Result<()> {

--- a/src/algorithms/closure_star.rs
+++ b/src/algorithms/closure_star.rs
@@ -1,5 +1,5 @@
 use crate::arc::Arc;
-use crate::closure_plus;
+use crate::algorithms::closure_plus;
 use crate::fst_traits::{CoreFst, MutableFst};
 use crate::semirings::Semiring;
 use crate::EPS_LABEL;

--- a/src/algorithms/closure_star.rs
+++ b/src/algorithms/closure_star.rs
@@ -1,5 +1,5 @@
-use crate::arc::Arc;
 use crate::algorithms::closure_plus;
+use crate::arc::Arc;
 use crate::fst_traits::{CoreFst, MutableFst};
 use crate::semirings::Semiring;
 use crate::EPS_LABEL;

--- a/src/algorithms/composition.rs
+++ b/src/algorithms/composition.rs
@@ -19,7 +19,7 @@ use crate::Result;
 /// # use rustfst::utils::transducer;
 /// # use rustfst::semirings::{Semiring, IntegerWeight};
 /// # use rustfst::fst_impls::VectorFst;
-/// # use rustfst::compose;
+/// # use rustfst::algorithms::compose;
 /// # fn main() -> Result<()> {
 /// let fst_1 : VectorFst<IntegerWeight> = transducer![1,2 => 2,3];
 ///

--- a/src/algorithms/composition.rs
+++ b/src/algorithms/composition.rs
@@ -21,11 +21,11 @@ use crate::Result;
 /// # use rustfst::fst_impls::VectorFst;
 /// # use rustfst::algorithms::compose;
 /// # fn main() -> Result<()> {
-/// let fst_1 : VectorFst<IntegerWeight> = transducer![1,2 => 2,3];
+/// let fst_1 : VectorFst<IntegerWeight> = fst![1,2 => 2,3];
 ///
-/// let fst_2 : VectorFst<IntegerWeight> = transducer![2,3 => 3,4];
+/// let fst_2 : VectorFst<IntegerWeight> = fst![2,3 => 3,4];
 ///
-/// let fst_ref : VectorFst<IntegerWeight> = transducer![1,2 => 3,4];
+/// let fst_ref : VectorFst<IntegerWeight> = fst![1,2 => 3,4];
 ///
 /// let composed_fst : VectorFst<_> = compose(&fst_1, &fst_2)?;
 /// assert_eq!(composed_fst, fst_ref);

--- a/src/algorithms/concat.rs
+++ b/src/algorithms/concat.rs
@@ -15,7 +15,7 @@ use crate::{Result, EPS_LABEL};
 /// # use rustfst::fst_impls::VectorFst;
 /// # use rustfst::fst_traits::PathsIterator;
 /// # use rustfst::Path;
-/// # use rustfst::concat;
+/// # use rustfst::algorithms::concat;
 /// # use rustfst::Result;
 /// # use std::collections::HashSet;
 /// # fn main() -> Result<()> {

--- a/src/algorithms/concat.rs
+++ b/src/algorithms/concat.rs
@@ -19,14 +19,14 @@ use crate::{Result, EPS_LABEL};
 /// # use rustfst::Result;
 /// # use std::collections::HashSet;
 /// # fn main() -> Result<()> {
-/// let fst_a : VectorFst<IntegerWeight> = transducer![2 => 3];
-/// let fst_b : VectorFst<IntegerWeight> = transducer![6 => 5];
+/// let fst_a : VectorFst<IntegerWeight> = fst![2 => 3];
+/// let fst_b : VectorFst<IntegerWeight> = fst![6 => 5];
 ///
 /// let fst_res : VectorFst<IntegerWeight> = concat(&fst_a, &fst_b)?;
 /// let paths : HashSet<_> = fst_res.paths_iter().collect();
 ///
-/// let mut paths_ref = HashSet::new();
-/// paths_ref.insert(Path::new(vec![2, 6], vec![3, 5], IntegerWeight::ONE));
+/// let mut paths_ref = HashSet::<Path<IntegerWeight>>::new();
+/// paths_ref.insert(fst_path![2,6 => 3,5]);
 ///
 /// assert_eq!(paths, paths_ref);
 /// # Ok(())

--- a/src/algorithms/concat.rs
+++ b/src/algorithms/concat.rs
@@ -14,7 +14,7 @@ use crate::{Result, EPS_LABEL};
 /// # use rustfst::semirings::{Semiring, IntegerWeight};
 /// # use rustfst::fst_impls::VectorFst;
 /// # use rustfst::fst_traits::PathsIterator;
-/// # use rustfst::Path;
+/// # use rustfst::FstPath;
 /// # use rustfst::algorithms::concat;
 /// # use rustfst::Result;
 /// # use std::collections::HashSet;
@@ -25,7 +25,7 @@ use crate::{Result, EPS_LABEL};
 /// let fst_res : VectorFst<IntegerWeight> = concat(&fst_a, &fst_b)?;
 /// let paths : HashSet<_> = fst_res.paths_iter().collect();
 ///
-/// let mut paths_ref = HashSet::<Path<IntegerWeight>>::new();
+/// let mut paths_ref = HashSet::<FstPath<IntegerWeight>>::new();
 /// paths_ref.insert(fst_path![2,6 => 3,5]);
 ///
 /// assert_eq!(paths, paths_ref);

--- a/src/algorithms/connect.rs
+++ b/src/algorithms/connect.rs
@@ -39,7 +39,7 @@ fn dfs<F: Fst>(
 /// # use rustfst::fst_impls::VectorFst;
 /// # use rustfst::algorithms::connect;
 /// # use rustfst::fst_traits::MutableFst;
-/// let fst : VectorFst<IntegerWeight> = transducer![2 => 3];
+/// let fst : VectorFst<IntegerWeight> = fst![2 => 3];
 ///
 /// // Add a state not on a successful path
 /// let mut no_connected_fst = fst.clone();

--- a/src/algorithms/connect.rs
+++ b/src/algorithms/connect.rs
@@ -37,7 +37,7 @@ fn dfs<F: Fst>(
 /// # use rustfst::utils::transducer;
 /// # use rustfst::semirings::{Semiring, IntegerWeight};
 /// # use rustfst::fst_impls::VectorFst;
-/// # use rustfst::connect;
+/// # use rustfst::algorithms::connect;
 /// # use rustfst::fst_traits::MutableFst;
 /// let fst : VectorFst<IntegerWeight> = transducer![2 => 3];
 ///

--- a/src/algorithms/epsilon_removal.rs
+++ b/src/algorithms/epsilon_removal.rs
@@ -1,9 +1,10 @@
-use crate::all_pairs_shortest_distance;
+use std::collections::HashMap;
+
+use crate::algorithms::all_pairs_shortest_distance;
 use crate::arc::Arc;
 use crate::fst_traits::{ExpandedFst, FinalStatesIterator, MutableFst};
 use crate::semirings::{Semiring, StarSemiring};
 use crate::{Result, EPS_LABEL};
-use std::collections::HashMap;
 
 // Compute the wFST derived from "fst" by keeping only the epsilon transitions
 fn compute_fst_epsilon<W, F1, F2>(fst: &F1, keep_only_epsilon: bool) -> Result<F2>
@@ -66,7 +67,7 @@ where
 /// # use rustfst::semirings::{Semiring, IntegerWeight};
 /// # use rustfst::fst_impls::VectorFst;
 /// # use rustfst::fst_traits::MutableFst;
-/// # use rustfst::rm_epsilon;
+/// # use rustfst::algorithms::rm_epsilon;
 /// # use rustfst::Arc;
 /// # use rustfst::EPS_LABEL;
 /// let mut fst = VectorFst::new();

--- a/src/algorithms/inversion.rs
+++ b/src/algorithms/inversion.rs
@@ -12,10 +12,10 @@ use crate::fst_traits::{ExpandedFst, MutableFst};
 /// # use rustfst::semirings::{Semiring, IntegerWeight};
 /// # use rustfst::fst_impls::VectorFst;
 /// # use rustfst::algorithms::invert;
-/// let mut fst : VectorFst<IntegerWeight> = transducer![2 => 3];
+/// let mut fst : VectorFst<IntegerWeight> = fst![2 => 3];
 /// invert(&mut fst);
 ///
-/// assert_eq!(fst, transducer![3 => 2]);
+/// assert_eq!(fst, fst![3 => 2]);
 /// ```
 pub fn invert<F: ExpandedFst + MutableFst>(fst: &mut F) {
     let states: Vec<_> = fst.states_iter().collect();

--- a/src/algorithms/inversion.rs
+++ b/src/algorithms/inversion.rs
@@ -11,7 +11,7 @@ use crate::fst_traits::{ExpandedFst, MutableFst};
 /// # use rustfst::utils::{acceptor, transducer};
 /// # use rustfst::semirings::{Semiring, IntegerWeight};
 /// # use rustfst::fst_impls::VectorFst;
-/// # use rustfst::invert;
+/// # use rustfst::algorithms::invert;
 /// let mut fst : VectorFst<IntegerWeight> = transducer![2 => 3];
 /// invert(&mut fst);
 ///

--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -1,17 +1,36 @@
-pub mod all_pairs_shortest_distance;
-pub mod closure_plus;
-pub mod closure_star;
-pub mod composition;
-pub mod concat;
-pub mod connect;
-pub mod determinization;
-pub mod epsilon_removal;
-pub mod inversion;
-pub mod isomorphic;
-pub mod projection;
-pub mod relabel_pairs;
-pub mod reverse;
-pub mod reweight;
-pub mod single_source_shortest_distance;
-pub mod union;
-pub mod weight_pushing;
+mod all_pairs_shortest_distance;
+mod closure_plus;
+mod closure_star;
+mod composition;
+mod concat;
+mod connect;
+mod determinization;
+mod epsilon_removal;
+mod inversion;
+mod isomorphic;
+mod projection;
+mod relabel_pairs;
+mod reverse;
+mod reweight;
+mod single_source_shortest_distance;
+mod union;
+mod weight_pushing;
+
+pub use self::{
+    all_pairs_shortest_distance::all_pairs_shortest_distance,
+    closure_plus::closure_plus,
+    closure_star::closure_star,
+    composition::compose,
+    concat::concat,
+    connect::connect,
+    epsilon_removal::rm_epsilon,
+    inversion::invert,
+    isomorphic::isomorphic,
+    projection::{project, ProjectType},
+    relabel_pairs::relabel_pairs,
+    reverse::reverse,
+    reweight::{reweight, ReweightType},
+    single_source_shortest_distance::{shortest_distance, single_source_shortest_distance},
+    union::union,
+    weight_pushing::push_weights,
+};

--- a/src/algorithms/projection.rs
+++ b/src/algorithms/projection.rs
@@ -18,7 +18,7 @@ pub enum ProjectType {
 /// # use rustfst::utils::{acceptor, transducer};
 /// # use rustfst::semirings::{Semiring, IntegerWeight};
 /// # use rustfst::fst_impls::VectorFst;
-/// # use rustfst::{project, ProjectType};
+/// # use rustfst::algorithms::{project, ProjectType};
 /// # fn main() -> Result<()> {
 /// let mut fst : VectorFst<IntegerWeight> = transducer![2 => 3];
 /// project(&mut fst, ProjectType::ProjectInput);
@@ -35,7 +35,7 @@ pub enum ProjectType {
 /// # use rustfst::utils::{acceptor, transducer};
 /// # use rustfst::semirings::{Semiring, IntegerWeight};
 /// # use rustfst::fst_impls::VectorFst;
-/// # use rustfst::{project, ProjectType};
+/// # use rustfst::algorithms::{project, ProjectType};
 /// # fn main() -> Result<()> {
 /// let mut fst : VectorFst<IntegerWeight> = transducer![2 => 3];
 /// project(&mut fst, ProjectType::ProjectOutput);

--- a/src/algorithms/projection.rs
+++ b/src/algorithms/projection.rs
@@ -1,7 +1,10 @@
 use crate::fst_traits::{ExpandedFst, MutableFst};
 
+/// Different types of labels projection in a FST.
 pub enum ProjectType {
+    /// Input projection : output labels are replaced with input ones.
     ProjectInput,
+    /// Output projection : input labels are replaced with output ones.
     ProjectOutput,
 }
 

--- a/src/algorithms/projection.rs
+++ b/src/algorithms/projection.rs
@@ -20,10 +20,10 @@ pub enum ProjectType {
 /// # use rustfst::fst_impls::VectorFst;
 /// # use rustfst::algorithms::{project, ProjectType};
 /// # fn main() -> Result<()> {
-/// let mut fst : VectorFst<IntegerWeight> = transducer![2 => 3];
+/// let mut fst : VectorFst<IntegerWeight> = fst![2 => 3];
 /// project(&mut fst, ProjectType::ProjectInput);
 ///
-/// assert_eq!(fst, acceptor![2]);
+/// assert_eq!(fst, fst![2]);
 /// # Ok(())
 /// # }
 /// ```
@@ -37,10 +37,10 @@ pub enum ProjectType {
 /// # use rustfst::fst_impls::VectorFst;
 /// # use rustfst::algorithms::{project, ProjectType};
 /// # fn main() -> Result<()> {
-/// let mut fst : VectorFst<IntegerWeight> = transducer![2 => 3];
+/// let mut fst : VectorFst<IntegerWeight> = fst![2 => 3];
 /// project(&mut fst, ProjectType::ProjectOutput);
 ///
-/// assert_eq!(fst, acceptor(vec![3].into_iter()));
+/// assert_eq!(fst, fst![3]);
 /// # Ok(())
 /// # }
 /// ```

--- a/src/algorithms/relabel_pairs.rs
+++ b/src/algorithms/relabel_pairs.rs
@@ -34,7 +34,7 @@ where
 /// # use rustfst::utils::transducer;
 /// # use rustfst::semirings::{Semiring, IntegerWeight};
 /// # use rustfst::fst_impls::VectorFst;
-/// # use rustfst::relabel_pairs;
+/// # use rustfst::algorithms::relabel_pairs;
 /// # use rustfst::Result;
 /// # fn main() -> Result<()> {
 /// let mut fst : VectorFst<IntegerWeight> = transducer![2 => 3];

--- a/src/algorithms/relabel_pairs.rs
+++ b/src/algorithms/relabel_pairs.rs
@@ -37,10 +37,10 @@ where
 /// # use rustfst::algorithms::relabel_pairs;
 /// # use rustfst::Result;
 /// # fn main() -> Result<()> {
-/// let mut fst : VectorFst<IntegerWeight> = transducer![2 => 3];
+/// let mut fst : VectorFst<IntegerWeight> = fst![2 => 3];
 /// relabel_pairs(&mut fst, vec![(2,5)], vec![(3,4)])?;
 ///
-/// assert_eq!(fst, transducer![5 => 4]);
+/// assert_eq!(fst, fst![5 => 4]);
 /// # Ok(())
 /// # }
 /// ```

--- a/src/algorithms/reweight.rs
+++ b/src/algorithms/reweight.rs
@@ -2,8 +2,11 @@ use crate::fst_traits::{ExpandedFst, FinalStatesIterator, Fst, MutableFst};
 use crate::semirings::{Semiring, WeaklyDivisibleSemiring};
 use crate::Result;
 
+/// Different types of reweighting.
 pub enum ReweightType {
+    /// Reweight toward initial state.
     ReweightToInitial,
+    /// Reweight toward final states.
     ReweightToFinal,
 }
 

--- a/src/algorithms/single_source_shortest_distance.rs
+++ b/src/algorithms/single_source_shortest_distance.rs
@@ -13,7 +13,7 @@ use crate::{Result, StateId};
 /// # use rustfst::semirings::{Semiring, IntegerWeight};
 /// # use rustfst::fst_impls::VectorFst;
 /// # use rustfst::fst_traits::MutableFst;
-/// # use rustfst::single_source_shortest_distance;
+/// # use rustfst::algorithms::single_source_shortest_distance;
 /// # use rustfst::Arc;
 /// let mut fst = VectorFst::new();
 /// let s0 = fst.add_state();
@@ -84,7 +84,7 @@ pub fn single_source_shortest_distance<F: ExpandedFst>(
 /// # use rustfst::semirings::{Semiring, IntegerWeight};
 /// # use rustfst::fst_impls::VectorFst;
 /// # use rustfst::fst_traits::MutableFst;
-/// # use rustfst::shortest_distance;
+/// # use rustfst::algorithms::shortest_distance;
 /// # use rustfst::Arc;
 /// let mut fst = VectorFst::new();
 /// let s0 = fst.add_state();

--- a/src/algorithms/union.rs
+++ b/src/algorithms/union.rs
@@ -19,7 +19,7 @@ use crate::{Result, StateId};
 /// # use rustfst::semirings::{Semiring, IntegerWeight};
 /// # use rustfst::fst_impls::VectorFst;
 /// # use rustfst::fst_traits::PathsIterator;
-/// # use rustfst::Path;
+/// # use rustfst::FstPath;
 /// # use rustfst::algorithms::union;
 /// # use std::collections::HashSet;
 /// # fn main() -> Result<()> {
@@ -29,7 +29,7 @@ use crate::{Result, StateId};
 /// let fst_res : VectorFst<IntegerWeight> = union(&fst_a, &fst_b)?;
 /// let paths : HashSet<_> = fst_res.paths_iter().collect();
 ///
-/// let mut paths_ref = HashSet::<Path<IntegerWeight>>::new();
+/// let mut paths_ref = HashSet::<FstPath<IntegerWeight>>::new();
 /// paths_ref.insert(fst_path![2 => 3]);
 /// paths_ref.insert(fst_path![6 => 5]);
 ///

--- a/src/algorithms/union.rs
+++ b/src/algorithms/union.rs
@@ -23,15 +23,15 @@ use crate::{Result, StateId};
 /// # use rustfst::algorithms::union;
 /// # use std::collections::HashSet;
 /// # fn main() -> Result<()> {
-/// let fst_a : VectorFst<IntegerWeight> = transducer![2 => 3];
-/// let fst_b : VectorFst<IntegerWeight> = transducer![6 => 5];
+/// let fst_a : VectorFst<IntegerWeight> = fst![2 => 3];
+/// let fst_b : VectorFst<IntegerWeight> = fst![6 => 5];
 ///
 /// let fst_res : VectorFst<IntegerWeight> = union(&fst_a, &fst_b)?;
 /// let paths : HashSet<_> = fst_res.paths_iter().collect();
 ///
-/// let mut paths_ref = HashSet::new();
-/// paths_ref.insert(Path::new(vec![2], vec![3], IntegerWeight::ONE));
-/// paths_ref.insert(Path::new(vec![6], vec![5], IntegerWeight::ONE));
+/// let mut paths_ref = HashSet::<Path<IntegerWeight>>::new();
+/// paths_ref.insert(fst_path![2 => 3]);
+/// paths_ref.insert(fst_path![6 => 5]);
 ///
 /// assert_eq!(paths, paths_ref);
 /// # Ok(())

--- a/src/algorithms/union.rs
+++ b/src/algorithms/union.rs
@@ -20,7 +20,7 @@ use crate::{Result, StateId};
 /// # use rustfst::fst_impls::VectorFst;
 /// # use rustfst::fst_traits::PathsIterator;
 /// # use rustfst::Path;
-/// # use rustfst::union;
+/// # use rustfst::algorithms::union;
 /// # use std::collections::HashSet;
 /// # fn main() -> Result<()> {
 /// let fst_a : VectorFst<IntegerWeight> = transducer![2 => 3];

--- a/src/algorithms/weight_pushing.rs
+++ b/src/algorithms/weight_pushing.rs
@@ -1,7 +1,7 @@
+use crate::algorithms::{reverse, reweight, shortest_distance, ReweightType};
 use crate::fst_traits::{ExpandedFst, Fst, MutableFst};
 use crate::semirings::WeaklyDivisibleSemiring;
 use crate::Result;
-use crate::algorithms::{reverse, reweight, shortest_distance, ReweightType};
 
 /// Pushes the weights in FST in the direction defined by TYPE. If
 /// pushing towards the initial state, the sum of the weight of the

--- a/src/algorithms/weight_pushing.rs
+++ b/src/algorithms/weight_pushing.rs
@@ -1,7 +1,7 @@
 use crate::fst_traits::{ExpandedFst, Fst, MutableFst};
 use crate::semirings::WeaklyDivisibleSemiring;
 use crate::Result;
-use crate::{reverse, reweight, shortest_distance, ReweightType};
+use crate::algorithms::{reverse, reweight, shortest_distance, ReweightType};
 
 /// Pushes the weights in FST in the direction defined by TYPE. If
 /// pushing towards the initial state, the sum of the weight of the

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -1,7 +1,7 @@
 use crate::semirings::Semiring;
 use crate::{Label, StateId};
 
-/// Arc structure.
+/// Structure representing a transition from a state to another state in a FST.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Arc<W: Semiring> {
     /// Input label.

--- a/src/drawing_config.rs
+++ b/src/drawing_config.rs
@@ -1,25 +1,25 @@
-/// Struct to configure how the FST will be displayed
+/// Struct to configure how the FST should be drawn.
 #[derive(Debug, Clone, PartialEq)]
 pub struct DrawingConfig {
-    /// Draw bottom-to-top instead of left-to-right
+    /// Draw bottom-to-top instead of left-to-right.
     pub vertical: bool,
-    /// Set width
+    /// Set width.
     pub width: f32,
-    /// Set height
+    /// Set height.
     pub height: f32,
-    /// Set figure title
+    /// Set figure title.
     pub title: String,
-    /// Portrait mode (def: landscape)
+    /// Portrait mode (def: landscape).
     pub portrait: bool,
-    /// Set minimum separation between ranks (see dot documentation)
+    /// Set minimum separation between ranks (see dot documentation).
     pub ranksep: f32,
-    /// Set minimum separation between nodes (see dot documentation)
+    /// Set minimum separation between nodes (see dot documentation).
     pub nodesep: f32,
-    /// Set fontsize
+    /// Set fontsize.
     pub fontsize: u32,
-    /// Input in acceptor format
+    /// Input in acceptor format.
     pub acceptor: bool,
-    /// Print/draw arc weights and final weights equal to Weight::One()
+    /// Print/draw arc weights and final weights equal to Weight::ONE.
     pub show_weight_one: bool,
 }
 

--- a/src/fst_impls/vector/vector_fst.rs
+++ b/src/fst_impls/vector/vector_fst.rs
@@ -14,6 +14,10 @@ use crate::semirings::Semiring;
 use crate::algorithms::{concat, union};
 use crate::{Result, StateId};
 
+/// Simple concrete, mutable FST whose states and arcs are stored in standard vectors.
+///
+/// All states are stored in a vector of states.
+/// In each state, there is a vector of arcs containing the outgoing transitions.
 #[derive(Debug, PartialEq, Clone)]
 pub struct VectorFst<W: Semiring> {
     pub(crate) states: Vec<VectorFstState<W>>,

--- a/src/fst_impls/vector/vector_fst.rs
+++ b/src/fst_impls/vector/vector_fst.rs
@@ -11,7 +11,7 @@ use crate::fst_traits::{
 };
 use crate::parsers::text_fst::ParsedTextFst;
 use crate::semirings::Semiring;
-use crate::{concat, union};
+use crate::algorithms::{concat, union};
 use crate::{Result, StateId};
 
 #[derive(Debug, PartialEq, Clone)]

--- a/src/fst_impls/vector/vector_fst.rs
+++ b/src/fst_impls/vector/vector_fst.rs
@@ -4,6 +4,7 @@ use std::slice;
 
 use failure::{bail, ensure, format_err};
 
+use crate::algorithms::{concat, union};
 use crate::arc::Arc;
 use crate::fst_traits::{
     ArcIterator, CoreFst, ExpandedFst, FinalStatesIterator, Fst, MutableArcIterator, MutableFst,
@@ -11,7 +12,6 @@ use crate::fst_traits::{
 };
 use crate::parsers::text_fst::ParsedTextFst;
 use crate::semirings::Semiring;
-use crate::algorithms::{concat, union};
 use crate::{Result, StateId};
 
 /// Simple concrete, mutable FST whose states and arcs are stored in standard vectors.

--- a/src/fst_path.rs
+++ b/src/fst_path.rs
@@ -6,7 +6,7 @@ use crate::{Label, EPS_LABEL};
 /// Structure representing a path in a FST
 /// (list of input labels, list of output labels and total weight).
 #[derive(PartialEq, Debug, Clone, PartialOrd)]
-pub struct Path<W: Semiring> {
+pub struct FstPath<W: Semiring> {
     /// List of input labels.
     pub ilabels: Vec<Label>,
     /// List of output labels.
@@ -15,11 +15,11 @@ pub struct Path<W: Semiring> {
     pub weight: W,
 }
 
-impl<W: Semiring> Path<W> {
+impl<W: Semiring> FstPath<W> {
 
     /// Creates a new Path.
     pub fn new(ilabels: Vec<Label>, olabels: Vec<Label>, weight: W) -> Self {
-        Path {
+        FstPath {
             ilabels,
             olabels,
             weight,
@@ -47,18 +47,18 @@ impl<W: Semiring> Path<W> {
     }
 
     /// Append a Path to the current Path. Labels are appended and weights multiplied.
-    pub fn concat(&mut self, other: Path<W>) {
+    pub fn concat(&mut self, other: FstPath<W>) {
         self.ilabels.extend(other.ilabels);
         self.olabels.extend(other.olabels);
         self.weight *= other.weight;
     }
 }
 
-impl<W: Semiring> Default for Path<W> {
+impl<W: Semiring> Default for FstPath<W> {
 
     /// Creates an empty path with a weight one.
     fn default() -> Self {
-        Path {
+        FstPath {
             ilabels: vec![],
             olabels: vec![],
             weight: W::ONE,
@@ -67,7 +67,7 @@ impl<W: Semiring> Default for Path<W> {
 }
 
 #[allow(clippy::derive_hash_xor_eq)]
-impl<W: Semiring + Hash + Eq> Hash for Path<W> {
+impl<W: Semiring + Hash + Eq> Hash for FstPath<W> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.ilabels.hash(state);
         self.olabels.hash(state);
@@ -75,7 +75,7 @@ impl<W: Semiring + Hash + Eq> Hash for Path<W> {
     }
 }
 
-impl<W: Semiring + Hash + Eq> Eq for Path<W> {}
+impl<W: Semiring + Hash + Eq> Eq for FstPath<W> {}
 
 /// Creates a Path containing the arguments.
 ///
@@ -86,8 +86,8 @@ impl<W: Semiring + Hash + Eq> Eq for Path<W> {}
 /// ```
 /// # #[macro_use] extern crate rustfst; fn main() {
 /// # use rustfst::semirings::{IntegerWeight, Semiring};
-/// # use rustfst::Path;
-/// let path : Path<IntegerWeight> = fst_path![1,2,3];
+/// # use rustfst::FstPath;
+/// let path : FstPath<IntegerWeight> = fst_path![1,2,3];
 /// assert_eq!(path.ilabels, vec![1,2,3]);
 /// assert_eq!(path.olabels, vec![1,2,3]);
 /// assert_eq!(path.weight, IntegerWeight::ONE);
@@ -99,8 +99,8 @@ impl<W: Semiring + Hash + Eq> Eq for Path<W> {}
 /// ```
 /// # #[macro_use] extern crate rustfst; fn main() {
 /// # use rustfst::semirings::{IntegerWeight, Semiring};
-/// # use rustfst::Path;
-/// let path : Path<IntegerWeight> = fst_path![1,2,3 => 1,2,4];
+/// # use rustfst::FstPath;
+/// let path : FstPath<IntegerWeight> = fst_path![1,2,3 => 1,2,4];
 /// assert_eq!(path.ilabels, vec![1,2,3]);
 /// assert_eq!(path.olabels, vec![1,2,4]);
 /// assert_eq!(path.weight, IntegerWeight::ONE);
@@ -112,8 +112,8 @@ impl<W: Semiring + Hash + Eq> Eq for Path<W> {}
 /// ```
 /// # #[macro_use] extern crate rustfst; fn main() {
 /// # use rustfst::semirings::{IntegerWeight, Semiring};
-/// # use rustfst::Path;
-/// let path : Path<IntegerWeight> = fst_path![1,2,3; 18];
+/// # use rustfst::FstPath;
+/// let path : FstPath<IntegerWeight> = fst_path![1,2,3; 18];
 /// assert_eq!(path.ilabels, vec![1,2,3]);
 /// assert_eq!(path.olabels, vec![1,2,3]);
 /// assert_eq!(path.weight, IntegerWeight::new(18));
@@ -125,8 +125,8 @@ impl<W: Semiring + Hash + Eq> Eq for Path<W> {}
 /// ```
 /// # #[macro_use] extern crate rustfst; fn main() {
 /// # use rustfst::semirings::{IntegerWeight, Semiring};
-/// # use rustfst::Path;
-/// let path : Path<IntegerWeight> = fst_path![1,2,3 => 1,2,4; 18];
+/// # use rustfst::FstPath;
+/// let path : FstPath<IntegerWeight> = fst_path![1,2,3 => 1,2,4; 18];
 /// assert_eq!(path.ilabels, vec![1,2,3]);
 /// assert_eq!(path.olabels, vec![1,2,4]);
 /// assert_eq!(path.weight, IntegerWeight::new(18));
@@ -137,7 +137,7 @@ impl<W: Semiring + Hash + Eq> Eq for Path<W> {}
 macro_rules! fst_path {
     ( $( $x:expr ),*) => {
         {
-            Path::new(
+            FstPath::new(
                 vec![$($x),*],
                 vec![$($x),*],
                 Semiring::ONE
@@ -146,7 +146,7 @@ macro_rules! fst_path {
     };
     ( $( $x:expr ),* => $( $y:expr ),* ) => {
         {
-            Path::new(
+            FstPath::new(
                 vec![$($x),*],
                 vec![$($y),*],
                 Semiring::ONE
@@ -155,7 +155,7 @@ macro_rules! fst_path {
     };
     ( $( $x:expr ),* ; $weight:expr) => {
         {
-            Path::new(
+            FstPath::new(
                 vec![$($x),*],
                 vec![$($x),*],
                 Semiring::new($weight)
@@ -164,7 +164,7 @@ macro_rules! fst_path {
     };
     ( $( $x:expr ),* => $( $y:expr ),* ; $weight:expr) => {
         {
-            Path::new(
+            FstPath::new(
                 vec![$($x),*],
                 vec![$($y),*],
                 Semiring::new($weight)

--- a/src/fst_path.rs
+++ b/src/fst_path.rs
@@ -16,7 +16,6 @@ pub struct FstPath<W: Semiring> {
 }
 
 impl<W: Semiring> FstPath<W> {
-
     /// Creates a new Path.
     pub fn new(ilabels: Vec<Label>, olabels: Vec<Label>, weight: W) -> Self {
         FstPath {
@@ -55,7 +54,6 @@ impl<W: Semiring> FstPath<W> {
 }
 
 impl<W: Semiring> Default for FstPath<W> {
-
     /// Creates an empty path with a weight one.
     fn default() -> Self {
         FstPath {

--- a/src/fst_traits/expanded_fst.rs
+++ b/src/fst_traits/expanded_fst.rs
@@ -6,6 +6,8 @@ use std::fs::File;
 use std::io::{LineWriter, Write};
 use std::path::Path;
 
+/// Trait defining the necessary methods that should implement an ExpandedFST e.g
+/// a FST where all the states are already computed and not computed on the fly.
 pub trait ExpandedFst: Fst {
     /// Returns the number of states that contains the FST. They are all counted even if some states
     /// are not on a successful path (doesn't perform triming).
@@ -13,10 +15,9 @@ pub trait ExpandedFst: Fst {
     /// # Example
     ///
     /// ```
-    /// use rustfst::fst_traits::{CoreFst, MutableFst, ExpandedFst};
-    /// use rustfst::fst_impls::VectorFst;
-    /// use rustfst::semirings::{BooleanWeight, Semiring};
-    ///
+    /// # use rustfst::fst_traits::{CoreFst, MutableFst, ExpandedFst};
+    /// # use rustfst::fst_impls::VectorFst;
+    /// # use rustfst::semirings::{BooleanWeight, Semiring};
     /// let mut fst = VectorFst::<BooleanWeight>::new();
     ///
     /// assert_eq!(fst.num_states(), 0);

--- a/src/fst_traits/final_states_iterator.rs
+++ b/src/fst_traits/final_states_iterator.rs
@@ -8,7 +8,7 @@ pub struct FinalState<W: Semiring> {
     pub final_weight: W,
 }
 
-/// Trait to iterate over the final states of a wFST
+/// Trait to iterate over the final states of a wFST.
 pub trait FinalStatesIterator<'a> {
     type W: Semiring;
     type Iter: Iterator<Item = FinalState<Self::W>>;

--- a/src/fst_traits/fst.rs
+++ b/src/fst_traits/fst.rs
@@ -3,9 +3,9 @@ use crate::semirings::Semiring;
 use crate::{Result, StateId, EPS_LABEL};
 use std::fmt::Display;
 
-/// Trait defining necessary methods for a wFST to access start states and final states
+/// Trait defining necessary methods for a wFST to access start states and final states.
 pub trait CoreFst {
-    /// Weight use in the wFST. This type must implement the Semiring trait
+    /// Weight use in the wFST. This type must implement the Semiring trait.
     type W: Semiring;
 
     /// Returns the ID of the start state of the wFST if it exists else none.
@@ -47,7 +47,7 @@ pub trait CoreFst {
     /// ```
     fn final_weight(&self, state_id: StateId) -> Option<<Self as CoreFst>::W>;
 
-    /// Number of arcs leaving a specific state in the wFST
+    /// Number of arcs leaving a specific state in the wFST.
     ///
     /// # Example
     ///
@@ -88,12 +88,13 @@ pub trait CoreFst {
         self.final_weight(state_id).is_some()
     }
 
+    /// Check whether a state is the start state or not.
     fn is_start(&self, state_id: StateId) -> bool {
         Some(state_id) == self.start()
     }
 }
 
-/// Trait to iterate over the states of a wFST
+/// Trait to iterate over the states of a wFST.
 pub trait StateIterator<'a> {
     /// Iterator used to iterate over the `state_id` of the states of an FST.
     type Iter: Iterator<Item = StateId> + Clone;
@@ -121,7 +122,7 @@ pub trait StateIterator<'a> {
     fn states_iter(&'a self) -> Self::Iter;
 }
 
-/// Trait to iterate over the outgoing arcs of a partical state in a wFST
+/// Trait to iterate over the outgoing arcs of a particular state in a wFST
 pub trait ArcIterator<'a>: CoreFst
 where
     Self::W: 'a,
@@ -132,7 +133,7 @@ where
     fn arcs_iter(&'a self, state_id: StateId) -> Result<Self::Iter>;
 }
 
-/// Trait defining the minimum interface necessary for a wFST
+/// Trait defining the minimum interface necessary for a wFST.
 pub trait Fst:
     CoreFst + PartialEq + Clone + for<'a> ArcIterator<'a> + for<'b> StateIterator<'b> + Display
 {

--- a/src/fst_traits/mutable_fst.rs
+++ b/src/fst_traits/mutable_fst.rs
@@ -193,7 +193,7 @@ pub trait MutableFst: Fst + for<'a> MutableArcIterator<'a> {
     /// then the closure transduces `x` to `y` with weight `a`,
     /// `xx` to `yy` with weight `a ⊗ a`, `xxx` to `yyy` with weight `a ⊗ a ⊗ a`, etc.
     fn closure_plus(&mut self) {
-        crate::closure_plus(self)
+        crate::algorithms::closure_plus(self)
     }
 
     /// This operation computes the concatenative closure.
@@ -202,7 +202,7 @@ pub trait MutableFst: Fst + for<'a> MutableArcIterator<'a> {
     /// `xx` to `yy` with weight `a ⊗ a`, `xxx` to `yyy` with weight `a ⊗ a ⊗ a`, etc.
     /// The empty string is transduced to itself with weight `1` as well.
     fn closure_star(&mut self) {
-        crate::closure_star(self)
+        crate::algorithms::closure_star(self)
     }
 }
 

--- a/src/fst_traits/mutable_fst.rs
+++ b/src/fst_traits/mutable_fst.rs
@@ -3,9 +3,9 @@ use crate::fst_traits::{CoreFst, ExpandedFst, Fst};
 use crate::{Result, StateId};
 use std::collections::HashMap;
 
-/// Trait defining the methods to modify a wFST
+/// Trait defining the methods to modify a wFST.
 pub trait MutableFst: Fst + for<'a> MutableArcIterator<'a> {
-    /// Creates an empty wFST
+    /// Creates an empty wFST.
     fn new() -> Self;
 
     /// The state with identifier `state_id` is now the start state.
@@ -206,6 +206,7 @@ pub trait MutableFst: Fst + for<'a> MutableArcIterator<'a> {
     }
 }
 
+/// Iterate over mutable arcs in a wFST.
 pub trait MutableArcIterator<'a>: CoreFst
 where
     Self::W: 'a,

--- a/src/fst_traits/paths_iterator.rs
+++ b/src/fst_traits/paths_iterator.rs
@@ -111,7 +111,7 @@ mod tests {
     fn test_paths_iterator_linear_fst() {
         let labels = vec![153, 45, 96];
 
-        let fst: VectorFst<IntegerWeight> = acceptor(labels.clone().into_iter());
+        let fst: VectorFst<IntegerWeight> = acceptor(&labels);
 
         assert_eq!(fst.paths_iter().count(), 1);
 

--- a/src/fst_traits/paths_iterator.rs
+++ b/src/fst_traits/paths_iterator.rs
@@ -1,7 +1,7 @@
 use std::collections::VecDeque;
 
-use crate::fst_traits::Fst;
 use crate::fst_path::FstPath;
+use crate::fst_traits::Fst;
 use crate::semirings::Semiring;
 use crate::StateId;
 

--- a/src/fst_traits/paths_iterator.rs
+++ b/src/fst_traits/paths_iterator.rs
@@ -5,7 +5,7 @@ use crate::fst_path::FstPath;
 use crate::semirings::Semiring;
 use crate::StateId;
 
-/// Trait to iterate over the paths accepted by an FST
+/// Trait to iterate over the paths accepted by an FST.
 pub trait PathsIterator<'a> {
     type W: Semiring;
     type Iter: Iterator<Item = FstPath<Self::W>>;
@@ -111,7 +111,7 @@ mod tests {
     fn test_paths_iterator_linear_fst() {
         let labels = vec![153, 45, 96];
 
-        let fst: VectorFst<IntegerWeight> = acceptor(&labels);
+        let fst: VectorFst<IntegerWeight> = acceptor(&labels, IntegerWeight::ONE);
 
         assert_eq!(fst.paths_iter().count(), 1);
 

--- a/src/fst_traits/paths_iterator.rs
+++ b/src/fst_traits/paths_iterator.rs
@@ -1,14 +1,14 @@
 use std::collections::VecDeque;
 
 use crate::fst_traits::Fst;
-use crate::path::Path;
+use crate::fst_path::FstPath;
 use crate::semirings::Semiring;
 use crate::StateId;
 
 /// Trait to iterate over the paths accepted by an FST
 pub trait PathsIterator<'a> {
     type W: Semiring;
-    type Iter: Iterator<Item = Path<Self::W>>;
+    type Iter: Iterator<Item = FstPath<Self::W>>;
     fn paths_iter(&'a self) -> Self::Iter;
 }
 
@@ -28,7 +28,7 @@ where
     F: 'a + Fst,
 {
     fst: &'a F,
-    queue: VecDeque<(StateId, Path<F::W>)>,
+    queue: VecDeque<(StateId, FstPath<F::W>)>,
 }
 
 impl<'a, F> StructPathsIterator<'a, F>
@@ -39,7 +39,7 @@ where
         let mut queue = VecDeque::new();
 
         if let Some(state_start) = fst.start() {
-            queue.push_back((state_start, Path::default()));
+            queue.push_back((state_start, FstPath::default()));
         }
 
         StructPathsIterator { fst, queue }
@@ -50,7 +50,7 @@ impl<'a, F> Iterator for StructPathsIterator<'a, F>
 where
     F: 'a + Fst,
 {
-    type Item = Path<F::W>;
+    type Item = FstPath<F::W>;
 
     fn next(&mut self) -> Option<Self::Item> {
         while !self.queue.is_empty() {
@@ -102,7 +102,7 @@ mod tests {
         let paths: Counter<_> = fst.paths_iter().collect();
 
         let mut paths_ref: Counter<_> = Counter::new();
-        paths_ref.update(vec![Path::default()]);
+        paths_ref.update(vec![FstPath::default()]);
 
         assert_eq!(paths, paths_ref);
     }
@@ -118,7 +118,7 @@ mod tests {
         for path in fst.paths_iter() {
             assert_eq!(
                 path,
-                Path::new(labels.clone(), labels.clone(), IntegerWeight::ONE)
+                FstPath::new(labels.clone(), labels.clone(), IntegerWeight::ONE)
             );
         }
     }
@@ -149,17 +149,17 @@ mod tests {
         assert_eq!(fst.paths_iter().count(), 3);
 
         let mut paths_ref = Counter::new();
-        paths_ref.update(vec![Path::new(
+        paths_ref.update(vec![FstPath::new(
             vec![1, 4],
             vec![1, 4],
             IntegerWeight::new(4 * 18),
         )]);
-        paths_ref.update(vec![Path::new(
+        paths_ref.update(vec![FstPath::new(
             vec![2, 5],
             vec![2, 5],
             IntegerWeight::new(10 * 18),
         )]);
-        paths_ref.update(vec![Path::new(
+        paths_ref.update(vec![FstPath::new(
             vec![3],
             vec![3],
             IntegerWeight::new(3 * 18),
@@ -199,28 +199,28 @@ mod tests {
         assert_eq!(fst.paths_iter().count(), 6);
 
         let mut paths_ref = Counter::new();
-        paths_ref.update(vec![Path::new(vec![], vec![], IntegerWeight::new(38))]);
-        paths_ref.update(vec![Path::new(
+        paths_ref.update(vec![FstPath::new(vec![], vec![], IntegerWeight::new(38))]);
+        paths_ref.update(vec![FstPath::new(
             vec![1],
             vec![1],
             IntegerWeight::new(1 * 41),
         )]);
-        paths_ref.update(vec![Path::new(
+        paths_ref.update(vec![FstPath::new(
             vec![2],
             vec![2],
             IntegerWeight::new(2 * 53),
         )]);
-        paths_ref.update(vec![Path::new(
+        paths_ref.update(vec![FstPath::new(
             vec![1, 4],
             vec![1, 4],
             IntegerWeight::new(4 * 185),
         )]);
-        paths_ref.update(vec![Path::new(
+        paths_ref.update(vec![FstPath::new(
             vec![2, 5],
             vec![2, 5],
             IntegerWeight::new(10 * 185),
         )]);
-        paths_ref.update(vec![Path::new(
+        paths_ref.update(vec![FstPath::new(
             vec![3],
             vec![3],
             IntegerWeight::new(3 * 185),

--- a/src/fst_traits/text_parser.rs
+++ b/src/fst_traits/text_parser.rs
@@ -5,17 +5,21 @@ use crate::parsers::text_fst::ParsedTextFst;
 use crate::semirings::Semiring;
 use crate::Result;
 
+/// Trait to allow serialization and deserialization of a wFST in text format.
 pub trait TextParser: ExpandedFst
 where
     Self::W: Semiring<Type = f32>,
 {
+    /// Turns a generic wFST format into the one of the wFST.
     fn from_parsed_fst_text(parsed_fst_text: ParsedTextFst) -> Result<Self>;
 
+    /// Deserializes a wFST in text from a path and returns a loaded wFST.
     fn from_text_string(fst_string: &str) -> Result<Self> {
         let parsed_text_fst = ParsedTextFst::from_string(fst_string)?;
         Self::from_parsed_fst_text(parsed_text_fst)
     }
 
+    /// Deserializes a wFST in text from a path and returns a loaded wFST.
     fn read_text<P: AsRef<Path>>(path_text_fst: P) -> Result<Self> {
         let parsed_text_fst = ParsedTextFst::from_path(path_text_fst)?;
         Self::from_parsed_fst_text(parsed_text_fst)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,17 +111,17 @@ pub const EPS_SYMBOL: &str = "<eps>";
 /// A few utilities to manipulate wFSTs.
 pub mod utils;
 
-/// Provides algorithms that are generic for all wFST.
-mod algorithms;
+/// Provides algorithms that are generic to all wFST.
+pub mod algorithms;
 
 /// Implementation of the transitions inside a wFST.
 mod arc;
 pub use self::arc::Arc;
 
 #[macro_use]
-/// Provides trait that must be implemented to be able to use generic algorithms.
+/// Provides traits that must be implemented to be able to use generic algorithms.
 pub mod fst_traits;
-/// Implementation of the wFST traits with different data structure.
+/// Implementation of the wFST traits with different data structures.
 pub mod fst_impls;
 /// Provides a trait that shall be implemented for all weights stored inside a wFST.
 pub mod semirings;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,16 +95,17 @@ pub type Result<T> = std::result::Result<T, failure::Error>;
 mod symbol_table;
 pub use crate::symbol_table::SymbolTable;
 
-/// Type used for the input label and output label of an arc in a wFST.
+/// Type used for the input label and output label of an arc in a wFST -> usize
 pub type Label = usize;
+/// Symbol to map in the Symbol Table -> String
 pub type Symbol = String;
 
-/// Type used to identify a state in a wFST.
+/// Type used to identify a state in a wFST -> usize
 pub type StateId = usize;
 
-/// Epsilon label representing the epsilon transition (empty transition).
+/// Epsilon label representing the epsilon transition (empty transition) = `0`.
 pub const EPS_LABEL: Label = 0;
-/// Epsilon symbol representing the epsilon transition (empty transition).
+/// Epsilon symbol representing the epsilon transition (empty transition) = `<eps>`.
 pub const EPS_SYMBOL: &str = "<eps>";
 
 /// A few utilities to manipulate wFSTs.
@@ -112,24 +113,6 @@ pub mod utils;
 
 /// Provides algorithms that are generic for all wFST.
 mod algorithms;
-pub use self::algorithms::{
-    all_pairs_shortest_distance::all_pairs_shortest_distance,
-    closure_plus::closure_plus,
-    closure_star::closure_star,
-    composition::compose,
-    concat::concat,
-    connect::connect,
-    epsilon_removal::rm_epsilon,
-    inversion::invert,
-    isomorphic::isomorphic,
-    projection::{project, ProjectType},
-    relabel_pairs::relabel_pairs,
-    reverse::reverse,
-    reweight::{reweight, ReweightType},
-    single_source_shortest_distance::{shortest_distance, single_source_shortest_distance},
-    union::union,
-    weight_pushing::push_weights,
-};
 
 /// Implementation of the transitions inside a wFST.
 mod arc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,8 +132,8 @@ mod drawing_config;
 pub use crate::drawing_config::DrawingConfig;
 
 /// Implementation of a successful path inside a wFST.
-mod path;
-pub use crate::path::Path;
+mod fst_path;
+pub use crate::fst_path::FstPath;
 
 mod parsers;
 

--- a/src/path.rs
+++ b/src/path.rs
@@ -62,3 +62,99 @@ impl<W: Semiring + Hash + Eq> Hash for Path<W> {
 }
 
 impl<W: Semiring + Hash + Eq> Eq for Path<W> {}
+
+/// Creates a Path containing the arguments.
+///
+/// There are multiple forms to this macro :
+///
+/// - Create an unweighted acceptor path :
+///
+/// ```
+/// # #[macro_use] extern crate rustfst; fn main() {
+/// # use rustfst::semirings::{IntegerWeight, Semiring};
+/// # use rustfst::Path;
+/// let path : Path<IntegerWeight> = fst_path![1,2,3];
+/// assert_eq!(path.ilabels, vec![1,2,3]);
+/// assert_eq!(path.olabels, vec![1,2,3]);
+/// assert_eq!(path.weight, IntegerWeight::ONE);
+/// # }
+/// ```
+///
+/// - Create an unweighted transducer path :
+///
+/// ```
+/// # #[macro_use] extern crate rustfst; fn main() {
+/// # use rustfst::semirings::{IntegerWeight, Semiring};
+/// # use rustfst::Path;
+/// let path : Path<IntegerWeight> = fst_path![1,2,3 => 1,2,4];
+/// assert_eq!(path.ilabels, vec![1,2,3]);
+/// assert_eq!(path.olabels, vec![1,2,4]);
+/// assert_eq!(path.weight, IntegerWeight::ONE);
+/// # }
+/// ```
+///
+/// - Create a weighted acceptor path :
+///
+/// ```
+/// # #[macro_use] extern crate rustfst; fn main() {
+/// # use rustfst::semirings::{IntegerWeight, Semiring};
+/// # use rustfst::Path;
+/// let path : Path<IntegerWeight> = fst_path![1,2,3; 18];
+/// assert_eq!(path.ilabels, vec![1,2,3]);
+/// assert_eq!(path.olabels, vec![1,2,3]);
+/// assert_eq!(path.weight, IntegerWeight::new(18));
+/// # }
+/// ```
+///
+/// - Create a weighted transducer path :
+///
+/// ```
+/// # #[macro_use] extern crate rustfst; fn main() {
+/// # use rustfst::semirings::{IntegerWeight, Semiring};
+/// # use rustfst::Path;
+/// let path : Path<IntegerWeight> = fst_path![1,2,3 => 1,2,4; 18];
+/// assert_eq!(path.ilabels, vec![1,2,3]);
+/// assert_eq!(path.olabels, vec![1,2,4]);
+/// assert_eq!(path.weight, IntegerWeight::new(18));
+/// # }
+/// ```
+///
+#[macro_export]
+macro_rules! fst_path {
+    ( $( $x:expr ),*) => {
+        {
+            Path::new(
+                vec![$($x),*],
+                vec![$($x),*],
+                Semiring::ONE
+            )
+        }
+    };
+    ( $( $x:expr ),* => $( $y:expr ),* ) => {
+        {
+            Path::new(
+                vec![$($x),*],
+                vec![$($y),*],
+                Semiring::ONE
+            )
+        }
+    };
+    ( $( $x:expr ),* ; $weight:expr) => {
+        {
+            Path::new(
+                vec![$($x),*],
+                vec![$($x),*],
+                Semiring::new($weight)
+            )
+        }
+    };
+    ( $( $x:expr ),* => $( $y:expr ),* ; $weight:expr) => {
+        {
+            Path::new(
+                vec![$($x),*],
+                vec![$($y),*],
+                Semiring::new($weight)
+            )
+        }
+    };
+}

--- a/src/path.rs
+++ b/src/path.rs
@@ -3,14 +3,21 @@ use std::hash::{Hash, Hasher};
 use crate::semirings::Semiring;
 use crate::{Label, EPS_LABEL};
 
+/// Structure representing a path in a FST
+/// (list of input labels, list of output labels and total weight).
 #[derive(PartialEq, Debug, Clone, PartialOrd)]
 pub struct Path<W: Semiring> {
+    /// List of input labels.
     pub ilabels: Vec<Label>,
+    /// List of output labels.
     pub olabels: Vec<Label>,
+    /// Total weight of the path computed by multiplying the weight of each transition.
     pub weight: W,
 }
 
 impl<W: Semiring> Path<W> {
+
+    /// Creates a new Path.
     pub fn new(ilabels: Vec<Label>, olabels: Vec<Label>, weight: W) -> Self {
         Path {
             ilabels,
@@ -19,6 +26,9 @@ impl<W: Semiring> Path<W> {
         }
     }
 
+    /// Adds the content of an FST transition to the Path.
+    /// Labels are added at the end of the corresponding vectors and the weight
+    /// is multiplied by the total weight already stored in the Path.
     pub fn add_to_path(&mut self, ilabel: Label, olabel: Label, weight: W) {
         if ilabel != EPS_LABEL {
             self.ilabels.push(ilabel);
@@ -31,10 +41,12 @@ impl<W: Semiring> Path<W> {
         self.weight *= weight
     }
 
+    /// Add a single weight to the Path by multiplying the weight by the total weight of the path.
     pub fn add_weight(&mut self, weight: W) {
         self.weight *= weight
     }
 
+    /// Append a Path to the current Path. Labels are appended and weights multiplied.
     pub fn concat(&mut self, other: Path<W>) {
         self.ilabels.extend(other.ilabels);
         self.olabels.extend(other.olabels);
@@ -43,6 +55,8 @@ impl<W: Semiring> Path<W> {
 }
 
 impl<W: Semiring> Default for Path<W> {
+
+    /// Creates an empty path with a weight one.
     fn default() -> Self {
         Path {
             ilabels: vec![],

--- a/src/symbol_table.rs
+++ b/src/symbol_table.rs
@@ -282,16 +282,3 @@ macro_rules! symt {
         }
     };
 }
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn test_symt_write() -> Result<()> {
-        let s = symt!("a", "b");
-        //        s.write_text("a/symt.txt")?;
-        println!("symt = \n{}", s);
-        Ok(())
-    }
-}

--- a/src/symbol_table.rs
+++ b/src/symbol_table.rs
@@ -265,9 +265,12 @@ impl fmt::Display for SymbolTable {
 /// Creates a `SymbolTable` containing the arguments.
 /// ```
 /// # #[macro_use] extern crate rustfst; fn main() {
-/// # use rustfst::SymbolTable;
+/// # use rustfst::{SymbolTable, EPS_SYMBOL};
 /// let symt = symt!["a", "b"];
 /// assert_eq!(symt.len(), 3);
+/// assert_eq!(symt.get_symbol(0).unwrap(), EPS_SYMBOL);
+/// assert_eq!(symt.get_symbol(1).unwrap(), "a");
+/// assert_eq!(symt.get_symbol(2).unwrap(), "b");
 /// # }
 /// ```
 #[macro_export]

--- a/src/test_data/test_pynini.rs
+++ b/src/test_data/test_pynini.rs
@@ -4,14 +4,14 @@ mod test {
     use std::fs::read_to_string;
     use std::string::String;
 
-    use crate::fst_impls::VectorFst;
-    use crate::fst_traits::TextParser;
-    use crate::semirings::{Semiring, TropicalWeight};
-    use crate::Result;
     use crate::algorithms::{
         connect, invert, isomorphic, project, push_weights, reverse, rm_epsilon, ProjectType,
         ReweightType,
     };
+    use crate::fst_impls::VectorFst;
+    use crate::fst_traits::TextParser;
+    use crate::semirings::{Semiring, TropicalWeight};
+    use crate::Result;
 
     #[derive(Serialize, Deserialize, Debug)]
     struct OperationResult {

--- a/src/test_data/test_pynini.rs
+++ b/src/test_data/test_pynini.rs
@@ -8,7 +8,7 @@ mod test {
     use crate::fst_traits::TextParser;
     use crate::semirings::{Semiring, TropicalWeight};
     use crate::Result;
-    use crate::{
+    use crate::algorithms::{
         connect, invert, isomorphic, project, push_weights, reverse, rm_epsilon, ProjectType,
         ReweightType,
     };

--- a/src/test_data/vector_fst/fst_002_linear_acceptor_0_label.rs
+++ b/src/test_data/vector_fst/fst_002_linear_acceptor_0_label.rs
@@ -23,7 +23,7 @@ impl TestFst for LinearAcceptor0Label {
 
     fn get_fst() -> <Self as TestFst>::F {
         let labels = vec![];
-        acceptor(&labels)
+        acceptor(&labels, IntegerWeight::ONE)
     }
 
     fn get_name() -> String {

--- a/src/test_data/vector_fst/fst_002_linear_acceptor_0_label.rs
+++ b/src/test_data/vector_fst/fst_002_linear_acceptor_0_label.rs
@@ -23,7 +23,7 @@ impl TestFst for LinearAcceptor0Label {
 
     fn get_fst() -> <Self as TestFst>::F {
         let labels = vec![];
-        acceptor(labels.into_iter())
+        acceptor(&labels)
     }
 
     fn get_name() -> String {

--- a/src/test_data/vector_fst/fst_003_linear_acceptor_1_label.rs
+++ b/src/test_data/vector_fst/fst_003_linear_acceptor_1_label.rs
@@ -23,7 +23,7 @@ impl TestFst for LinearAcceptor1Label {
 
     fn get_fst() -> <Self as TestFst>::F {
         let labels = vec![32];
-        acceptor(labels.into_iter())
+        acceptor(&labels)
     }
 
     fn get_name() -> String {

--- a/src/test_data/vector_fst/fst_003_linear_acceptor_1_label.rs
+++ b/src/test_data/vector_fst/fst_003_linear_acceptor_1_label.rs
@@ -23,7 +23,7 @@ impl TestFst for LinearAcceptor1Label {
 
     fn get_fst() -> <Self as TestFst>::F {
         let labels = vec![32];
-        acceptor(&labels)
+        acceptor(&labels, IntegerWeight::ONE)
     }
 
     fn get_name() -> String {

--- a/src/test_data/vector_fst/fst_004_linear_acceptor_3_labels.rs
+++ b/src/test_data/vector_fst/fst_004_linear_acceptor_3_labels.rs
@@ -23,7 +23,7 @@ impl TestFst for LinearAcceptor3Labels {
 
     fn get_fst() -> <Self as TestFst>::F {
         let labels = vec![45, 58, 31];
-        acceptor(labels.into_iter())
+        acceptor(&labels)
     }
 
     fn get_name() -> String {

--- a/src/test_data/vector_fst/fst_004_linear_acceptor_3_labels.rs
+++ b/src/test_data/vector_fst/fst_004_linear_acceptor_3_labels.rs
@@ -23,7 +23,7 @@ impl TestFst for LinearAcceptor3Labels {
 
     fn get_fst() -> <Self as TestFst>::F {
         let labels = vec![45, 58, 31];
-        acceptor(&labels)
+        acceptor(&labels, IntegerWeight::ONE)
     }
 
     fn get_name() -> String {

--- a/src/test_data/vector_fst/fst_006_linear_transducer_1_label.rs
+++ b/src/test_data/vector_fst/fst_006_linear_transducer_1_label.rs
@@ -24,7 +24,7 @@ impl TestFst for LinearTransducerOneLabel {
     fn get_fst() -> <Self as TestFst>::F {
         let ilabels = vec![32];
         let olabels = vec![45];
-        transducer(ilabels.into_iter(), olabels.into_iter())
+        transducer(&ilabels, &olabels)
     }
 
     fn get_name() -> String {

--- a/src/test_data/vector_fst/fst_006_linear_transducer_1_label.rs
+++ b/src/test_data/vector_fst/fst_006_linear_transducer_1_label.rs
@@ -24,7 +24,7 @@ impl TestFst for LinearTransducerOneLabel {
     fn get_fst() -> <Self as TestFst>::F {
         let ilabels = vec![32];
         let olabels = vec![45];
-        transducer(&ilabels, &olabels)
+        transducer(&ilabels, &olabels, IntegerWeight::ONE)
     }
 
     fn get_name() -> String {

--- a/src/test_data/vector_fst/fst_007_linear_transducer_3_to_2_labels.rs
+++ b/src/test_data/vector_fst/fst_007_linear_transducer_3_to_2_labels.rs
@@ -24,7 +24,7 @@ impl TestFst for LinearTransducer3to2Labels {
     fn get_fst() -> <Self as TestFst>::F {
         let ilabels = vec![45, 58, 31];
         let olabels = vec![21, 18];
-        transducer(&ilabels, &olabels)
+        transducer(&ilabels, &olabels, IntegerWeight::ONE)
     }
 
     fn get_name() -> String {

--- a/src/test_data/vector_fst/fst_007_linear_transducer_3_to_2_labels.rs
+++ b/src/test_data/vector_fst/fst_007_linear_transducer_3_to_2_labels.rs
@@ -24,7 +24,7 @@ impl TestFst for LinearTransducer3to2Labels {
     fn get_fst() -> <Self as TestFst>::F {
         let ilabels = vec![45, 58, 31];
         let olabels = vec![21, 18];
-        transducer(ilabels.into_iter(), olabels.into_iter())
+        transducer(&ilabels, &olabels)
     }
 
     fn get_name() -> String {

--- a/src/utils/fst_to_labels.rs
+++ b/src/utils/fst_to_labels.rs
@@ -20,7 +20,7 @@ use crate::Result;
 /// let labels_input = vec![32, 43, 21];
 /// let labels_output = vec![53, 18, 89];
 ///
-/// let fst : VectorFst<BooleanWeight> = transducer(&labels_input, &labels_output);
+/// let fst : VectorFst<BooleanWeight> = transducer(&labels_input, &labels_output, BooleanWeight::ONE);
 ///
 /// let path = decode_linear_fst(&fst).unwrap();
 ///
@@ -47,7 +47,7 @@ mod tests {
     #[test]
     fn test_decode_linear_fst_acceptor() -> Result<()> {
         let labels = vec![1, 2, 3];
-        let fst: VectorFst<BooleanWeight> = acceptor(&labels);
+        let fst: VectorFst<BooleanWeight> = acceptor(&labels, BooleanWeight::ONE);
 
         let path = decode_linear_fst(&fst)?;
         let path_ref = FstPath::new(labels.clone(), labels, BooleanWeight::ONE);
@@ -62,6 +62,7 @@ mod tests {
         let fst: VectorFst<BooleanWeight> = transducer(
             &labels_input,
             &labels_output,
+            BooleanWeight::ONE
         );
 
         let path = decode_linear_fst(&fst)?;

--- a/src/utils/fst_to_labels.rs
+++ b/src/utils/fst_to_labels.rs
@@ -1,7 +1,7 @@
 use failure::bail;
 
 use crate::fst_traits::{Fst, PathsIterator};
-use crate::path::Path;
+use crate::fst_path::FstPath;
 use crate::Result;
 
 /// Decode a linear FST to retrieves the only path recognized by it. A path is composed of the
@@ -16,7 +16,7 @@ use crate::Result;
 /// # use rustfst::semirings::{BooleanWeight, Semiring};
 /// # use rustfst::utils::{transducer, decode_linear_fst};
 /// # use rustfst::Arc;
-/// # use rustfst::Path;
+/// # use rustfst::FstPath;
 /// let labels_input = vec![32, 43, 21];
 /// let labels_output = vec![53, 18, 89];
 ///
@@ -24,9 +24,9 @@ use crate::Result;
 ///
 /// let path = decode_linear_fst(&fst).unwrap();
 ///
-/// assert_eq!(path, Path::new(labels_input, labels_output, BooleanWeight::ONE));
+/// assert_eq!(path, FstPath::new(labels_input, labels_output, BooleanWeight::ONE));
 /// ```
-pub fn decode_linear_fst<F: Fst>(fst: &F) -> Result<Path<F::W>> {
+pub fn decode_linear_fst<F: Fst>(fst: &F) -> Result<FstPath<F::W>> {
     let mut it_path = fst.paths_iter();
     let path = it_path.next().unwrap_or_default();
     if it_path.next().is_some() {
@@ -50,7 +50,7 @@ mod tests {
         let fst: VectorFst<BooleanWeight> = acceptor(labels.clone().into_iter());
 
         let path = decode_linear_fst(&fst)?;
-        let path_ref = Path::new(labels.clone(), labels, BooleanWeight::ONE);
+        let path_ref = FstPath::new(labels.clone(), labels, BooleanWeight::ONE);
         assert_eq!(path, path_ref);
         Ok(())
     }
@@ -65,7 +65,7 @@ mod tests {
         );
 
         let path = decode_linear_fst(&fst)?;
-        let path_ref = Path::new(labels_input, labels_output, BooleanWeight::ONE);
+        let path_ref = FstPath::new(labels_input, labels_output, BooleanWeight::ONE);
 
         assert_eq!(path, path_ref);
         Ok(())
@@ -76,7 +76,7 @@ mod tests {
         let fst = VectorFst::<BooleanWeight>::new();
         let path = decode_linear_fst(&fst)?;
 
-        assert_eq!(path, Path::default());
+        assert_eq!(path, FstPath::default());
 
         Ok(())
     }
@@ -90,7 +90,7 @@ mod tests {
 
         let path = decode_linear_fst(&fst)?;
 
-        assert_eq!(path, Path::default());
+        assert_eq!(path, FstPath::default());
 
         Ok(())
     }

--- a/src/utils/fst_to_labels.rs
+++ b/src/utils/fst_to_labels.rs
@@ -1,7 +1,7 @@
 use failure::bail;
 
-use crate::fst_traits::{Fst, PathsIterator};
 use crate::fst_path::FstPath;
+use crate::fst_traits::{Fst, PathsIterator};
 use crate::Result;
 
 /// Decode a linear FST to retrieves the only path recognized by it. A path is composed of the
@@ -59,11 +59,8 @@ mod tests {
     fn test_decode_linear_fst_transducer() -> Result<()> {
         let labels_input = vec![1, 2, 3];
         let labels_output = vec![43, 22, 18];
-        let fst: VectorFst<BooleanWeight> = transducer(
-            &labels_input,
-            &labels_output,
-            BooleanWeight::ONE
-        );
+        let fst: VectorFst<BooleanWeight> =
+            transducer(&labels_input, &labels_output, BooleanWeight::ONE);
 
         let path = decode_linear_fst(&fst)?;
         let path_ref = FstPath::new(labels_input, labels_output, BooleanWeight::ONE);

--- a/src/utils/fst_to_labels.rs
+++ b/src/utils/fst_to_labels.rs
@@ -20,7 +20,7 @@ use crate::Result;
 /// let labels_input = vec![32, 43, 21];
 /// let labels_output = vec![53, 18, 89];
 ///
-/// let fst : VectorFst<BooleanWeight> = transducer(labels_input.clone().into_iter(), labels_output.clone().into_iter());
+/// let fst : VectorFst<BooleanWeight> = transducer(&labels_input, &labels_output);
 ///
 /// let path = decode_linear_fst(&fst).unwrap();
 ///
@@ -47,7 +47,7 @@ mod tests {
     #[test]
     fn test_decode_linear_fst_acceptor() -> Result<()> {
         let labels = vec![1, 2, 3];
-        let fst: VectorFst<BooleanWeight> = acceptor(labels.clone().into_iter());
+        let fst: VectorFst<BooleanWeight> = acceptor(&labels);
 
         let path = decode_linear_fst(&fst)?;
         let path_ref = FstPath::new(labels.clone(), labels, BooleanWeight::ONE);
@@ -60,8 +60,8 @@ mod tests {
         let labels_input = vec![1, 2, 3];
         let labels_output = vec![43, 22, 18];
         let fst: VectorFst<BooleanWeight> = transducer(
-            labels_input.clone().into_iter(),
-            labels_output.clone().into_iter(),
+            &labels_input,
+            &labels_output,
         );
 
         let path = decode_linear_fst(&fst)?;

--- a/src/utils/labels_to_fst.rs
+++ b/src/utils/labels_to_fst.rs
@@ -43,9 +43,8 @@ use std::cmp;
 pub fn transducer<F: MutableFst>(
     labels_input: &[Label],
     labels_output: &[Label],
-    weight: F::W
+    weight: F::W,
 ) -> F {
-
     let max_size = cmp::max(labels_input.len(), labels_output.len());
 
     let mut fst = F::new();

--- a/src/utils/labels_to_fst.rs
+++ b/src/utils/labels_to_fst.rs
@@ -139,7 +139,10 @@ pub fn acceptor<T: Iterator<Item = Label>, F: MutableFst>(labels: T) -> F {
     fst
 }
 
-/// Creates an acceptor of its arguments.
+/// Easily creates an acceptor from a list of labels.
+///
+/// This will return a linear FST with one arc for each label given
+/// (same input and output, weight one).
 ///
 /// ```
 /// # #[macro_use] extern crate rustfst; fn main() {
@@ -162,8 +165,10 @@ macro_rules! acceptor {
     };
 }
 
-/// Creates a transducer of its arguments.
+/// Easily creates a transducer from two lists of labels.
 ///
+/// This will return a linear FST. The only accepted path in the FST has for input the first
+/// of labels and for output the second list of labels.
 /// ```
 /// # #[macro_use] extern crate rustfst; fn main() {
 /// # use rustfst::utils;
@@ -177,6 +182,68 @@ macro_rules! acceptor {
 /// ```
 #[macro_export]
 macro_rules! transducer {
+    ( $( $x:expr ),* => $( $y:expr ),* ) => {
+        {
+            let mut temp_vec_input = vec![$($x),*];
+            let mut temp_vec_output = vec![$($y),*];
+            transducer(
+                temp_vec_input.clone().into_iter(),
+                temp_vec_output.clone().into_iter()
+            )
+        }
+    };
+}
+
+/// Creates a Path containing the arguments.
+///
+/// There are multiple forms to this macro :
+///
+/// - Create an unweighted linear acceptor :
+///
+/// This will return a linear FST with one arc for each label given
+/// (same input and output, weight one).
+///
+/// ```
+/// # #[macro_use] extern crate rustfst; fn main() {
+/// # use rustfst::utils;
+/// # use rustfst::fst_traits::{CoreFst, MutableFst, ExpandedFst, PathsIterator};
+/// # use rustfst::fst_impls::VectorFst;
+/// # use rustfst::semirings::{ProbabilityWeight, Semiring};
+/// # use rustfst::utils::acceptor;
+/// # use rustfst::{Arc, Path};
+/// let fst : VectorFst<ProbabilityWeight> = fst![1,2,3];
+/// assert_eq!(fst.paths_iter().count(), 1);
+/// assert_eq!(fst.paths_iter().next().unwrap(), fst_path![1,2,3]);
+/// # }
+/// ```
+///
+/// - Create an unweighted linear transducer from two list of labels :
+///
+/// The only accepted path in the FST has for input the first
+/// list of labels and for output the second list of labels.
+///
+/// ```
+/// # #[macro_use] extern crate rustfst; fn main() {
+/// # use rustfst::utils;
+/// # use rustfst::fst_traits::{CoreFst, MutableFst, ExpandedFst, PathsIterator};
+/// # use rustfst::fst_impls::VectorFst;
+/// # use rustfst::semirings::{ProbabilityWeight, Semiring};
+/// # use rustfst::utils::transducer;
+/// # use rustfst::{Arc, Path};
+/// let fst : VectorFst<ProbabilityWeight> = fst![1,2,3 => 1,2,4];
+/// assert_eq!(fst.paths_iter().count(), 1);
+/// assert_eq!(fst.paths_iter().next().unwrap(), fst_path![1,2,3 => 1,2,4]);
+/// # }
+/// ```
+///
+#[macro_export]
+macro_rules! fst {
+    ( $( $x:expr ),* ) => {
+        {
+            let mut temp_vec = vec![$($x),*];
+            acceptor(temp_vec.clone().into_iter())
+        }
+    };
     ( $( $x:expr ),* => $( $y:expr ),* ) => {
         {
             let mut temp_vec_input = vec![$($x),*];

--- a/src/utils/labels_to_fst.rs
+++ b/src/utils/labels_to_fst.rs
@@ -139,61 +139,6 @@ pub fn acceptor<T: Iterator<Item = Label>, F: MutableFst>(labels: T) -> F {
     fst
 }
 
-/// Easily creates an acceptor from a list of labels.
-///
-/// This will return a linear FST with one arc for each label given
-/// (same input and output, weight one).
-///
-/// ```
-/// # #[macro_use] extern crate rustfst; fn main() {
-/// # use rustfst::utils;
-/// # use rustfst::fst_traits::{CoreFst, MutableFst, ExpandedFst};
-/// # use rustfst::fst_impls::VectorFst;
-/// # use rustfst::semirings::{ProbabilityWeight, Semiring};
-/// # use rustfst::utils::acceptor;
-/// # use rustfst::Arc;
-/// let fst : VectorFst<ProbabilityWeight> = acceptor![1,2,3];
-/// # }
-/// ```
-#[macro_export]
-macro_rules! acceptor {
-    ( $( $x:expr ),* ) => {
-        {
-            let mut temp_vec = vec![$($x),*];
-            acceptor(temp_vec.clone().into_iter())
-        }
-    };
-}
-
-/// Easily creates a transducer from two lists of labels.
-///
-/// This will return a linear FST. The only accepted path in the FST has for input the first
-/// of labels and for output the second list of labels.
-/// ```
-/// # #[macro_use] extern crate rustfst; fn main() {
-/// # use rustfst::utils;
-/// # use rustfst::fst_traits::{CoreFst, MutableFst, ExpandedFst};
-/// # use rustfst::fst_impls::VectorFst;
-/// # use rustfst::semirings::{ProbabilityWeight, Semiring};
-/// # use rustfst::utils::transducer;
-/// # use rustfst::Arc;
-/// let fst : VectorFst<ProbabilityWeight> = transducer![1,2,3 => 1,2,4];
-/// # }
-/// ```
-#[macro_export]
-macro_rules! transducer {
-    ( $( $x:expr ),* => $( $y:expr ),* ) => {
-        {
-            let mut temp_vec_input = vec![$($x),*];
-            let mut temp_vec_output = vec![$($y),*];
-            transducer(
-                temp_vec_input.clone().into_iter(),
-                temp_vec_output.clone().into_iter()
-            )
-        }
-    };
-}
-
 /// Creates a Path containing the arguments.
 ///
 /// There are multiple forms to this macro :

--- a/src/utils/labels_to_fst.rs
+++ b/src/utils/labels_to_fst.rs
@@ -155,7 +155,7 @@ pub fn acceptor<T: Iterator<Item = Label>, F: MutableFst>(labels: T) -> F {
 /// # use rustfst::fst_impls::VectorFst;
 /// # use rustfst::semirings::{ProbabilityWeight, Semiring};
 /// # use rustfst::utils::acceptor;
-/// # use rustfst::{Arc, Path};
+/// # use rustfst::{Arc, FstPath};
 /// let fst : VectorFst<ProbabilityWeight> = fst![1,2,3];
 /// assert_eq!(fst.paths_iter().count(), 1);
 /// assert_eq!(fst.paths_iter().next().unwrap(), fst_path![1,2,3]);
@@ -174,7 +174,7 @@ pub fn acceptor<T: Iterator<Item = Label>, F: MutableFst>(labels: T) -> F {
 /// # use rustfst::fst_impls::VectorFst;
 /// # use rustfst::semirings::{ProbabilityWeight, Semiring};
 /// # use rustfst::utils::transducer;
-/// # use rustfst::{Arc, Path};
+/// # use rustfst::{Arc, FstPath};
 /// let fst : VectorFst<ProbabilityWeight> = fst![1,2,3 => 1,2,4];
 /// assert_eq!(fst.paths_iter().count(), 1);
 /// assert_eq!(fst.paths_iter().next().unwrap(), fst_path![1,2,3 => 1,2,4]);


### PR DESCRIPTION
- Add `fst!` macro to quickly create an acceptor or a transducer from a list of labels.
- `acceptor` and `transducer` methods now take slices and weight instead of only iterator of labels.
- Rename `Path` object to `FstPath` to avoid conflicts with the one from the standard library.
- Add `fst_path!` macro to easily create a FstPath object.
- Add doc
