### PR TITLE
Add quotes around DOT file title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Make `KDELTA` public outside of the crate
+- Fix serialization into a DOT file by putting the `label` into quotes.
 
 ## [0.4.0] - 2019-11-12
 

--- a/rustfst/src/fst_traits/expanded_fst.rs
+++ b/rustfst/src/fst_traits/expanded_fst.rs
@@ -67,7 +67,7 @@ pub trait ExpandedFst: Fst {
             }
 
             writeln!(f, "size = \"{},{}\";", config.width, config.height)?;
-            writeln!(f, "label = {};", config.title)?;
+            writeln!(f, "label = \"{}\";", config.title)?;
             writeln!(f, "center = 1;")?;
 
             if config.portrait {


### PR DESCRIPTION
This is to make sure that the `label` in a DOT file is rendered correctly even if it consists of several words (contains spaces). The addition of quotes also prevents dot from complaining about a syntax error if no  `DrawingConfig.title` is specified (e.g. when using `DrawingConfig::default()`) which previously resulted in the line `label = ;` being added to the DOT file.
