### PR TITLE
Introducing the CLI for minimize and connect + prelude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement `ShortestDistance` algorithm.
 - Implememt `ShortestPaths` algorithm.
 - Add associated type `ReverseWeight` in the `Semiring` trait denoting the type of the weight reversed.
+- Added the crate `rustfst-cli` as a CLI for the lib. It supports the subcommands:
+    - `minimize` for the minimization
+    - `connect` for the connect algorithm
+- Added a prelude to `rustfst` to reduce the number of imports necessary when using the lib.
 
 ### Changed
 - Before test cases were generated with pynini (python wrapper around openfst). Now they are directly generated with OpenFST (c++). Allows to test operations that are not wrapped.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
 members = [
-    "rustfst"
+    "rustfst",
+    "rustfst-cli"
 ]

--- a/rustfst-cli/Cargo.toml
+++ b/rustfst-cli/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "rustfst-cli"
+version = "0.1.0"
+authors = ["Garvys <alexandre.caulier@orange.fr>"]
+edition = "2018"
+
+[dependencies]
+clap = "2.33"
+log = "0.4"
+env_logger = "0.6"
+failure = '0.1'
+rustfst = {path = "../rustfst"}

--- a/rustfst-cli/src/connect.rs
+++ b/rustfst-cli/src/connect.rs
@@ -1,0 +1,13 @@
+use rustfst::prelude::*;
+
+use log::info;
+
+use failure::Fallible;
+
+pub fn connect_cli(path_in: &str, path_out: &str) -> Fallible<()> {
+    info!("Connect");
+    let mut fst = VectorFst::<TropicalWeight>::read(path_in)?;
+    connect(&mut fst)?;
+    fst.write(path_out)?;
+    Ok(())
+}

--- a/rustfst-cli/src/main.rs
+++ b/rustfst-cli/src/main.rs
@@ -1,0 +1,74 @@
+use std::process;
+
+use clap::{App, Arg, SubCommand};
+use failure::format_err;
+use log::error;
+
+use crate::pretty_errors::ExitFailure;
+
+mod connect;
+mod minimize;
+mod pretty_errors;
+
+fn main() {
+//    env_logxger::init();
+    let mut app = App::new("rustfst")
+        .version("1.0")
+        .author("Alexandre Caulier <alexandre.caulier@protonmail.com>")
+        .about("Rustfst CLI");
+
+    // Minimization
+    let minimize_cmd = SubCommand::with_name("minimize")
+        .about("Minimization algorithm")
+        .version("1.0")
+        .author("Alexandre Caulier <alexandre.caulier@protonmail.com>")
+        .arg(Arg::with_name("in.fst").help("Path to input fst file").required(true))
+        .arg(
+            Arg::with_name("allow-nondet")
+                .help("Minimize non-deterministic FSTs ?")
+                .long("allow-nondet"),
+        )
+        .arg(Arg::with_name("out.fst").help("Path to output fst file").required(true));
+    app = app.subcommand(minimize_cmd);
+
+    // Connect
+    let connect_cmd = SubCommand::with_name("connect")
+        .about("Connect algorithm")
+        .version("1.0")
+        .author("Alexandre Caulier <alexandre.caulier@protonmail.com>")
+        .arg(Arg::with_name("in.fst").help("Path to input fst file").required(true))
+        .arg(Arg::with_name("out.fst").help("Path to output fst file").required(true));
+    app = app.subcommand(connect_cmd);
+
+    let matches = app.get_matches();
+
+    let env = env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, "debug");
+
+    env_logger::Builder::from_env(env).default_format_timestamp_nanos(true).init();
+
+    if let Err(e) = handle(matches) {
+        error!("{:?}", e);
+        process::exit(1)
+    }
+}
+
+/// Handles the command-line input.
+fn handle(matches: clap::ArgMatches) -> Result<(), ExitFailure> {
+    match matches.subcommand() {
+        ("minimize", Some(m)) => {
+            crate::minimize::minimize_cli(
+                m.value_of("in.fst").unwrap(),
+                m.is_present("allow-nondet"),
+                m.value_of("out.fst").unwrap(),
+            )
+        },
+        ("connect", Some(m)) => {
+            crate::connect::connect_cli(
+                m.value_of("in.fst").unwrap(),
+                m.value_of("out.fst").unwrap(),
+            )
+        }
+        (s, _) => Err(format_err!("Unknown subcommand {}.", s)),
+    }.map_err(|e| e.into())
+}
+

--- a/rustfst-cli/src/minimize.rs
+++ b/rustfst-cli/src/minimize.rs
@@ -1,0 +1,13 @@
+use rustfst::prelude::*;
+
+use log::info;
+
+use failure::Fallible;
+
+pub fn minimize_cli(path_in: &str, allow_nondet: bool, path_out: &str) -> Fallible<()> {
+    info!("Minimization");
+    let mut fst = VectorFst::<TropicalWeight>::read(path_in)?;
+    minimize(&mut fst, allow_nondet)?;
+    fst.write(path_out)?;
+    Ok(())
+}

--- a/rustfst-cli/src/pretty_errors.rs
+++ b/rustfst-cli/src/pretty_errors.rs
@@ -1,0 +1,30 @@
+use failure::Fail;
+
+pub struct ExitFailure(failure::Error);
+
+/// Prints a list of causes for this Error, along with any backtrace
+/// information collected by the Error (if RUST_BACKTRACE=1).
+impl std::fmt::Debug for ExitFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let fail = self.0.as_fail();
+
+        writeln!(f, "{}", &fail)?;
+
+        let mut x: &Fail = fail;
+        while let Some(cause) = x.cause() {
+            writeln!(f, " -> caused by: {}", &cause)?;
+            x = cause;
+        }
+        if let Some(backtrace) = x.backtrace() {
+            writeln!(f, "{:?}", backtrace)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<T: Into<failure::Error>> From<T> for ExitFailure {
+    fn from(t: T) -> Self {
+        ExitFailure(t.into())
+    }
+}

--- a/rustfst/src/lib.rs
+++ b/rustfst/src/lib.rs
@@ -142,3 +142,10 @@ mod parsers;
 
 /// A representable float near .001. (Used in Quantize)
 pub(crate) const KDELTA: f32 = 1.0f32 / 1024.0f32;
+
+pub mod prelude {
+    pub use crate::fst_traits::*;
+    pub use crate::fst_impls::*;
+    pub use crate::semirings::*;
+    pub use crate::algorithms::*;
+}

--- a/rustfst/src/parsers/bin_fst/vector_fst.rs
+++ b/rustfst/src/parsers/bin_fst/vector_fst.rs
@@ -3,7 +3,7 @@ use std::fs::File;
 use std::io::Write;
 use std::path::Path;
 
-use failure::Fallible;
+use failure::{Fallible, ResultExt};
 use nom::{le_f32, le_i32, le_i64, le_u64};
 
 use crate::fst_impls::vector::vector_fst::VectorFstState;
@@ -104,7 +104,7 @@ named!(complete_parse_fst <&[u8], ParsedFst>, complete!(parse_fst));
 
 impl<W: 'static + Semiring<Type = f32>> BinaryDeserializer for VectorFst<W> {
     fn read<P: AsRef<Path>>(path_bin_fst: P) -> Fallible<Self> {
-        let data = read(path_bin_fst.as_ref())?;
+        let data = read(path_bin_fst.as_ref()).with_context(|_| format!("Can't open FST binary file : {:?}", path_bin_fst.as_ref()))?;
         let (_, parsed_fst) = complete_parse_fst(&data)
             .map_err(|_| format_err!("Error while parsing binary VectorFst"))?;
 


### PR DESCRIPTION
### Added
- Added the crate `rustfst-cli` as a CLI for the lib. It supports the subcommands:
    - `minimize` for the minimization
    - `connect` for the connect algorithm
- Added a prelude to `rustfst` to reduce the number of imports necessary when using the lib.