### PR TITLE
Fst Memory Management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Make `KDELTA` public outside of the crate
 - Fix serialization into a DOT file by putting the `label` into quotes.
-- remove `reverse` API from `MutableFst`, see `AllocableFst` for this API 
+- remove `reserve` API from `MutableFst`, see `AllocableFst` for this API 
 
 ## [0.4.0] - 2019-11-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add `FstIterator` and `FstIteratorMut` to iterate over states and arcs in a given FST without referencing the FST.
 - Implement `FstIterator` and `FstIteratorMut` for ConstFst and VectorFst.
+- Add `AllocableFst` to control the wFst allocation: `capacity`, `reserve`, `shrink_to_fit`
+- Implement `AllocableFst` for Vector Fst
 - Add `del_all_states` method in the `MutableFst` trait to remove all the states in a Fst.
 - Add `set_input_symbols()` and `set_output_symbols()` to the `MutableFst` trait to attach a `SymbolTable` to an Fst.
 - Add `input_symbols()` and `output_symbols()` to the `Fst` trait to retrieve previously attached `SymbolTable`.
@@ -16,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Make `KDELTA` public outside of the crate
 - Fix serialization into a DOT file by putting the `label` into quotes.
+- remove `reverse` API from `MutableFst`, see `AllocableFst` for this API 
 
 ## [0.4.0] - 2019-11-12
 

--- a/rustfst/src/algorithms/determinize.rs
+++ b/rustfst/src/algorithms/determinize.rs
@@ -12,7 +12,7 @@ use crate::algorithms::weight_converters::{FromGallicConverter, ToGallicConverte
 use crate::algorithms::{factor_weight, weight_convert, FactorWeightOptions, FactorWeightType};
 use crate::arc::Arc;
 use crate::fst_impls::VectorFst;
-use crate::fst_traits::{ExpandedFst, Fst, MutableFst};
+use crate::fst_traits::{ExpandedFst, Fst, MutableFst, AllocableFst};
 use crate::semirings::{
     DivideType, GallicWeight, GallicWeightLeft, GallicWeightMin, GallicWeightRestrict, Semiring,
     SemiringProperties, StringWeightLeft, StringWeightRestrict, WeaklyDivisibleSemiring,
@@ -442,7 +442,7 @@ pub fn determinize_fst<W, F1, F2>(fst_in: &F1, det_type: DeterminizeType) -> Fal
 where
     W: WeaklyDivisibleSemiring + WeightQuantize + 'static,
     F1: ExpandedFst<W = W>,
-    F2: MutableFst<W = W> + ExpandedFst<W = W>,
+    F2: MutableFst<W = W> + ExpandedFst<W = W> + AllocableFst,
 {
     let mut to_gallic = ToGallicConverter {};
     let mut from_gallic = FromGallicConverter {
@@ -496,7 +496,7 @@ pub fn determinize<W, F1, F2>(fst_in: &F1, det_type: DeterminizeType) -> Fallibl
 where
     W: WeaklyDivisibleSemiring + WeightQuantize + 'static,
     F1: ExpandedFst<W = W>,
-    F2: MutableFst<W = W> + ExpandedFst<W = W>,
+    F2: MutableFst<W = W> + ExpandedFst<W = W> + AllocableFst,
 {
     if fst_in.is_acceptor() {
         determinize_fsa::<_, _, _, DefaultCommonDivisor>(fst_in)

--- a/rustfst/src/algorithms/determinize.rs
+++ b/rustfst/src/algorithms/determinize.rs
@@ -12,7 +12,7 @@ use crate::algorithms::weight_converters::{FromGallicConverter, ToGallicConverte
 use crate::algorithms::{factor_weight, weight_convert, FactorWeightOptions, FactorWeightType};
 use crate::arc::Arc;
 use crate::fst_impls::VectorFst;
-use crate::fst_traits::{ExpandedFst, Fst, MutableFst, AllocableFst};
+use crate::fst_traits::{AllocableFst, ExpandedFst, Fst, MutableFst};
 use crate::semirings::{
     DivideType, GallicWeight, GallicWeightLeft, GallicWeightMin, GallicWeightRestrict, Semiring,
     SemiringProperties, StringWeightLeft, StringWeightRestrict, WeaklyDivisibleSemiring,

--- a/rustfst/src/algorithms/fst_convert.rs
+++ b/rustfst/src/algorithms/fst_convert.rs
@@ -1,4 +1,4 @@
-use crate::fst_traits::{ExpandedFst, MutableFst, AllocableFst};
+use crate::fst_traits::{AllocableFst, ExpandedFst, MutableFst};
 
 pub fn fst_convert<F1, F2>(ifst: &F1) -> F2
 where

--- a/rustfst/src/algorithms/fst_convert.rs
+++ b/rustfst/src/algorithms/fst_convert.rs
@@ -1,9 +1,9 @@
-use crate::fst_traits::{ExpandedFst, MutableFst};
+use crate::fst_traits::{ExpandedFst, MutableFst, AllocableFst};
 
 pub fn fst_convert<F1, F2>(ifst: &F1) -> F2
 where
     F1: ExpandedFst,
-    F2: MutableFst<W = F1::W> + ExpandedFst,
+    F2: MutableFst<W = F1::W> + ExpandedFst + AllocableFst,
 {
     let mut ofst = F2::new();
     ofst.add_states(ifst.num_states());
@@ -12,6 +12,10 @@ where
         unsafe { ofst.set_start_unchecked(start) };
 
         for s in 0..ifst.num_states() {
+            // Preallocation
+            unsafe {
+                ofst.reserve_arcs_unchecked(s, ifst.num_arcs_unchecked(s));
+            }
             for arc in unsafe { ifst.arcs_iter_unchecked(s) } {
                 unsafe { ofst.add_arc_unchecked(s, arc.clone()) };
             }

--- a/rustfst/src/algorithms/minimize.rs
+++ b/rustfst/src/algorithms/minimize.rs
@@ -23,7 +23,7 @@ use crate::algorithms::{
 use crate::fst_impls::VectorFst;
 use crate::fst_properties::FstProperties;
 use crate::fst_traits::ArcIterator;
-use crate::fst_traits::{CoreFst, ExpandedFst, Fst, MutableFst};
+use crate::fst_traits::{CoreFst, ExpandedFst, Fst, MutableFst, AllocableFst};
 use crate::semirings::{
     GallicWeightLeft, Semiring, SemiringProperties, WeaklyDivisibleSemiring, WeightQuantize,
 };
@@ -35,7 +35,7 @@ use crate::NO_STATE_ID;
 
 pub fn minimize<F>(ifst: &mut F, allow_nondet: bool) -> Fallible<()>
 where
-    F: MutableFst + ExpandedFst,
+    F: MutableFst + ExpandedFst + AllocableFst,
     F::W: WeaklyDivisibleSemiring + WeightQuantize + 'static,
     <<F as CoreFst>::W as Semiring>::ReverseWeight: 'static,
 {

--- a/rustfst/src/algorithms/minimize.rs
+++ b/rustfst/src/algorithms/minimize.rs
@@ -23,7 +23,7 @@ use crate::algorithms::{
 use crate::fst_impls::VectorFst;
 use crate::fst_properties::FstProperties;
 use crate::fst_traits::ArcIterator;
-use crate::fst_traits::{CoreFst, ExpandedFst, Fst, MutableFst, AllocableFst};
+use crate::fst_traits::{AllocableFst, CoreFst, ExpandedFst, Fst, MutableFst};
 use crate::semirings::{
     GallicWeightLeft, Semiring, SemiringProperties, WeaklyDivisibleSemiring, WeightQuantize,
 };

--- a/rustfst/src/algorithms/push.rs
+++ b/rustfst/src/algorithms/push.rs
@@ -11,7 +11,7 @@ use crate::algorithms::{
     FactorWeightType, ReweightType,
 };
 use crate::fst_impls::VectorFst;
-use crate::fst_traits::{CoreFst, ExpandedFst, Fst, MutableFst};
+use crate::fst_traits::{CoreFst, ExpandedFst, Fst, MutableFst, AllocableFst};
 use crate::semirings::{DivideType, Semiring};
 use crate::semirings::{
     GallicWeightLeft, GallicWeightRight, StringWeightLeft, StringWeightRight,
@@ -163,7 +163,7 @@ pub fn push<F1, F2>(ifst: &F1, reweight_type: ReweightType, push_type: PushType)
 where
     F1: ExpandedFst,
     F1::W: WeaklyDivisibleSemiring + WeightQuantize,
-    F2: ExpandedFst<W = F1::W> + MutableFst,
+    F2: ExpandedFst<W = F1::W> + MutableFst + AllocableFst,
     <F1 as CoreFst>::W: 'static,
     <<F1 as CoreFst>::W as Semiring>::ReverseWeight: 'static,
 {

--- a/rustfst/src/algorithms/push.rs
+++ b/rustfst/src/algorithms/push.rs
@@ -11,7 +11,7 @@ use crate::algorithms::{
     FactorWeightType, ReweightType,
 };
 use crate::fst_impls::VectorFst;
-use crate::fst_traits::{CoreFst, ExpandedFst, Fst, MutableFst, AllocableFst};
+use crate::fst_traits::{AllocableFst, CoreFst, ExpandedFst, Fst, MutableFst};
 use crate::semirings::{DivideType, Semiring};
 use crate::semirings::{
     GallicWeightLeft, GallicWeightRight, StringWeightLeft, StringWeightRight,

--- a/rustfst/src/algorithms/reverse.rs
+++ b/rustfst/src/algorithms/reverse.rs
@@ -1,7 +1,7 @@
 use failure::Fallible;
 
 use crate::arc::Arc;
-use crate::fst_traits::{ExpandedFst, MutableFst, AllocableFst};
+use crate::fst_traits::{AllocableFst, ExpandedFst, MutableFst};
 use crate::semirings::Semiring;
 
 /// Reverses an FST. The reversed result is written to an output mutable FST.

--- a/rustfst/src/algorithms/reverse.rs
+++ b/rustfst/src/algorithms/reverse.rs
@@ -1,7 +1,7 @@
 use failure::Fallible;
 
 use crate::arc::Arc;
-use crate::fst_traits::{ExpandedFst, MutableFst};
+use crate::fst_traits::{ExpandedFst, MutableFst, AllocableFst};
 use crate::semirings::Semiring;
 
 /// Reverses an FST. The reversed result is written to an output mutable FST.
@@ -18,7 +18,7 @@ pub fn reverse<W, F1, F2>(ifst: &F1) -> Fallible<F2>
 where
     W: Semiring,
     F1: ExpandedFst<W = W>,
-    F2: MutableFst<W = W::ReverseWeight> + ExpandedFst<W = W::ReverseWeight>,
+    F2: MutableFst<W = W::ReverseWeight> + ExpandedFst<W = W::ReverseWeight> + AllocableFst,
 {
     let mut ofst = F2::new();
     ofst.reserve_states(ifst.num_states());

--- a/rustfst/src/algorithms/weight_convert.rs
+++ b/rustfst/src/algorithms/weight_convert.rs
@@ -1,7 +1,7 @@
 use failure::Fallible;
 
 use crate::algorithms::{FinalArc, MapFinalAction};
-use crate::fst_traits::{ExpandedFst, MutableFst, AllocableFst};
+use crate::fst_traits::{AllocableFst, ExpandedFst, MutableFst};
 use crate::semirings::Semiring;
 use crate::{Arc, EPS_LABEL};
 

--- a/rustfst/src/algorithms/weight_convert.rs
+++ b/rustfst/src/algorithms/weight_convert.rs
@@ -1,7 +1,7 @@
 use failure::Fallible;
 
 use crate::algorithms::{FinalArc, MapFinalAction};
-use crate::fst_traits::{ExpandedFst, MutableFst};
+use crate::fst_traits::{ExpandedFst, MutableFst, AllocableFst};
 use crate::semirings::Semiring;
 use crate::{Arc, EPS_LABEL};
 
@@ -18,7 +18,7 @@ pub trait WeightConverter<SI: Semiring, SO: Semiring> {
 pub fn weight_convert<F1, F2, M>(fst_in: &F1, mapper: &mut M) -> Fallible<F2>
 where
     F1: ExpandedFst,
-    F2: MutableFst,
+    F2: MutableFst + AllocableFst,
     M: WeightConverter<F1::W, F2::W>,
 {
     let mut fst_out = F2::new();

--- a/rustfst/src/fst_impls/vector_fst/allocable_fst.rs
+++ b/rustfst/src/fst_impls/vector_fst/allocable_fst.rs
@@ -1,5 +1,5 @@
 use crate::{StateId};
-use crate::fst_impls::vector_fst::{VectorFst, VectorFstState};
+use crate::fst_impls::vector_fst::VectorFst;
 use crate::fst_traits::AllocableFst;
 use crate::semirings::Semiring;
 use failure::Fallible;
@@ -24,35 +24,59 @@ impl<W: 'static + Semiring> AllocableFst for VectorFst<W> {
             .reserve(additional)
     }
 
+    #[inline]
     fn reserve_states(&mut self, additional: usize) {
         self.states.reserve(additional);
     }
 
     fn shrink_to_fit(&mut self) {
-
+        self.states.shrink_to_fit();
+        for state in self.states.iter_mut() {
+            state.arcs.shrink_to_fit();
+        }
     }
 
+    #[inline]
     fn shrink_to_fit_states(&mut self) {
-
+        self.states.shrink_to_fit()
     }
 
     fn shrink_to_fit_arcs(&mut self, source: StateId) -> Fallible<()> {
+        self.states
+            .get_mut(source)
+            .ok_or_else(|| format_err!("State {:?} doesn't exist", source))?
+            .arcs
+            .shrink_to_fit();
         Ok(())
     }
 
+    #[inline]
     unsafe fn shrink_to_fit_arcs_unchecked(&mut self, source: StateId) {
-
+        self.states
+            .get_unchecked_mut(source)
+            .arcs
+            .shrink_to_fit()
     }
 
-
+    #[inline]
     fn states_capacity(&self) -> usize {
-        0
+        self.states.capacity()
     }
+
     fn arcs_capacity(&self, source: StateId) -> Fallible<usize> {
-        Ok(0)
+        Ok(self.states
+            .get(source)
+            .ok_or_else(|| format_err!("State {:?} doesn't exist", source))?
+            .arcs
+            .capacity())
     }
-    unsafe fn arcs_capacity_unchecked(&self) -> usize {
-        0
+
+    #[inline]
+    unsafe fn arcs_capacity_unchecked(&self, source: StateId) -> usize {
+        self.states
+            .get_unchecked(source)
+            .arcs
+            .capacity()
     }
 }
 

--- a/rustfst/src/fst_impls/vector_fst/allocable_fst.rs
+++ b/rustfst/src/fst_impls/vector_fst/allocable_fst.rs
@@ -1,12 +1,10 @@
-use crate::{StateId};
 use crate::fst_impls::vector_fst::VectorFst;
 use crate::fst_traits::AllocableFst;
 use crate::semirings::Semiring;
+use crate::StateId;
 use failure::Fallible;
 
-
 impl<W: 'static + Semiring> AllocableFst for VectorFst<W> {
-
     fn reserve_arcs(&mut self, source: usize, additional: usize) -> Fallible<()> {
         self.states
             .get_mut(source)
@@ -52,10 +50,7 @@ impl<W: 'static + Semiring> AllocableFst for VectorFst<W> {
 
     #[inline]
     unsafe fn shrink_to_fit_arcs_unchecked(&mut self, source: StateId) {
-        self.states
-            .get_unchecked_mut(source)
-            .arcs
-            .shrink_to_fit()
+        self.states.get_unchecked_mut(source).arcs.shrink_to_fit()
     }
 
     #[inline]
@@ -64,7 +59,8 @@ impl<W: 'static + Semiring> AllocableFst for VectorFst<W> {
     }
 
     fn arcs_capacity(&self, source: StateId) -> Fallible<usize> {
-        Ok(self.states
+        Ok(self
+            .states
             .get(source)
             .ok_or_else(|| format_err!("State {:?} doesn't exist", source))?
             .arcs
@@ -73,10 +69,6 @@ impl<W: 'static + Semiring> AllocableFst for VectorFst<W> {
 
     #[inline]
     unsafe fn arcs_capacity_unchecked(&self, source: StateId) -> usize {
-        self.states
-            .get_unchecked(source)
-            .arcs
-            .capacity()
+        self.states.get_unchecked(source).arcs.capacity()
     }
 }
-

--- a/rustfst/src/fst_impls/vector_fst/allocable_fst.rs
+++ b/rustfst/src/fst_impls/vector_fst/allocable_fst.rs
@@ -1,0 +1,58 @@
+use crate::{StateId};
+use crate::fst_impls::vector_fst::{VectorFst, VectorFstState};
+use crate::fst_traits::AllocableFst;
+use crate::semirings::Semiring;
+use failure::Fallible;
+
+
+impl<W: 'static + Semiring> AllocableFst for VectorFst<W> {
+
+    fn reserve_arcs(&mut self, source: usize, additional: usize) -> Fallible<()> {
+        self.states
+            .get_mut(source)
+            .ok_or_else(|| format_err!("State {:?} doesn't exist", source))?
+            .arcs
+            .reserve(additional);
+        Ok(())
+    }
+
+    #[inline]
+    unsafe fn reserve_arcs_unchecked(&mut self, source: usize, additional: usize) {
+        self.states
+            .get_unchecked_mut(source)
+            .arcs
+            .reserve(additional)
+    }
+
+    fn reserve_states(&mut self, additional: usize) {
+        self.states.reserve(additional);
+    }
+
+    fn shrink_to_fit(&mut self) {
+
+    }
+
+    fn shrink_to_fit_states(&mut self) {
+
+    }
+
+    fn shrink_to_fit_arcs(&mut self, source: StateId) -> Fallible<()> {
+        Ok(())
+    }
+
+    unsafe fn shrink_to_fit_arcs_unchecked(&mut self, source: StateId) {
+
+    }
+
+
+    fn states_capacity(&self) -> usize {
+        0
+    }
+    fn arcs_capacity(&self, source: StateId) -> Fallible<usize> {
+        Ok(0)
+    }
+    unsafe fn arcs_capacity_unchecked(&self) -> usize {
+        0
+    }
+}
+

--- a/rustfst/src/fst_impls/vector_fst/mod.rs
+++ b/rustfst/src/fst_impls/vector_fst/mod.rs
@@ -1,6 +1,7 @@
 pub use self::data_structure::VectorFst;
 pub(crate) use self::data_structure::VectorFstState;
 
+mod allocable_fst;
 mod data_structure;
 mod expanded_fst;
 mod fst;

--- a/rustfst/src/fst_impls/vector_fst/mutable_fst.rs
+++ b/rustfst/src/fst_impls/vector_fst/mutable_fst.rs
@@ -194,27 +194,6 @@ impl<W: 'static + Semiring> MutableFst for VectorFst<W> {
             .collect()
     }
 
-    fn reserve_arcs(&mut self, source: usize, additional: usize) -> Fallible<()> {
-        self.states
-            .get_mut(source)
-            .ok_or_else(|| format_err!("State {:?} doesn't exist", source))?
-            .arcs
-            .reserve(additional);
-        Ok(())
-    }
-
-    #[inline]
-    unsafe fn reserve_arcs_unchecked(&mut self, source: usize, additional: usize) {
-        self.states
-            .get_unchecked_mut(source)
-            .arcs
-            .reserve(additional)
-    }
-
-    fn reserve_states(&mut self, additional: usize) {
-        self.states.reserve(additional);
-    }
-
     fn final_weight_mut(&mut self, state_id: StateId) -> Fallible<Option<&mut W>> {
         let s = self
             .states

--- a/rustfst/src/fst_traits/allocable_fst.rs
+++ b/rustfst/src/fst_traits/allocable_fst.rs
@@ -1,0 +1,39 @@
+use failure::Fallible;
+use crate::StateId;
+
+/// Trait defining the methods to control allocation for a wFST
+pub trait AllocableFst {
+    /// Reserve capacity for at least additional more arcs leaving the state.
+    /// The FST may reserve more space to avoid frequent allocation. 
+    /// After calling `reserve_arcs`, the capacity will be greater or equal to `num_arcs` + `additionnal`
+    /// This method has no effects if the capacity is already sufficient
+    fn reserve_arcs(&mut self, source: StateId, additional: usize) -> Fallible<()>;
+    unsafe fn reserve_arcs_unchecked(&mut self, source: StateId, additional: usize);
+
+    /// Reserve capacity for at least additional states.
+    /// The FST may reserve more space to avoid frequent allocation. 
+    /// After calling `reserve_states`, the capacity will be greater or equal to `num_states` + `additionnal`
+    /// This method has no effects if the capacity is already sufficient
+    fn reserve_states(&mut self, additional: usize);
+
+
+    /// Shrinks the capacity of the states and their leaving arcs as much as possible.
+    /// It will drop down as close as possible to the number of states and leaving arcs.
+    fn shrink_to_fit(&mut self);
+
+    /// Shrinks the capacity of the states.
+    /// It will drop down as close as possible to the number of states.
+    fn shrink_to_fit_states(&mut self);
+
+    /// Shrinks the capacity of the leaving arcs for the given state as much as possible.
+    /// It will drop down as close as possible to theleaving arcs
+    fn shrink_to_fit_arcs(&mut self, source: StateId) -> Fallible<()>;
+    unsafe fn shrink_to_fit_arcs_unchecked(&mut self, source: StateId);
+
+
+    /// Returns the number of states the FST can hold without reallocating.
+    fn states_capacity(&self) -> usize;
+    /// Returns the number of arcs for a given state the FST can hold without reallocating.
+    fn arcs_capacity(&self, source: StateId) -> Fallible<usize>;
+    unsafe fn arcs_capacity_unchecked(&self) -> usize;
+}

--- a/rustfst/src/fst_traits/allocable_fst.rs
+++ b/rustfst/src/fst_traits/allocable_fst.rs
@@ -1,8 +1,9 @@
 use crate::StateId;
 use failure::Fallible;
+use crate::fst_traits::Fst;
 
 /// Trait defining the methods to control allocation for a wFST
-pub trait AllocableFst {
+pub trait AllocableFst: Fst {
     /// Reserve capacity for at least additional more arcs leaving the state.
     /// The FST may reserve more space to avoid frequent allocation.
     /// After calling `reserve_arcs`, the capacity will be greater or equal to `num_arcs` + `additionnal`

--- a/rustfst/src/fst_traits/allocable_fst.rs
+++ b/rustfst/src/fst_traits/allocable_fst.rs
@@ -35,5 +35,5 @@ pub trait AllocableFst {
     fn states_capacity(&self) -> usize;
     /// Returns the number of arcs for a given state the FST can hold without reallocating.
     fn arcs_capacity(&self, source: StateId) -> Fallible<usize>;
-    unsafe fn arcs_capacity_unchecked(&self) -> usize;
+    unsafe fn arcs_capacity_unchecked(&self, source: StateId) -> usize;
 }

--- a/rustfst/src/fst_traits/allocable_fst.rs
+++ b/rustfst/src/fst_traits/allocable_fst.rs
@@ -1,21 +1,20 @@
-use failure::Fallible;
 use crate::StateId;
+use failure::Fallible;
 
 /// Trait defining the methods to control allocation for a wFST
 pub trait AllocableFst {
     /// Reserve capacity for at least additional more arcs leaving the state.
-    /// The FST may reserve more space to avoid frequent allocation. 
+    /// The FST may reserve more space to avoid frequent allocation.
     /// After calling `reserve_arcs`, the capacity will be greater or equal to `num_arcs` + `additionnal`
     /// This method has no effects if the capacity is already sufficient
     fn reserve_arcs(&mut self, source: StateId, additional: usize) -> Fallible<()>;
     unsafe fn reserve_arcs_unchecked(&mut self, source: StateId, additional: usize);
 
     /// Reserve capacity for at least additional states.
-    /// The FST may reserve more space to avoid frequent allocation. 
+    /// The FST may reserve more space to avoid frequent allocation.
     /// After calling `reserve_states`, the capacity will be greater or equal to `num_states` + `additionnal`
     /// This method has no effects if the capacity is already sufficient
     fn reserve_states(&mut self, additional: usize);
-
 
     /// Shrinks the capacity of the states and their leaving arcs as much as possible.
     /// It will drop down as close as possible to the number of states and leaving arcs.
@@ -29,7 +28,6 @@ pub trait AllocableFst {
     /// It will drop down as close as possible to theleaving arcs
     fn shrink_to_fit_arcs(&mut self, source: StateId) -> Fallible<()>;
     unsafe fn shrink_to_fit_arcs_unchecked(&mut self, source: StateId);
-
 
     /// Returns the number of states the FST can hold without reallocating.
     fn states_capacity(&self) -> usize;

--- a/rustfst/src/fst_traits/mod.rs
+++ b/rustfst/src/fst_traits/mod.rs
@@ -9,6 +9,7 @@ mod iterators;
 mod mutable_fst;
 mod paths_iterator;
 mod text_parser;
+mod allocable_fst;
 
 pub use self::binary_deserializer::BinaryDeserializer;
 pub use self::binary_serializer::BinarySerializer;
@@ -19,3 +20,4 @@ pub use self::iterators::{ArcIterator, FstIterator, FstIteratorMut, StateIterato
 pub use self::mutable_fst::{MutableArcIterator, MutableFst};
 pub use self::paths_iterator::PathsIterator;
 pub use self::text_parser::TextParser;
+pub use self::allocable_fst::AllocableFst;

--- a/rustfst/src/fst_traits/mod.rs
+++ b/rustfst/src/fst_traits/mod.rs
@@ -1,5 +1,6 @@
 #[macro_use]
 mod macros;
+mod allocable_fst;
 mod binary_deserializer;
 mod binary_serializer;
 mod expanded_fst;
@@ -9,8 +10,8 @@ mod iterators;
 mod mutable_fst;
 mod paths_iterator;
 mod text_parser;
-mod allocable_fst;
 
+pub use self::allocable_fst::AllocableFst;
 pub use self::binary_deserializer::BinaryDeserializer;
 pub use self::binary_serializer::BinarySerializer;
 pub use self::expanded_fst::ExpandedFst;
@@ -20,4 +21,3 @@ pub use self::iterators::{ArcIterator, FstIterator, FstIteratorMut, StateIterato
 pub use self::mutable_fst::{MutableArcIterator, MutableFst};
 pub use self::paths_iterator::PathsIterator;
 pub use self::text_parser::TextParser;
-pub use self::allocable_fst::AllocableFst;

--- a/rustfst/src/fst_traits/mutable_fst.rs
+++ b/rustfst/src/fst_traits/mutable_fst.rs
@@ -207,7 +207,6 @@ pub trait MutableFst: Fst + for<'a> MutableArcIterator<'a> {
     fn pop_arcs(&mut self, source: StateId) -> Fallible<Vec<Arc<Self::W>>>;
     unsafe fn pop_arcs_unchecked(&mut self, source: StateId) -> Vec<Arc<Self::W>>;
 
-
     /// Retrieves a mutable reference to the final weight of a state (if the state is a final one).
     fn final_weight_mut(
         &mut self,

--- a/rustfst/src/fst_traits/mutable_fst.rs
+++ b/rustfst/src/fst_traits/mutable_fst.rs
@@ -207,12 +207,6 @@ pub trait MutableFst: Fst + for<'a> MutableArcIterator<'a> {
     fn pop_arcs(&mut self, source: StateId) -> Fallible<Vec<Arc<Self::W>>>;
     unsafe fn pop_arcs_unchecked(&mut self, source: StateId) -> Vec<Arc<Self::W>>;
 
-    /// Reserve space for storing enough arcs leaving a state.
-    fn reserve_arcs(&mut self, source: StateId, additional: usize) -> Fallible<()>;
-    unsafe fn reserve_arcs_unchecked(&mut self, source: StateId, additional: usize);
-
-    /// Reserve space for storing enough states.
-    fn reserve_states(&mut self, additional: usize);
 
     /// Retrieves a mutable reference to the final weight of a state (if the state is a final one).
     fn final_weight_mut(

--- a/rustfst/src/tests_openfst/algorithms/determinize.rs
+++ b/rustfst/src/tests_openfst/algorithms/determinize.rs
@@ -4,8 +4,7 @@ use serde_derive::{Deserialize, Serialize};
 
 use crate::algorithms::{determinize, isomorphic, DeterminizeType};
 use crate::fst_properties::FstProperties;
-use crate::fst_traits::MutableFst;
-use crate::fst_traits::TextParser;
+use crate::fst_traits::{ MutableFst, TextParser , AllocableFst};
 use crate::semirings::Semiring;
 use crate::semirings::WeaklyDivisibleSemiring;
 use crate::semirings::WeightQuantize;
@@ -50,7 +49,7 @@ impl DeterminizeOperationResult {
 
 pub fn test_determinize<F>(test_data: &FstTestData<F>) -> Fallible<()>
 where
-    F: TextParser + MutableFst,
+    F: TextParser + MutableFst + AllocableFst,
     F::W: Semiring<Type = f32> + WeaklyDivisibleSemiring + WeightQuantize + 'static,
 {
     for determinize_data in &test_data.determinize {

--- a/rustfst/src/tests_openfst/algorithms/minimize.rs
+++ b/rustfst/src/tests_openfst/algorithms/minimize.rs
@@ -2,7 +2,7 @@ use failure::{format_err, Fallible};
 use serde_derive::{Deserialize, Serialize};
 
 use crate::algorithms::minimize;
-use crate::fst_traits::MutableFst;
+use crate::fst_traits::{ MutableFst, AllocableFst };
 use crate::fst_traits::TextParser;
 use crate::semirings::Semiring;
 use crate::semirings::WeaklyDivisibleSemiring;
@@ -42,7 +42,7 @@ impl MinimizeOperationResult {
 
 pub fn test_minimize<F>(test_data: &FstTestData<F>) -> Fallible<()>
 where
-    F: TextParser + MutableFst,
+    F: TextParser + MutableFst + AllocableFst,
     F::W: Semiring<Type = f32> + WeaklyDivisibleSemiring + WeightQuantize + 'static,
 {
     for minimize_data in &test_data.minimize {

--- a/rustfst/src/tests_openfst/algorithms/reverse.rs
+++ b/rustfst/src/tests_openfst/algorithms/reverse.rs
@@ -5,8 +5,7 @@ use crate::algorithms::MapFinalAction;
 use crate::algorithms::WeightConverter;
 use crate::algorithms::{reverse, weight_convert};
 use crate::fst_impls::VectorFst;
-use crate::fst_traits::MutableFst;
-use crate::fst_traits::TextParser;
+use crate::fst_traits::{ MutableFst, TextParser, AllocableFst };
 use crate::semirings::Semiring;
 use crate::semirings::WeaklyDivisibleSemiring;
 use crate::Arc;
@@ -44,7 +43,7 @@ where
 
 pub fn test_reverse<F>(test_data: &FstTestData<F>) -> Fallible<()>
 where
-    F: TextParser + MutableFst,
+    F: TextParser + MutableFst + AllocableFst,
     F::W: 'static + Semiring<Type = f32> + WeaklyDivisibleSemiring,
 {
     let fst_reverse: VectorFst<_> = reverse(&test_data.raw).unwrap();


### PR DESCRIPTION
# Motivation

While running algorithms that modify an FST or build a new one, in many cases we know in advance how much we will allocate. For this purpose, we discuss with @Garvys about a dedicated trait for this end.

# Todo List
- [x] AllocableFst: `reserve`, `capacity`, `shrink_to_fit`
- [x] AllocableFst implementation for the VectorFst
- [x] Remove `reserve` API from the `MutableFst` trait
- [x] Propagate this changes in the algorithms crates
  - [x] Preallocation when converting Fst
  - [ ] Better allocation management over the all crate
- [x] Update the Changelog  