### PR TITLE
final_weight() now returs Fallible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `fst_convert` to the public API to convert one Fst object from one type to another type.
 - Added `divide_assign` to `WeaklyDivisibleSemiring` semiring to perform in-place division.
 - Added support for `ConstFst`. Also added a converter from `VectorFst` to `ConstFst` through the `From` trait.
+- Added `final_weight_unnchecked_mut` to `MutableFst` trait.
 
 ### Changed
 - Before test cases were generated with pynini (python wrapper around openfst). Now they are directly generated with OpenFST (c++). Allows to test operations that are not wrapped.
@@ -74,6 +75,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use `SccVisitor` in `compute_fst_properties` implementation.
 - `value` methods of Semiring trait now returns a reference to the underlying weight.
 - `final_weight` method of `Fst` trait now returns a reference to the final weight instead of a copy.
+- `final_weight` method of `Fst` trait now returns a `Fallible`. Fail only when the state doesn't exist.
+- `final_weight_mut` method of `Fst` trait now returns a `Fallible`. Fail only when the state doesn't exist.
+- `FinalStateIterator` now returns reference to final weights instead of copy.
 
 ### Removed
 - Crate `rustfst-tests-openfst` has been removed and moved to the `rustfst` as unit tests. 

--- a/rustfst/src/algorithms/arc_map.rs
+++ b/rustfst/src/algorithms/arc_map.rs
@@ -1,6 +1,6 @@
 use failure::Fallible;
 
-use crate::fst_traits::MutableFst;
+use crate::fst_traits::{ExpandedFst, MutableFst};
 use crate::semirings::Semiring;
 use crate::Arc;
 use crate::{Label, StateId, EPS_LABEL};
@@ -71,13 +71,14 @@ where
         ifst.set_final(superfinal_id, F::W::one()).unwrap();
     }
 
+    // TODO: Remove this collect
     let states: Vec<_> = ifst.states_iter().collect();
     for state in states {
         for arc in ifst.arcs_iter_mut(state).unwrap() {
             mapper.arc_map(arc)?;
         }
 
-        if let Some(w) = ifst.final_weight_mut(state) {
+        if let Some(w) = unsafe { ifst.final_weight_unchecked_mut(state) } {
             let mut final_arc = FinalArc {
                 ilabel: EPS_LABEL,
                 olabel: EPS_LABEL,

--- a/rustfst/src/algorithms/composition.rs
+++ b/rustfst/src/algorithms/composition.rs
@@ -55,7 +55,7 @@ where
     while !queue.is_empty() {
         let (q1, q2, q) = queue.pop_front().unwrap();
 
-        if let (Some(rho_1), Some(rho_2)) = (fst_1.final_weight(q1), fst_2.final_weight(q2)) {
+        if let (Some(rho_1), Some(rho_2)) = (fst_1.final_weight(q1)?, fst_2.final_weight(q2)?) {
             composed_fst.set_final(q, rho_1.times(&rho_2)?)?;
         }
 

--- a/rustfst/src/algorithms/concat.rs
+++ b/rustfst/src/algorithms/concat.rs
@@ -62,7 +62,7 @@ where
                 Arc::new(
                     EPS_LABEL,
                     EPS_LABEL,
-                    old_final_state_1.final_weight,
+                    old_final_state_1.final_weight.clone(),
                     *start_state_2,
                 ),
             )?;
@@ -72,7 +72,7 @@ where
     // Final states are final states of the second fst
     for old_final_state in fst_2.final_states_iter() {
         let final_state = mapping_states_fst_2[&old_final_state.state_id];
-        fst_out.set_final(final_state, old_final_state.final_weight)?;
+        fst_out.set_final(final_state, old_final_state.final_weight.clone())?;
     }
 
     // FINISH

--- a/rustfst/src/algorithms/connect.rs
+++ b/rustfst/src/algorithms/connect.rs
@@ -120,7 +120,7 @@ impl<'a, F: 'a + ExpandedFst> Visitor<'a, F> for ConnectVisitor<'a, F> {
         parent: Option<usize>,
         _arc: Option<&Arc<<F as CoreFst>::W>>,
     ) {
-        if self.fst.is_final(s) {
+        if unsafe { self.fst.is_final_unchecked(s) } {
             self.coaccess[s] = true;
         }
         if self.dfnumber[s] == self.lowlink[s] {

--- a/rustfst/src/algorithms/determinize.rs
+++ b/rustfst/src/algorithms/determinize.rs
@@ -236,7 +236,7 @@ where
             final_weight.plus_assign(
                 det_elt.weight.times(
                     self.fst
-                        .final_weight(det_elt.state)
+                        .final_weight(det_elt.state)?
                         .unwrap_or_else(|| &zero),
                 )?,
             )?;

--- a/rustfst/src/algorithms/factor_weight.rs
+++ b/rustfst/src/algorithms/factor_weight.rs
@@ -163,7 +163,7 @@ where
                 None => elt.weight.clone(),
                 Some(s) => elt
                     .weight
-                    .times(self.fst.final_weight(s).unwrap_or_else(|| &zero))
+                    .times(self.fst.final_weight(s)?.unwrap_or_else(|| &zero))
                     .unwrap(),
             };
             let factor_iterator = FI::new(weight.clone());
@@ -214,14 +214,14 @@ where
             }
         }
         if self.factor_final_weights()
-            && (elt.state.is_none() || self.fst.is_final(elt.state.unwrap()))
+            && (elt.state.is_none() || self.fst.is_final(elt.state.unwrap())?)
         {
             let one = F::W::one();
             let weight = match elt.state {
                 None => elt.weight.clone(),
                 Some(s) => elt
                     .weight
-                    .times(self.fst.final_weight(s).unwrap_or_else(|| &one))
+                    .times(self.fst.final_weight(s)?.unwrap_or_else(|| &one))
                     .unwrap(),
             };
             let mut ilabel = self.opts.final_ilabel;

--- a/rustfst/src/algorithms/isomorphic.rs
+++ b/rustfst/src/algorithms/isomorphic.rs
@@ -66,7 +66,7 @@ impl<'a, W: Semiring, F1: ExpandedFst<W = W>, F2: ExpandedFst<W = W>> Isomorphis
     }
 
     fn ismorphic_state(&mut self, s1: StateId, s2: StateId) -> Fallible<bool> {
-        if !(self.fst_1.final_weight(s1) == self.fst_2.final_weight(s2)) {
+        if !(self.fst_1.final_weight(s1)? == self.fst_2.final_weight(s2)?) {
             return Ok(false);
         }
 

--- a/rustfst/src/algorithms/minimize.rs
+++ b/rustfst/src/algorithms/minimize.rs
@@ -300,8 +300,8 @@ struct StateComparator<'a, F: MutableFst + ExpandedFst> {
 impl<'a, F: MutableFst + ExpandedFst> StateComparator<'a, F> {
     fn do_compare(&self, x: StateId, y: StateId) -> Fallible<bool> {
         let zero = F::W::zero();
-        let xfinal = self.fst.final_weight(x).unwrap_or_else(|| &zero);
-        let yfinal = self.fst.final_weight(y).unwrap_or_else(|| &zero);
+        let xfinal = self.fst.final_weight(x)?.unwrap_or_else(|| &zero);
+        let yfinal = self.fst.final_weight(y)?.unwrap_or_else(|| &zero);
 
         if xfinal < yfinal {
             return Ok(true);
@@ -375,7 +375,7 @@ fn pre_partition<W: Semiring, F: MutableFst<W = W> + ExpandedFst<W = W>>(
                 .map(|arc| arc.ilabel)
                 .collect();
 
-            let this_map = if fst.is_final(s) {
+            let this_map = if unsafe { fst.is_final_unchecked(s) } {
                 &mut hash_to_class_final
             } else {
                 &mut hash_to_class_nonfinal

--- a/rustfst/src/algorithms/push.rs
+++ b/rustfst/src/algorithms/push.rs
@@ -94,7 +94,7 @@ where
     }
     if at_final {
         for s in 0..fst.num_states() {
-            if let Some(final_weight) = fst.final_weight_mut(s) {
+            if let Some(final_weight) = unsafe { fst.final_weight_unchecked_mut(s) } {
                 final_weight.divide_assign(&weight, DivideType::DivideRight)?;
             }
         }
@@ -103,7 +103,7 @@ where
             for arc in unsafe { fst.arcs_iter_unchecked_mut(start) } {
                 arc.weight.divide_assign(&weight, DivideType::DivideLeft)?;
             }
-            if let Some(final_weight) = fst.final_weight_mut(start) {
+            if let Some(final_weight) = unsafe { fst.final_weight_unchecked_mut(start) } {
                 final_weight.divide_assign(&weight, DivideType::DivideLeft)?;
             }
         }

--- a/rustfst/src/algorithms/push.rs
+++ b/rustfst/src/algorithms/push.rs
@@ -76,7 +76,9 @@ where
         let mut sum = F::W::zero();
         let zero = F::W::zero();
         for s in 0..dist.len() {
-            sum.plus_assign(dist[s].times(fst.final_weight(s).unwrap_or_else(|| &zero))?)?;
+            sum.plus_assign(
+                dist[s].times(unsafe { fst.final_weight_unchecked(s) }.unwrap_or_else(|| &zero))?,
+            )?;
         }
         Ok(sum)
     }

--- a/rustfst/src/algorithms/reverse.rs
+++ b/rustfst/src/algorithms/reverse.rs
@@ -43,7 +43,7 @@ where
         if Some(is) == istart {
             ofst.set_final(os, W::ReverseWeight::one())?;
         }
-        let weight = ifst.final_weight(is);
+        let weight = unsafe { ifst.final_weight_unchecked(is) };
         if let Some(w) = weight {
             states_arcs[0].push(Arc::new(0, 0, w.reverse()?, os));
         }

--- a/rustfst/src/algorithms/reweight.rs
+++ b/rustfst/src/algorithms/reweight.rs
@@ -1,6 +1,6 @@
 use failure::Fallible;
 
-use crate::fst_traits::{ExpandedFst, FinalStatesIterator, Fst, MutableFst};
+use crate::fst_traits::{ExpandedFst, Fst, MutableFst};
 use crate::semirings::{DivideType, Semiring, WeaklyDivisibleSemiring};
 
 /// Different types of reweighting.
@@ -72,7 +72,7 @@ where
     }
 
     for state_id in 0..fst.num_states() {
-        if let Some(final_weight) = fst.final_weight_mut(state_id) {
+        if let Some(final_weight) = unsafe { fst.final_weight_unchecked_mut(state_id) } {
             let d_s = potentials.get(state_id).unwrap_or(&zero);
 
             match reweight_type {

--- a/rustfst/src/algorithms/reweight.rs
+++ b/rustfst/src/algorithms/reweight.rs
@@ -71,25 +71,22 @@ where
         }
     }
 
-    let final_states: Vec<_> = fst.final_states_iter().collect();
+    for state_id in 0..fst.num_states() {
+        if let Some(final_weight) = fst.final_weight_mut(state_id) {
+            let d_s = potentials.get(state_id).unwrap_or(&zero);
 
-    for final_state in final_states {
-        let d_s = potentials.get(final_state.state_id).unwrap_or(&zero);
-
-        match reweight_type {
-            ReweightType::ReweightToFinal => {
-                let new_weight = d_s.times(&final_state.final_weight)?;
-                fst.set_final(final_state.state_id, new_weight)?;
-            }
-            ReweightType::ReweightToInitial => {
-                if d_s.is_zero() {
-                    continue;
+            match reweight_type {
+                ReweightType::ReweightToFinal => {
+                    final_weight.times_assign(d_s)?;
                 }
-                let new_weight =
-                    (&final_state.final_weight).divide(&d_s, DivideType::DivideLeft)?;
-                fst.set_final(final_state.state_id, new_weight)?;
-            }
-        };
+                ReweightType::ReweightToInitial => {
+                    if d_s.is_zero() {
+                        continue;
+                    }
+                    final_weight.divide_assign(d_s, DivideType::DivideLeft)?;
+                }
+            };
+        }
     }
 
     // Handles potential of the start state

--- a/rustfst/src/algorithms/reweight.rs
+++ b/rustfst/src/algorithms/reweight.rs
@@ -38,7 +38,7 @@ where
             match reweight_type {
                 ReweightType::ReweightToInitial => {}
                 ReweightType::ReweightToFinal => {
-                    if let Some(final_weight) = fst.final_weight(state) {
+                    if let Some(final_weight) = fst.final_weight(state)? {
                         let new_weight = F::W::zero().times(&final_weight)?;
                         fst.set_final(state, new_weight)?;
                     }
@@ -106,7 +106,7 @@ where
                 };
             }
 
-            if let Some(final_weight) = fst.final_weight(start_state) {
+            if let Some(final_weight) = fst.final_weight(start_state)? {
                 let new_weight = match reweight_type {
                     ReweightType::ReweightToInitial => d_s.times(&final_weight)?,
                     ReweightType::ReweightToFinal => {

--- a/rustfst/src/algorithms/rm_epsilon.rs
+++ b/rustfst/src/algorithms/rm_epsilon.rs
@@ -56,7 +56,7 @@ where
     for old_final_state in fst.final_states_iter() {
         fst_epsilon.set_final(
             mapping_states[&old_final_state.state_id],
-            old_final_state.final_weight,
+            old_final_state.final_weight.clone(),
         )?;
     }
     Ok(fst_epsilon)

--- a/rustfst/src/algorithms/rm_epsilon.rs
+++ b/rustfst/src/algorithms/rm_epsilon.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use failure::Fallible;
+use unsafe_unwrap::UnsafeUnwrap;
 
 use crate::algorithms::all_pairs_shortest_distance;
 use crate::algorithms::arc_sum;
@@ -131,12 +132,12 @@ where
                 )?;
             }
 
-            if fst_no_epsilon.is_final(*q) {
-                if !fst_no_epsilon.is_final(p) {
+            if unsafe { fst_no_epsilon.is_final_unchecked(*q) } {
+                if !unsafe { fst_no_epsilon.is_final_unchecked(p) } {
                     output_fst.set_final(p, W::zero())?;
                 }
-                let rho_prime_p = output_fst.final_weight(p).unwrap();
-                let rho_q = fst_no_epsilon.final_weight(*q).unwrap();
+                let rho_prime_p = unsafe { output_fst.final_weight_unchecked(p).unsafe_unwrap() };
+                let rho_q = unsafe { fst_no_epsilon.final_weight_unchecked(*q).unsafe_unwrap() };
                 let new_weight = rho_prime_p.plus(&w_prime.times(&rho_q)?)?;
                 output_fst.set_final(p, new_weight)?;
             }
@@ -150,14 +151,16 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use counter::Counter;
+    use failure::format_err;
+    use failure::ResultExt;
+
     use crate::fst_impls::VectorFst;
     use crate::fst_traits::PathsIterator;
     use crate::semirings::IntegerWeight;
     use crate::test_data::vector_fst::get_vector_fsts_for_tests;
-    use counter::Counter;
-    use failure::format_err;
-    use failure::ResultExt;
+
+    use super::*;
 
     // TODO: Add test with epsilon arcs
 

--- a/rustfst/src/algorithms/shortest_path.rs
+++ b/rustfst/src/algorithms/shortest_path.rs
@@ -119,7 +119,7 @@ where
         enqueued[s] = false;
         let sd = distance[s].clone();
 
-        if let Some(final_weight) = ifst.final_weight(s) {
+        if let Some(final_weight) = ifst.final_weight(s)? {
             let plus = f_distance.plus(&sd.times(&final_weight)?)?;
             if f_distance != plus {
                 f_distance = plus;
@@ -169,7 +169,7 @@ where
         d_p = s_p;
         s_p = Some(ofst.add_state());
         if d.is_none() {
-            if let Some(final_weight) = ifst.final_weight(f_parent.unwrap()) {
+            if let Some(final_weight) = ifst.final_weight(f_parent.unwrap())? {
                 ofst.set_final(s_p.unwrap(), final_weight.clone())?;
             }
         } else {
@@ -313,7 +313,7 @@ where
             ofst.add_arc(next, arc)?;
             heap.push(next);
         }
-        let final_weight = ifst.final_weight(p.0.unwrap());
+        let final_weight = ifst.final_weight(p.0.unwrap())?;
         if let Some(_final_weight) = final_weight {
             let r_final_weight: W = hack_convert_reverse_reverse(_final_weight.reverse()?);
             if !r_final_weight.is_zero() {

--- a/rustfst/src/algorithms/state_sort.rs
+++ b/rustfst/src/algorithms/state_sort.rs
@@ -37,14 +37,14 @@ where
         if done[s1] {
             continue;
         }
-        let mut final1 = fst.final_weight(s1).cloned();
+        let mut final1 = unsafe { fst.final_weight_unchecked(s1) }.cloned();
         let mut final2 = None;
         let mut arcsa: Vec<_> = fst.arcs_iter(s1)?.cloned().collect();
         let mut arcsb = vec![];
         while !done[s1] {
             let s2 = order[s1];
             if !done[s2] {
-                final2 = fst.final_weight(s2).cloned();
+                final2 = unsafe { fst.final_weight_unchecked(s2) }.cloned();
                 arcsb = fst.arcs_iter(s2)?.cloned().collect();
             }
             match final1 {

--- a/rustfst/src/algorithms/union.rs
+++ b/rustfst/src/algorithms/union.rs
@@ -102,7 +102,7 @@ where
                 old_final_state.state_id
             )
         })?;
-        fst_out.set_final(*final_state, old_final_state.final_weight)?;
+        fst_out.set_final(*final_state, old_final_state.final_weight.clone())?;
     }
 
     Ok(())

--- a/rustfst/src/algorithms/visitors/scc_visitors.rs
+++ b/rustfst/src/algorithms/visitors/scc_visitors.rs
@@ -93,7 +93,7 @@ impl<'a, F: 'a + ExpandedFst> Visitor<'a, F> for SccVisitor<'a, F> {
         parent: Option<usize>,
         _arc: Option<&Arc<<F as CoreFst>::W>>,
     ) {
-        if self.fst.is_final(s) {
+        if unsafe { self.fst.is_final_unchecked(s) } {
             self.coaccess[s] = true;
         }
         if self.dfnumber[s] == self.lowlink[s] {

--- a/rustfst/src/algorithms/weight_convert.rs
+++ b/rustfst/src/algorithms/weight_convert.rs
@@ -58,7 +58,7 @@ where
         for arc in fst_in.arcs_iter(state)? {
             fst_out.add_arc(state, mapper.arc_map(arc)?)?;
         }
-        if let Some(w) = fst_in.final_weight(state) {
+        if let Some(w) = unsafe { fst_in.final_weight_unchecked(state) } {
             let final_arc = FinalArc {
                 ilabel: EPS_LABEL,
                 olabel: EPS_LABEL,

--- a/rustfst/src/fst_impls/const_fst/fst.rs
+++ b/rustfst/src/fst_impls/const_fst/fst.rs
@@ -13,12 +13,12 @@ impl<W: Semiring> CoreFst for ConstFst<W> {
         self.start
     }
 
-    fn final_weight(&self, state_id: usize) -> Option<&Self::W> {
-        if let Some(state) = self.states.get(state_id) {
-            state.final_weight.as_ref()
-        } else {
-            None
-        }
+    fn final_weight(&self, state_id: usize) -> Fallible<Option<&Self::W>> {
+        let s = self
+            .states
+            .get(state_id)
+            .ok_or_else(|| format_err!("State {:?} doesn't exist", state_id))?;
+        Ok(s.final_weight.as_ref())
     }
 
     unsafe fn final_weight_unchecked(&self, state_id: usize) -> Option<&Self::W> {

--- a/rustfst/src/fst_impls/vector_fst/fst.rs
+++ b/rustfst/src/fst_impls/vector_fst/fst.rs
@@ -13,12 +13,12 @@ impl<W: 'static + Semiring> CoreFst for VectorFst<W> {
         self.start_state
     }
 
-    fn final_weight(&self, state_id: StateId) -> Option<&W> {
-        if let Some(state) = self.states.get(state_id) {
-            state.final_weight.as_ref()
-        } else {
-            None
-        }
+    fn final_weight(&self, state_id: StateId) -> Fallible<Option<&W>> {
+        let s = self
+            .states
+            .get(state_id)
+            .ok_or_else(|| format_err!("State {:?} doesn't exist", state_id))?;
+        Ok(s.final_weight.as_ref())
     }
 
     #[inline]

--- a/rustfst/src/fst_impls/vector_fst/mutable_fst.rs
+++ b/rustfst/src/fst_impls/vector_fst/mutable_fst.rs
@@ -204,12 +204,19 @@ impl<W: 'static + Semiring> MutableFst for VectorFst<W> {
         self.states.reserve(additional);
     }
 
-    fn final_weight_mut(&mut self, state_id: StateId) -> Option<&mut W> {
-        if let Some(state) = self.states.get_mut(state_id) {
-            state.final_weight.as_mut()
-        } else {
-            None
-        }
+    fn final_weight_mut(&mut self, state_id: StateId) -> Fallible<Option<&mut W>> {
+        let s = self
+            .states
+            .get_mut(state_id)
+            .ok_or_else(|| format_err!("State {:?} doesn't exist", state_id))?;
+        Ok(s.final_weight.as_mut())
+    }
+
+    unsafe fn final_weight_unchecked_mut(&mut self, state_id: usize) -> Option<&mut Self::W> {
+        self.states
+            .get_unchecked_mut(state_id)
+            .final_weight
+            .as_mut()
     }
 
     fn sort_arcs_unchecked<F: Fn(&Arc<Self::W>, &Arc<Self::W>) -> Ordering>(

--- a/rustfst/src/fst_impls/vector_fst/test.rs
+++ b/rustfst/src/fst_impls/vector_fst/test.rs
@@ -149,7 +149,7 @@ mod tests {
         // None of the states are final => None final weight
         assert!(fst
             .states_iter()
-            .map(|state_id| fst.final_weight(state_id))
+            .map(|state_id| fst.final_weight(state_id).unwrap())
             .all(|v| v.is_none()));
 
         // Select randomly n_final_states
@@ -164,11 +164,13 @@ mod tests {
         });
 
         // Check they are final with the correct weight
-        assert!(final_states.iter().all(|state_id| fst.is_final(*state_id)));
+        assert!(final_states
+            .iter()
+            .all(|state_id| fst.is_final(*state_id).unwrap()));
         assert!(final_states
             .iter()
             .enumerate()
-            .all(|(idx, state_id)| fst.final_weight(*state_id)
+            .all(|(idx, state_id)| fst.final_weight(*state_id).unwrap()
                 == Some(&ProbabilityWeight::new(idx as f32))));
         Ok(())
     }

--- a/rustfst/src/fst_properties/compute_fst_properties.rs
+++ b/rustfst/src/fst_properties/compute_fst_properties.rs
@@ -147,8 +147,8 @@ pub fn compute_fst_properties<F: Fst + ExpandedFst>(fst: &F) -> Fallible<FstProp
             comp_props |= FstProperties::NOT_STRING;
             comp_props &= !FstProperties::STRING;
         }
-        if fst.is_final(state) {
-            let final_weight = fst.final_weight(state).unwrap();
+        if fst.is_final(state)? {
+            let final_weight = unsafe { fst.final_weight_unchecked(state).unsafe_unwrap() };
             if !final_weight.is_one() {
                 comp_props |= FstProperties::WEIGHTED;
                 comp_props &= !FstProperties::UNWEIGHTED;

--- a/rustfst/src/fst_traits/final_states_iterator.rs
+++ b/rustfst/src/fst_traits/final_states_iterator.rs
@@ -3,42 +3,42 @@ use crate::semirings::Semiring;
 use crate::StateId;
 
 #[derive(Debug)]
-pub struct FinalState<W: Semiring> {
+pub struct FinalState<'f, W: Semiring> {
     pub state_id: StateId,
-    pub final_weight: W,
+    pub final_weight: &'f W,
 }
 
 /// Trait to iterate over the final states of a wFST.
-pub trait FinalStatesIterator<'a> {
-    type W: Semiring;
-    type Iter: Iterator<Item = FinalState<Self::W>>;
-    fn final_states_iter(&'a self) -> Self::Iter;
+pub trait FinalStatesIterator<'f> {
+    type W: Semiring + 'f;
+    type Iter: Iterator<Item = FinalState<'f, Self::W>>;
+    fn final_states_iter(&'f self) -> Self::Iter;
 }
 
-impl<'a, F> FinalStatesIterator<'a> for F
+impl<'f, F> FinalStatesIterator<'f> for F
 where
-    F: 'a + Fst,
+    F: 'f + Fst,
 {
     type W = F::W;
-    type Iter = StructFinalStatesIterator<'a, F>;
-    fn final_states_iter(&'a self) -> Self::Iter {
+    type Iter = StructFinalStatesIterator<'f, F>;
+    fn final_states_iter(&'f self) -> Self::Iter {
         StructFinalStatesIterator::new(&self)
     }
 }
 
-pub struct StructFinalStatesIterator<'a, F>
+pub struct StructFinalStatesIterator<'f, F>
 where
-    F: 'a + Fst,
+    F: 'f + Fst,
 {
-    fst: &'a F,
-    it: <F as StateIterator<'a>>::Iter,
+    fst: &'f F,
+    it: <F as StateIterator<'f>>::Iter,
 }
 
-impl<'a, F> StructFinalStatesIterator<'a, F>
+impl<'f, F> StructFinalStatesIterator<'f, F>
 where
-    F: 'a + Fst,
+    F: 'f + Fst,
 {
-    fn new(fst: &'a F) -> StructFinalStatesIterator<F> {
+    fn new(fst: &'f F) -> StructFinalStatesIterator<F> {
         StructFinalStatesIterator {
             fst,
             it: fst.states_iter(),
@@ -46,19 +46,18 @@ where
     }
 }
 
-impl<'a, F> Iterator for StructFinalStatesIterator<'a, F>
+impl<'f, F> Iterator for StructFinalStatesIterator<'f, F>
 where
-    F: 'a + Fst,
+    F: 'f + Fst,
 {
-    type Item = FinalState<F::W>;
+    type Item = FinalState<'f, F::W>;
 
     fn next(&mut self) -> Option<Self::Item> {
         while let Some(state_id) = self.it.next() {
-            if let Some(final_weight) = self.fst.final_weight(state_id) {
+            if let Some(final_weight) = unsafe { self.fst.final_weight_unchecked(state_id) } {
                 return Some(FinalState {
                     state_id,
-                    // TODO: No need to clone here.
-                    final_weight: final_weight.clone(),
+                    final_weight: &final_weight,
                 });
             }
         }

--- a/rustfst/src/fst_traits/macros.rs
+++ b/rustfst/src/fst_traits/macros.rs
@@ -82,7 +82,7 @@ macro_rules! draw_single_state {
     ($fst:expr, $state_id:expr, $f: expr, $config:expr) => {
         write!($f, "{}", $state_id)?;
         write!($f, " [label = \"{}", $state_id)?;
-        if let Some(final_weight) = $fst.final_weight($state_id) {
+        if let Some(final_weight) = $fst.final_weight($state_id)? {
             if $config.show_weight_one || !final_weight.is_one() {
                 write!($f, "/{}", final_weight)?;
             }

--- a/rustfst/src/fst_traits/mutable_fst.rs
+++ b/rustfst/src/fst_traits/mutable_fst.rs
@@ -187,10 +187,15 @@ pub trait MutableFst: Fst + for<'a> MutableArcIterator<'a> {
     /// Reserve space for storing enough states.
     fn reserve_states(&mut self, additional: usize);
 
-    // TODO: Return Result<Option<_>>
-    // TODO: Provide unchecked equivalent
     /// Retrieves a mutable reference to the final weight of a state (if the state is a final one).
-    fn final_weight_mut(&mut self, state_id: StateId) -> Option<&mut <Self as CoreFst>::W>;
+    fn final_weight_mut(
+        &mut self,
+        state_id: StateId,
+    ) -> Fallible<Option<&mut <Self as CoreFst>::W>>;
+    unsafe fn final_weight_unchecked_mut(
+        &mut self,
+        state_id: StateId,
+    ) -> Option<&mut <Self as CoreFst>::W>;
 
     fn sort_arcs_unchecked<F: Fn(&Arc<Self::W>, &Arc<Self::W>) -> Ordering>(
         &mut self,

--- a/rustfst/src/fst_traits/mutable_fst.rs
+++ b/rustfst/src/fst_traits/mutable_fst.rs
@@ -50,16 +50,16 @@ pub trait MutableFst: Fst + for<'a> MutableArcIterator<'a> {
     /// let s1 = fst.add_state();
     /// let s2 = fst.add_state();
     ///
-    /// assert_eq!(fst.final_weight(s1), None);
-    /// assert_eq!(fst.final_weight(s2), None);
+    /// assert_eq!(fst.final_weight(s1).unwrap(), None);
+    /// assert_eq!(fst.final_weight(s2).unwrap(), None);
     ///
     /// fst.set_final(s1, BooleanWeight::one());
-    /// assert_eq!(fst.final_weight(s1), Some(&BooleanWeight::one()));
-    /// assert_eq!(fst.final_weight(s2), None);
+    /// assert_eq!(fst.final_weight(s1).unwrap(), Some(&BooleanWeight::one()));
+    /// assert_eq!(fst.final_weight(s2).unwrap(), None);
     ///
     /// fst.set_final(s2, BooleanWeight::one());
-    /// assert_eq!(fst.final_weight(s1), Some(&BooleanWeight::one()));
-    /// assert_eq!(fst.final_weight(s2), Some(&BooleanWeight::one()));
+    /// assert_eq!(fst.final_weight(s1).unwrap(), Some(&BooleanWeight::one()));
+    /// assert_eq!(fst.final_weight(s2).unwrap(), Some(&BooleanWeight::one()));
     /// ```
     fn set_final(&mut self, state_id: StateId, final_weight: <Self as CoreFst>::W) -> Fallible<()>;
     unsafe fn set_final_unchecked(&mut self, state_id: StateId, final_weight: <Self as CoreFst>::W);

--- a/rustfst/src/fst_traits/mutable_fst.rs
+++ b/rustfst/src/fst_traits/mutable_fst.rs
@@ -187,6 +187,8 @@ pub trait MutableFst: Fst + for<'a> MutableArcIterator<'a> {
     /// Reserve space for storing enough states.
     fn reserve_states(&mut self, additional: usize);
 
+    // TODO: Return Result<Option<_>>
+    // TODO: Provide unchecked equivalent
     /// Retrieves a mutable reference to the final weight of a state (if the state is a final one).
     fn final_weight_mut(&mut self, state_id: StateId) -> Option<&mut <Self as CoreFst>::W>;
 

--- a/rustfst/src/fst_traits/paths_iterator.rs
+++ b/rustfst/src/fst_traits/paths_iterator.rs
@@ -56,7 +56,7 @@ where
         while !self.queue.is_empty() {
             let (state_id, mut path) = self.queue.pop_front().unwrap();
 
-            for arc in self.fst.arcs_iter(state_id).unwrap() {
+            for arc in unsafe { self.fst.arcs_iter_unchecked(state_id) } {
                 let mut new_path = path.clone();
                 new_path
                     .add_to_path(arc.ilabel, arc.olabel, &arc.weight)
@@ -64,7 +64,7 @@ where
                 self.queue.push_back((arc.nextstate, new_path));
             }
 
-            if let Some(final_weight) = self.fst.final_weight(state_id) {
+            if let Some(final_weight) = unsafe { self.fst.final_weight_unchecked(state_id) } {
                 path.add_weight(final_weight)
                     .expect("Error add_weight in PathsIterator");
                 return Some(path);

--- a/rustfst/src/parsers/bin_fst/vector_fst.rs
+++ b/rustfst/src/parsers/bin_fst/vector_fst.rs
@@ -186,10 +186,10 @@ impl<W: 'static + Semiring<Type = f32>> BinarySerializer for VectorFst<W> {
         //version: i32,
         write_bin_i32(&mut file, 2i32)?;
         //flags: i32,
-        // FIXME: Flags are used to check whether or not a symboltable has to be loaded
+        // TODO: Flags are used to check whether or not a symboltable has to be loaded
         write_bin_i32(&mut file, 0i32)?;
         //properties: u64, 3 = kMutable | kExpanded
-        // FIXME: Once the properties are stored, need to read them
+        // TODO: Once the properties are stored, need to read them
         write_bin_u64(&mut file, 3u64)?;
         //start: i64,
         write_bin_i64(&mut file, self.start_state.map(|v| v as i64).unwrap_or(-1))?;
@@ -204,7 +204,11 @@ impl<W: 'static + Semiring<Type = f32>> BinarySerializer for VectorFst<W> {
         let zero = W::zero();
         // FstBody
         for state in 0..self.num_states() {
-            let f_weight = self.final_weight(state).unwrap_or_else(|| &zero).value();
+            let f_weight = unsafe {
+                self.final_weight_unchecked(state)
+                    .unwrap_or_else(|| &zero)
+                    .value()
+            };
             write_bin_f32(&mut file, *f_weight)?;
             write_bin_i64(&mut file, unsafe { self.num_arcs_unchecked(state) } as i64)?;
 


### PR DESCRIPTION
- Added `final_weight_unnchecked_mut` to `MutableFst` trait.
- `final_weight` method of `Fst` trait now returns a `Fallible`. Fail only when the state doesn't exist.
- `final_weight_mut` method of `Fst` trait now returns a `Fallible`. Fail only when the state doesn't exist.
- `FinalStateIterator` now returns reference to final weights instead of copy.