### PR TITLE
Factorize dynamic implementations of Replace, Determinize and FactorWeight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `set_input_symbols()` and `set_output_symbols()` to the `MutableFst` trait to attach a `SymbolTable` to an Fst.
 - Add `input_symbols()` and `output_symbols()` to the `Fst` trait to retrieve previously attached `SymbolTable`.
 - Add `replace` fst operations.
+- Change internal implementation of `Replace`, `Determinize` and `FactorWeight` to share more code by creating the trait `FstImpl` and the struct `StateTable`.
 
 ### Changed
 - Make `KDELTA` public outside of the crate

--- a/rustfst/src/algorithms/cache/fst_impl.rs
+++ b/rustfst/src/algorithms/cache/fst_impl.rs
@@ -3,10 +3,10 @@ use std::slice::Iter as IterSlice;
 
 use failure::Fallible;
 
-use crate::{Arc, StateId};
 use crate::algorithms::cache::CacheImpl;
 use crate::fst_traits::{ExpandedFst, MutableFst};
 use crate::semirings::Semiring;
+use crate::{Arc, StateId};
 
 pub trait FstImpl<W: Semiring + 'static> {
     fn cache_impl(&mut self) -> &mut CacheImpl<W>;
@@ -36,6 +36,15 @@ pub trait FstImpl<W: Semiring + 'static> {
             self.cache_impl().mark_expanded(state);
         }
         self.cache_impl().arcs_iter(state)
+    }
+
+    #[allow(unused)]
+    fn num_arcs(&mut self, state: StateId) -> Fallible<usize> {
+        if !self.cache_impl().expanded(state) {
+            self.expand(state)?;
+            self.cache_impl().mark_expanded(state);
+        }
+        self.cache_impl().num_arcs(state)
     }
 
     /// Turns the Dynamic FST into a static one.

--- a/rustfst/src/algorithms/cache/fst_impl.rs
+++ b/rustfst/src/algorithms/cache/fst_impl.rs
@@ -1,0 +1,76 @@
+use std::collections::{HashSet, VecDeque};
+use std::slice::Iter as IterSlice;
+
+use failure::Fallible;
+
+use crate::{Arc, StateId};
+use crate::algorithms::cache::CacheImpl;
+use crate::fst_traits::{ExpandedFst, MutableFst};
+use crate::semirings::Semiring;
+
+pub trait FstImpl<W: Semiring + 'static> {
+    fn cache_impl(&mut self) -> &mut CacheImpl<W>;
+    fn expand(&mut self, state: StateId) -> Fallible<()>;
+    fn compute_start(&mut self) -> Fallible<Option<StateId>>;
+    fn compute_final(&mut self, state: StateId) -> Fallible<Option<W>>;
+
+    fn start(&mut self) -> Fallible<Option<StateId>> {
+        if !self.cache_impl().has_start() {
+            let start = self.compute_start()?;
+            self.cache_impl().set_start(start);
+        }
+        Ok(self.cache_impl().start().unwrap())
+    }
+
+    fn final_weight(&mut self, state: StateId) -> Fallible<Option<&W>> {
+        if !self.cache_impl().has_final(state) {
+            let final_weight = self.compute_final(state)?;
+            self.cache_impl().set_final_weight(state, final_weight)?;
+        }
+        self.cache_impl().final_weight(state)
+    }
+
+    fn arcs_iter(&mut self, state: StateId) -> Fallible<IterSlice<Arc<W>>> {
+        if !self.cache_impl().expanded(state) {
+            self.expand(state)?;
+            self.cache_impl().mark_expanded(state);
+        }
+        self.cache_impl().arcs_iter(state)
+    }
+
+    /// Turns the Dynamic FST into a static one.
+    fn compute<F2: MutableFst<W = W> + ExpandedFst<W = W>>(&mut self) -> Fallible<F2> {
+        let start_state = self.start()?;
+        let mut fst_out = F2::new();
+        if start_state.is_none() {
+            return Ok(fst_out);
+        }
+        let start_state = start_state.unwrap();
+        for _ in 0..=start_state {
+            fst_out.add_state();
+        }
+        fst_out.set_start(start_state)?;
+        let mut queue = VecDeque::new();
+        let mut visited_states = HashSet::new();
+        visited_states.insert(start_state);
+        queue.push_back(start_state);
+        while !queue.is_empty() {
+            let s = queue.pop_front().unwrap();
+            for arc in self.arcs_iter(s)? {
+                if !visited_states.contains(&arc.nextstate) {
+                    queue.push_back(arc.nextstate);
+                    visited_states.insert(arc.nextstate);
+                }
+                let n = fst_out.num_states();
+                for _ in n..=arc.nextstate {
+                    fst_out.add_state();
+                }
+                fst_out.add_arc(s, arc.clone())?;
+            }
+            if let Some(f_w) = self.final_weight(s)? {
+                fst_out.set_final(s, f_w.clone())?;
+            }
+        }
+        Ok(fst_out)
+    }
+}

--- a/rustfst/src/algorithms/cache/mod.rs
+++ b/rustfst/src/algorithms/cache/mod.rs
@@ -5,3 +5,5 @@ mod vector_cache_state;
 pub use self::cache_impl::CacheImpl;
 pub use self::cache_state::CacheState;
 pub use self::vector_cache_state::VectorCacheState;
+
+pub mod fst_impl;

--- a/rustfst/src/algorithms/cache/mod.rs
+++ b/rustfst/src/algorithms/cache/mod.rs
@@ -5,6 +5,5 @@ pub use self::vector_cache_state::VectorCacheState;
 
 mod cache_impl;
 mod cache_state;
-mod vector_cache_state;
 mod fst_impl;
-
+mod vector_cache_state;

--- a/rustfst/src/algorithms/cache/mod.rs
+++ b/rustfst/src/algorithms/cache/mod.rs
@@ -1,9 +1,10 @@
+pub use self::cache_impl::CacheImpl;
+pub use self::cache_state::CacheState;
+pub use self::fst_impl::FstImpl;
+pub use self::vector_cache_state::VectorCacheState;
+
 mod cache_impl;
 mod cache_state;
 mod vector_cache_state;
+mod fst_impl;
 
-pub use self::cache_impl::CacheImpl;
-pub use self::cache_state::CacheState;
-pub use self::vector_cache_state::VectorCacheState;
-
-pub mod fst_impl;

--- a/rustfst/src/algorithms/cache/mod.rs
+++ b/rustfst/src/algorithms/cache/mod.rs
@@ -1,9 +1,11 @@
 pub use self::cache_impl::CacheImpl;
 pub use self::cache_state::CacheState;
 pub use self::fst_impl::FstImpl;
+pub use self::state_table::StateTable;
 pub use self::vector_cache_state::VectorCacheState;
 
 mod cache_impl;
 mod cache_state;
 mod fst_impl;
+mod state_table;
 mod vector_cache_state;

--- a/rustfst/src/algorithms/cache/state_table.rs
+++ b/rustfst/src/algorithms/cache/state_table.rs
@@ -21,6 +21,7 @@ impl<T: Hash + Eq + Clone> StateTable<T> {
         if !self.table.borrow().contains_right(tuple) {
             let n = self.table.borrow().len();
             self.table.borrow_mut().insert(n, tuple.clone());
+            return n;
         }
         *self.table.borrow().get_by_right(tuple).unwrap()
     }

--- a/rustfst/src/algorithms/cache/state_table.rs
+++ b/rustfst/src/algorithms/cache/state_table.rs
@@ -17,12 +17,21 @@ impl<T: Hash + Eq + Clone> StateTable<T> {
     }
 
     /// Looks up integer ID from entry. If it doesn't exist and insert
-    pub fn find_id(&self, tuple: &T) -> StateId {
+    pub fn find_id_from_ref(&self, tuple: &T) -> StateId {
         if !self.table.borrow().contains_right(tuple) {
             let n = self.table.borrow().len();
             self.table.borrow_mut().insert(n, tuple.clone());
         }
         *self.table.borrow().get_by_right(tuple).unwrap()
+    }
+
+    pub fn find_id(&self, tuple: T) -> StateId {
+        if !self.table.borrow().contains_right(&tuple) {
+            let n = self.table.borrow().len();
+            self.table.borrow_mut().insert(n, tuple);
+            return n;
+        }
+        *self.table.borrow().get_by_right(&tuple).unwrap()
     }
 
     /// Looks up tuple from integer ID.

--- a/rustfst/src/algorithms/cache/state_table.rs
+++ b/rustfst/src/algorithms/cache/state_table.rs
@@ -1,0 +1,33 @@
+use std::cell::{Ref, RefCell};
+use std::hash::Hash;
+
+use bimap::BiHashMap;
+
+use crate::StateId;
+
+pub struct StateTable<T: Hash + Eq + Clone> {
+    pub(crate) table: RefCell<BiHashMap<StateId, T>>,
+}
+
+impl<T: Hash + Eq + Clone> StateTable<T> {
+    pub fn new() -> Self {
+        Self {
+            table: RefCell::new(BiHashMap::new()),
+        }
+    }
+
+    /// Looks up integer ID from entry. If it doesn't exist and insert
+    pub fn find_id(&self, tuple: &T) -> StateId {
+        if !self.table.borrow().contains_right(tuple) {
+            let n = self.table.borrow().len();
+            self.table.borrow_mut().insert(n, tuple.clone());
+        }
+        *self.table.borrow().get_by_right(tuple).unwrap()
+    }
+
+    /// Looks up tuple from integer ID.
+    pub fn find_tuple(&self, tuple_id: StateId) -> Ref<T> {
+        let table = self.table.borrow();
+        Ref::map(table, |x| x.get_by_left(&tuple_id).unwrap())
+    }
+}

--- a/rustfst/src/algorithms/determinize.rs
+++ b/rustfst/src/algorithms/determinize.rs
@@ -1,24 +1,23 @@
 use std::collections::hash_map::Entry;
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::HashMap;
 use std::marker::PhantomData;
-use std::slice::Iter as IterSlice;
 
 use bimap::BiHashMap;
 use failure::Fallible;
 
-use crate::algorithms::cache::CacheImpl;
+use crate::{EPS_LABEL, KDELTA, Label, StateId};
+use crate::algorithms::{factor_weight, FactorWeightOptions, FactorWeightType, weight_convert};
+use crate::algorithms::cache::{CacheImpl, FstImpl};
 use crate::algorithms::factor_iterators::{GallicFactor, GallicFactorMin, GallicFactorRestrict};
 use crate::algorithms::weight_converters::{FromGallicConverter, ToGallicConverter};
-use crate::algorithms::{factor_weight, weight_convert, FactorWeightOptions, FactorWeightType};
 use crate::arc::Arc;
 use crate::fst_impls::VectorFst;
-use crate::fst_traits::{AllocableFst, ExpandedFst, Fst, MutableFst};
+use crate::fst_traits::{AllocableFst, CoreFst, ExpandedFst, Fst, MutableFst};
 use crate::semirings::{
     DivideType, GallicWeight, GallicWeightLeft, GallicWeightMin, GallicWeightRestrict, Semiring,
     SemiringProperties, StringWeightLeft, StringWeightRestrict, WeaklyDivisibleSemiring,
     WeightQuantize,
 };
-use crate::{Label, StateId, EPS_LABEL, KDELTA};
 
 /// Determinization type.
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
@@ -175,80 +174,15 @@ where
     out_dist: Vec<F::W>,
 }
 
-impl<'a, 'b, F: Fst, CD: CommonDivisor<F::W>> DeterminizeFsaImpl<'a, 'b, F, CD>
-where
-    F::W: WeaklyDivisibleSemiring + WeightQuantize,
+impl<'a, 'b, F: Fst, CD: CommonDivisor<F::W>> FstImpl<F::W> for DeterminizeFsaImpl<'a, 'b, F, CD>
+    where
+        F::W: WeaklyDivisibleSemiring + WeightQuantize + 'static,
 {
-    pub fn new(fst: &'a F, in_dist: Option<&'b [F::W]>) -> Fallible<Self> {
-        if !fst.is_acceptor() {
-            bail!("DeterminizeFsaImpl : expected acceptor as argument");
-        }
-        Ok(Self {
-            fst,
-            cache_impl: CacheImpl::new(),
-            state_table: BiHashMap::new(),
-            ghost: PhantomData,
-            in_dist,
-            out_dist: vec![],
-        })
+    fn cache_impl(&mut self) -> &mut CacheImpl<<F as CoreFst>::W> {
+        &mut self.cache_impl
     }
 
-    pub fn arcs_iter(&mut self, state: StateId) -> Fallible<IterSlice<Arc<F::W>>> {
-        if !self.cache_impl.expanded(state) {
-            self.expand(state)?;
-        }
-        self.cache_impl.arcs_iter(state)
-    }
-
-    pub fn start(&mut self) -> Fallible<Option<StateId>> {
-        if !self.cache_impl.has_start() {
-            let start = self.compute_start()?;
-            self.cache_impl.set_start(start);
-        }
-        Ok(self.cache_impl.start().unwrap())
-    }
-
-    pub fn final_weight(&mut self, state: StateId) -> Fallible<Option<&F::W>> {
-        if !self.cache_impl.has_final(state) {
-            let final_weight = self.compute_final(state)?;
-            self.cache_impl.set_final_weight(state, final_weight)?;
-        }
-        self.cache_impl.final_weight(state)
-    }
-
-    fn compute_start(&mut self) -> Fallible<Option<StateId>> {
-        if let Some(start_state) = self.fst.start() {
-            let elt = DeterminizeElement::new(start_state, F::W::one());
-            let tuple = DeterminizeStateTuple {
-                subset: WeightedSubset::from_vec(vec![elt]),
-                filter_state: start_state,
-            };
-            return Ok(Some(self.find_state(&tuple)?));
-        }
-        Ok(None)
-    }
-
-    fn compute_final(&mut self, state: StateId) -> Fallible<Option<F::W>> {
-        let zero = F::W::zero();
-        let tuple = self.state_table.get_by_left(&state).unwrap();
-        let mut final_weight = F::W::zero();
-        for det_elt in tuple.subset.iter() {
-            final_weight.plus_assign(
-                det_elt.weight.times(
-                    self.fst
-                        .final_weight(det_elt.state)?
-                        .unwrap_or_else(|| &zero),
-                )?,
-            )?;
-        }
-        if final_weight.is_zero() {
-            Ok(None)
-        } else {
-            Ok(Some(final_weight))
-        }
-    }
-
-    fn expand(&mut self, state: StateId) -> Fallible<()> {
+    fn expand(&mut self, state: usize) -> Fallible<()> {
         // GetLabelMap
         let mut label_map: HashMap<Label, DeterminizeArc<F::W>> = HashMap::new();
         let src_tuple = self.state_table.get_by_left(&state).unwrap();
@@ -283,8 +217,60 @@ where
         for det_arc in label_map.values() {
             self.add_arc(state, det_arc)?;
         }
-        self.cache_impl.mark_expanded(state);
+
         Ok(())
+    }
+
+    fn compute_start(&mut self) -> Fallible<Option<usize>> {
+        if let Some(start_state) = self.fst.start() {
+            let elt = DeterminizeElement::new(start_state, F::W::one());
+            let tuple = DeterminizeStateTuple {
+                subset: WeightedSubset::from_vec(vec![elt]),
+                filter_state: start_state,
+            };
+            return Ok(Some(self.find_state(&tuple)?));
+        }
+        Ok(None)
+    }
+
+    fn compute_final(&mut self, state: usize) -> Fallible<Option<<F as CoreFst>::W>> {
+        let zero = F::W::zero();
+        let tuple = self.state_table.get_by_left(&state).unwrap();
+        let mut final_weight = F::W::zero();
+        for det_elt in tuple.subset.iter() {
+            final_weight.plus_assign(
+                det_elt.weight.times(
+                    self.fst
+                        .final_weight(det_elt.state)?
+                        .unwrap_or_else(|| &zero),
+                )?,
+            )?;
+        }
+        if final_weight.is_zero() {
+            Ok(None)
+        } else {
+            Ok(Some(final_weight))
+        }
+    }
+}
+
+
+impl<'a, 'b, F: Fst, CD: CommonDivisor<F::W>> DeterminizeFsaImpl<'a, 'b, F, CD>
+where
+    F::W: WeaklyDivisibleSemiring + WeightQuantize,
+{
+    pub fn new(fst: &'a F, in_dist: Option<&'b [F::W]>) -> Fallible<Self> {
+        if !fst.is_acceptor() {
+            bail!("DeterminizeFsaImpl : expected acceptor as argument");
+        }
+        Ok(Self {
+            fst,
+            cache_impl: CacheImpl::new(),
+            state_table: BiHashMap::new(),
+            ghost: PhantomData,
+            in_dist,
+            out_dist: vec![],
+        })
     }
 
     fn add_arc(&mut self, state: StateId, det_arc: &DeterminizeArc<F::W>) -> Fallible<()> {
@@ -358,44 +344,6 @@ where
             outd.plus_assign(element.weight.times(ind)?)?;
         }
         Ok(outd)
-    }
-
-    pub fn compute<F2: MutableFst<W = F::W> + ExpandedFst<W = F::W>>(&mut self) -> Fallible<F2>
-    where
-        F::W: 'static,
-    {
-        let start_state = self.start()?;
-        let mut fst_out = F2::new();
-        if start_state.is_none() {
-            return Ok(fst_out);
-        }
-        let start_state = start_state.unwrap();
-        for _ in 0..=start_state {
-            fst_out.add_state();
-        }
-        fst_out.set_start(start_state)?;
-        let mut queue = VecDeque::new();
-        let mut visited_states = HashSet::new();
-        visited_states.insert(start_state);
-        queue.push_back(start_state);
-        while !queue.is_empty() {
-            let s = queue.pop_front().unwrap();
-            for arc in self.arcs_iter(s)? {
-                if !visited_states.contains(&arc.nextstate) {
-                    queue.push_back(arc.nextstate);
-                    visited_states.insert(arc.nextstate);
-                }
-                let n = fst_out.num_states();
-                for _ in n..=arc.nextstate {
-                    fst_out.add_state();
-                }
-                fst_out.add_arc(s, arc.clone())?;
-            }
-            if let Some(f_w) = self.final_weight(s)? {
-                fst_out.set_final(s, f_w.clone())?;
-            }
-        }
-        Ok(fst_out)
     }
 
     pub fn compute_with_distance<F2: MutableFst<W = F::W> + ExpandedFst<W = F::W>>(

--- a/rustfst/src/algorithms/determinize.rs
+++ b/rustfst/src/algorithms/determinize.rs
@@ -318,7 +318,7 @@ where
     }
 
     fn find_state(&mut self, tuple: &DeterminizeStateTuple<F::W>) -> Fallible<StateId> {
-        let s = self.state_table.find_id(&tuple);
+        let s = self.state_table.find_id_from_ref(&tuple);
         if let Some(_in_dist) = self.in_dist.as_ref() {
             if self.out_dist.len() <= s {
                 self.out_dist.push(self.compute_distance(&tuple.subset)?);

--- a/rustfst/src/algorithms/determinize.rs
+++ b/rustfst/src/algorithms/determinize.rs
@@ -5,11 +5,10 @@ use std::marker::PhantomData;
 use bimap::BiHashMap;
 use failure::Fallible;
 
-use crate::{EPS_LABEL, KDELTA, Label, StateId};
-use crate::algorithms::{factor_weight, FactorWeightOptions, FactorWeightType, weight_convert};
 use crate::algorithms::cache::{CacheImpl, FstImpl};
 use crate::algorithms::factor_iterators::{GallicFactor, GallicFactorMin, GallicFactorRestrict};
 use crate::algorithms::weight_converters::{FromGallicConverter, ToGallicConverter};
+use crate::algorithms::{factor_weight, weight_convert, FactorWeightOptions, FactorWeightType};
 use crate::arc::Arc;
 use crate::fst_impls::VectorFst;
 use crate::fst_traits::{AllocableFst, CoreFst, ExpandedFst, Fst, MutableFst};
@@ -18,6 +17,7 @@ use crate::semirings::{
     SemiringProperties, StringWeightLeft, StringWeightRestrict, WeaklyDivisibleSemiring,
     WeightQuantize,
 };
+use crate::{Label, StateId, EPS_LABEL, KDELTA};
 
 /// Determinization type.
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
@@ -175,8 +175,8 @@ where
 }
 
 impl<'a, 'b, F: Fst, CD: CommonDivisor<F::W>> FstImpl<F::W> for DeterminizeFsaImpl<'a, 'b, F, CD>
-    where
-        F::W: WeaklyDivisibleSemiring + WeightQuantize + 'static,
+where
+    F::W: WeaklyDivisibleSemiring + WeightQuantize + 'static,
 {
     fn cache_impl(&mut self) -> &mut CacheImpl<<F as CoreFst>::W> {
         &mut self.cache_impl
@@ -253,7 +253,6 @@ impl<'a, 'b, F: Fst, CD: CommonDivisor<F::W>> FstImpl<F::W> for DeterminizeFsaIm
         }
     }
 }
-
 
 impl<'a, 'b, F: Fst, CD: CommonDivisor<F::W>> DeterminizeFsaImpl<'a, 'b, F, CD>
 where

--- a/rustfst/src/algorithms/factor_weight.rs
+++ b/rustfst/src/algorithms/factor_weight.rs
@@ -223,7 +223,7 @@ where
             }
             self.unfactored[&old_state]
         } else {
-            self.state_table.find_id(&elt)
+            self.state_table.find_id_from_ref(&elt)
         }
     }
 }

--- a/rustfst/src/algorithms/replace.rs
+++ b/rustfst/src/algorithms/replace.rs
@@ -6,13 +6,11 @@ use bimap::BiHashMap;
 use bitflags::_core::cell::{Ref, RefCell};
 use failure::{bail, Fallible};
 
-use crate::algorithms::cache::CacheImpl;
+use crate::algorithms::cache::{CacheImpl, FstImpl};
 use crate::algorithms::replace::ReplaceLabelType::{ReplaceLabelInput, ReplaceLabelNeither};
 use crate::fst_traits::{ExpandedFst, MutableFst, CoreFst};
 use crate::semirings::Semiring;
 use crate::{Arc, Label, StateId, EPS_LABEL};
-
-use crate::algorithms::cache::fst_impl::FstImpl;
 
 /// This specifies what labels to output on the call or return arc.
 #[derive(PartialOrd, PartialEq, Copy, Clone)]

--- a/rustfst/src/algorithms/replace.rs
+++ b/rustfst/src/algorithms/replace.rs
@@ -8,7 +8,7 @@ use failure::{bail, Fallible};
 
 use crate::algorithms::cache::{CacheImpl, FstImpl};
 use crate::algorithms::replace::ReplaceLabelType::{ReplaceLabelInput, ReplaceLabelNeither};
-use crate::fst_traits::{ExpandedFst, MutableFst, CoreFst};
+use crate::fst_traits::{CoreFst, ExpandedFst, MutableFst};
 use crate::semirings::Semiring;
 use crate::{Arc, Label, StateId, EPS_LABEL};
 
@@ -123,7 +123,8 @@ struct ReplaceFstImpl<F: ExpandedFst> {
 }
 
 impl<F: ExpandedFst> FstImpl<F::W> for ReplaceFstImpl<F>
-where F::W: 'static
+where
+    F::W: 'static,
 {
     fn cache_impl(&mut self) -> &mut CacheImpl<<F as CoreFst>::W> {
         &mut self.cache_impl
@@ -141,11 +142,11 @@ where F::W: 'static
                 .get(tuple.fst_id.unwrap())
                 .unwrap()
                 .arcs_iter(fst_state)?
-                {
-                    if let Some(new_arc) = self.compute_arc(&tuple, arc) {
-                        self.cache_impl.push_arc(state, new_arc)?;
-                    }
+            {
+                if let Some(new_arc) = self.compute_arc(&tuple, arc) {
+                    self.cache_impl.push_arc(state, new_arc)?;
                 }
+            }
         }
         Ok(())
     }

--- a/rustfst/src/algorithms/replace.rs
+++ b/rustfst/src/algorithms/replace.rs
@@ -1,18 +1,18 @@
 use std::collections::hash_map::Entry;
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap};
 use std::hash::Hash;
-use std::slice::Iter as IterSlice;
 
 use bimap::BiHashMap;
 use bitflags::_core::cell::{Ref, RefCell};
 use failure::{bail, Fallible};
-use nom::lib::std::collections::VecDeque;
 
 use crate::algorithms::cache::CacheImpl;
 use crate::algorithms::replace::ReplaceLabelType::{ReplaceLabelInput, ReplaceLabelNeither};
-use crate::fst_traits::{ExpandedFst, MutableFst};
+use crate::fst_traits::{ExpandedFst, MutableFst, CoreFst};
 use crate::semirings::Semiring;
 use crate::{Arc, Label, StateId, EPS_LABEL};
+
+use crate::algorithms::cache::fst_impl::FstImpl;
 
 /// This specifies what labels to output on the call or return arc.
 #[derive(PartialOrd, PartialEq, Copy, Clone)]
@@ -124,6 +124,69 @@ struct ReplaceFstImpl<F: ExpandedFst> {
     state_table: ReplaceStateTable,
 }
 
+impl<F: ExpandedFst> FstImpl<F::W> for ReplaceFstImpl<F>
+where F::W: 'static
+{
+    fn cache_impl(&mut self) -> &mut CacheImpl<<F as CoreFst>::W> {
+        &mut self.cache_impl
+    }
+
+    fn expand(&mut self, state: usize) -> Fallible<()> {
+        let tuple = self.state_table.tuple_table.find_tuple(state).clone();
+        if let Some(fst_state) = tuple.fst_state {
+            if let Some(arc) = self.compute_final_arc(state) {
+                self.cache_impl.push_arc(state, arc)?;
+            }
+
+            for arc in self
+                .fst_array
+                .get(tuple.fst_id.unwrap())
+                .unwrap()
+                .arcs_iter(fst_state)?
+                {
+                    if let Some(new_arc) = self.compute_arc(&tuple, arc) {
+                        self.cache_impl.push_arc(state, new_arc)?;
+                    }
+                }
+        }
+        Ok(())
+    }
+
+    fn compute_start(&mut self) -> Fallible<Option<usize>> {
+        if self.fst_array.is_empty() {
+            return Ok(None);
+        } else {
+            if let Some(fst_start) = self.fst_array[self.root].start() {
+                let prefix = self.get_prefix_id(&ReplaceStackPrefix::new());
+                let start = self
+                    .state_table
+                    .tuple_table
+                    .find_id(&ReplaceStateTuple::new(
+                        prefix,
+                        Some(self.root),
+                        Some(fst_start),
+                    ));
+                return Ok(Some(start));
+            } else {
+                return Ok(None);
+            }
+        }
+    }
+
+    fn compute_final(&mut self, state: usize) -> Fallible<Option<F::W>> {
+        let tuple = self.state_table.tuple_table.find_tuple(state);
+        if tuple.prefix_id == 0 {
+            self.fst_array
+                .get(tuple.fst_id.unwrap())
+                .unwrap()
+                .final_weight(tuple.fst_state.unwrap())
+                .map(|e| e.cloned())
+        } else {
+            Ok(None)
+        }
+    }
+}
+
 impl<F: ExpandedFst> ReplaceFstImpl<F> {
     fn new(fst_list: Vec<(Label, F)>, opts: ReplaceFstOptions) -> Fallible<Self> {
         let mut replace_fst_impl = Self {
@@ -168,86 +231,6 @@ impl<F: ExpandedFst> ReplaceFstImpl<F> {
         };
 
         Ok(replace_fst_impl)
-    }
-
-    fn arcs_iter(&mut self, state: StateId) -> Fallible<IterSlice<Arc<F::W>>> {
-        if !self.cache_impl.expanded(state) {
-            self.expand(state)?;
-        }
-        self.cache_impl.arcs_iter(state)
-    }
-
-    fn start(&mut self) -> Fallible<Option<StateId>> {
-        if !self.cache_impl.has_start() {
-            let start = self.compute_start()?;
-            self.cache_impl.set_start(start);
-        }
-        Ok(self.cache_impl.start().unwrap())
-    }
-
-    fn compute_start(&mut self) -> Fallible<Option<StateId>> {
-        if self.fst_array.is_empty() {
-            return Ok(None);
-        } else {
-            if let Some(fst_start) = self.fst_array[self.root].start() {
-                let prefix = self.get_prefix_id(&ReplaceStackPrefix::new());
-                let start = self
-                    .state_table
-                    .tuple_table
-                    .find_id(&ReplaceStateTuple::new(
-                        prefix,
-                        Some(self.root),
-                        Some(fst_start),
-                    ));
-                return Ok(Some(start));
-            } else {
-                return Ok(None);
-            }
-        }
-    }
-
-    fn final_weight(&mut self, state: StateId) -> Fallible<Option<&F::W>> {
-        if !self.cache_impl.has_final(state) {
-            let final_weight = self.compute_final(state)?;
-            self.cache_impl.set_final_weight(state, final_weight)?;
-        }
-        self.cache_impl.final_weight(state)
-    }
-
-    fn compute_final(&mut self, state: StateId) -> Fallible<Option<F::W>> {
-        let tuple = self.state_table.tuple_table.find_tuple(state);
-        if tuple.prefix_id == 0 {
-            self.fst_array
-                .get(tuple.fst_id.unwrap())
-                .unwrap()
-                .final_weight(tuple.fst_state.unwrap())
-                .map(|e| e.cloned())
-        } else {
-            Ok(None)
-        }
-    }
-
-    fn expand(&mut self, state: StateId) -> Fallible<()> {
-        let tuple = self.state_table.tuple_table.find_tuple(state).clone();
-        if let Some(fst_state) = tuple.fst_state {
-            if let Some(arc) = self.compute_final_arc(state) {
-                self.cache_impl.push_arc(state, arc)?;
-            }
-
-            for arc in self
-                .fst_array
-                .get(tuple.fst_id.unwrap())
-                .unwrap()
-                .arcs_iter(fst_state)?
-            {
-                if let Some(new_arc) = self.compute_arc(&tuple, arc) {
-                    self.cache_impl.push_arc(state, new_arc)?;
-                }
-            }
-        }
-
-        self.cache_impl.mark_expanded(state);
-        Ok(())
     }
 
     fn compute_final_arc(&mut self, state: StateId) -> Option<Arc<F::W>> {
@@ -393,44 +376,6 @@ impl<F: ExpandedFst> ReplaceFstImpl<F> {
                 ));
             }
         }
-    }
-
-    pub fn compute<F2: MutableFst<W = F::W> + ExpandedFst<W = F::W>>(&mut self) -> Fallible<F2>
-    where
-        F::W: 'static,
-    {
-        let start_state = self.start()?;
-        let mut fst_out = F2::new();
-        if start_state.is_none() {
-            return Ok(fst_out);
-        }
-        let start_state = start_state.unwrap();
-        for _ in 0..=start_state {
-            fst_out.add_state();
-        }
-        fst_out.set_start(start_state)?;
-        let mut queue = VecDeque::new();
-        let mut visited_states = HashSet::new();
-        visited_states.insert(start_state);
-        queue.push_back(start_state);
-        while !queue.is_empty() {
-            let s = queue.pop_front().unwrap();
-            for arc in self.arcs_iter(s)? {
-                if !visited_states.contains(&arc.nextstate) {
-                    queue.push_back(arc.nextstate);
-                    visited_states.insert(arc.nextstate);
-                }
-                let n = fst_out.num_states();
-                for _ in n..=arc.nextstate {
-                    fst_out.add_state();
-                }
-                fst_out.add_arc(s, arc.clone())?;
-            }
-            if let Some(f_w) = self.final_weight(s)? {
-                fst_out.set_final(s, f_w.clone())?;
-            }
-        }
-        Ok(fst_out)
     }
 }
 

--- a/rustfst/src/algorithms/replace.rs
+++ b/rustfst/src/algorithms/replace.rs
@@ -154,15 +154,12 @@ where
             return Ok(None);
         } else {
             if let Some(fst_start) = self.fst_array[self.root].start() {
-                let prefix = self.get_prefix_id(&ReplaceStackPrefix::new());
-                let start = self
-                    .state_table
-                    .tuple_table
-                    .find_id(&ReplaceStateTuple::new(
-                        prefix,
-                        Some(self.root),
-                        Some(fst_start),
-                    ));
+                let prefix = self.get_prefix_id(ReplaceStackPrefix::new());
+                let start = self.state_table.tuple_table.find_id(ReplaceStateTuple::new(
+                    prefix,
+                    Some(self.root),
+                    Some(fst_start),
+                ));
                 return Ok(Some(start));
             } else {
                 return Ok(None);
@@ -267,14 +264,11 @@ impl<F: ExpandedFst> ReplaceFstImpl<F> {
                 .clone();
             let top = stack.top();
             let prefix_id = self.pop_prefix(stack.clone());
-            let nextstate = self
-                .state_table
-                .tuple_table
-                .find_id(&ReplaceStateTuple::new(
-                    prefix_id,
-                    top.fst_id,
-                    top.nextstate,
-                ));
+            let nextstate = self.state_table.tuple_table.find_id(ReplaceStateTuple::new(
+                prefix_id,
+                top.fst_id,
+                top.nextstate,
+            ));
             if let Some(weight) = self
                 .fst_array
                 .get(tuple.fst_id.unwrap())
@@ -291,13 +285,13 @@ impl<F: ExpandedFst> ReplaceFstImpl<F> {
         }
     }
 
-    fn get_prefix_id(&self, prefix: &ReplaceStackPrefix) -> StateId {
+    fn get_prefix_id(&self, prefix: ReplaceStackPrefix) -> StateId {
         self.state_table.prefix_table.find_id(prefix)
     }
 
     fn pop_prefix(&self, mut prefix: ReplaceStackPrefix) -> StateId {
         prefix.pop();
-        self.get_prefix_id(&prefix)
+        self.get_prefix_id(prefix)
     }
 
     fn push_prefix(
@@ -307,7 +301,7 @@ impl<F: ExpandedFst> ReplaceFstImpl<F> {
         nextstate: Option<StateId>,
     ) -> StateId {
         prefix.push(fst_id, nextstate);
-        self.get_prefix_id(&prefix)
+        self.get_prefix_id(prefix)
     }
 
     fn compute_arc<W: Semiring>(&self, tuple: &ReplaceStateTuple, arc: &Arc<W>) -> Option<Arc<W>> {
@@ -317,7 +311,7 @@ impl<F: ExpandedFst> ReplaceFstImpl<F> {
         {
             let state_tuple =
                 ReplaceStateTuple::new(tuple.prefix_id, tuple.fst_id, Some(arc.nextstate));
-            let nextstate = self.state_table.tuple_table.find_id(&state_tuple);
+            let nextstate = self.state_table.tuple_table.find_id(state_tuple);
             return Some(Arc::new(
                 arc.ilabel,
                 arc.olabel,
@@ -334,14 +328,9 @@ impl<F: ExpandedFst> ReplaceFstImpl<F> {
                     .clone();
                 let nt_prefix = self.push_prefix(p, tuple.fst_id, Some(arc.nextstate));
                 if let Some(nt_start) = self.fst_array.get(*nonterminal).unwrap().start() {
-                    let nt_nextstate =
-                        self.state_table
-                            .tuple_table
-                            .find_id(&ReplaceStateTuple::new(
-                                nt_prefix,
-                                Some(*nonterminal),
-                                Some(nt_start),
-                            ));
+                    let nt_nextstate = self.state_table.tuple_table.find_id(
+                        ReplaceStateTuple::new(nt_prefix, Some(*nonterminal), Some(nt_start)),
+                    );
                     let ilabel = if epsilon_on_input(self.call_label_type_) {
                         0
                     } else {
@@ -357,14 +346,11 @@ impl<F: ExpandedFst> ReplaceFstImpl<F> {
                     return None;
                 }
             } else {
-                let nextstate = self
-                    .state_table
-                    .tuple_table
-                    .find_id(&ReplaceStateTuple::new(
-                        tuple.prefix_id,
-                        tuple.fst_id,
-                        Some(arc.nextstate),
-                    ));
+                let nextstate = self.state_table.tuple_table.find_id(ReplaceStateTuple::new(
+                    tuple.prefix_id,
+                    tuple.fst_id,
+                    Some(arc.nextstate),
+                ));
                 return Some(Arc::new(
                     arc.ilabel,
                     arc.olabel,

--- a/rustfst/src/algorithms/replace.rs
+++ b/rustfst/src/algorithms/replace.rs
@@ -2,11 +2,9 @@ use std::collections::hash_map::Entry;
 use std::collections::{BTreeSet, HashMap};
 use std::hash::Hash;
 
-use bimap::BiHashMap;
-use bitflags::_core::cell::{Ref, RefCell};
 use failure::{bail, Fallible};
 
-use crate::algorithms::cache::{CacheImpl, FstImpl};
+use crate::algorithms::cache::{CacheImpl, FstImpl, StateTable};
 use crate::algorithms::replace::ReplaceLabelType::{ReplaceLabelInput, ReplaceLabelNeither};
 use crate::fst_traits::{CoreFst, ExpandedFst, MutableFst};
 use crate::semirings::Semiring;
@@ -425,34 +423,6 @@ impl ReplaceStateTuple {
             fst_id,
             fst_state,
         }
-    }
-}
-
-// TODO: Move this struct into its own file + use it for all implementation starting with determinization
-struct StateTable<T: Hash + Eq + Clone> {
-    table: RefCell<BiHashMap<StateId, T>>,
-}
-
-impl<T: Hash + Eq + Clone> StateTable<T> {
-    fn new() -> Self {
-        Self {
-            table: RefCell::new(BiHashMap::new()),
-        }
-    }
-
-    /// Looks up integer ID from entry. If it doesn't exist and insert
-    fn find_id(&self, tuple: &T) -> StateId {
-        if !self.table.borrow().contains_right(tuple) {
-            let n = self.table.borrow().len();
-            self.table.borrow_mut().insert(n, tuple.clone());
-        }
-        *self.table.borrow().get_by_right(tuple).unwrap()
-    }
-
-    /// Looks up tuple from integer ID.
-    fn find_tuple(&self, tuple_id: StateId) -> Ref<T> {
-        let table = self.table.borrow();
-        Ref::map(table, |x| x.get_by_left(&tuple_id).unwrap())
     }
 }
 


### PR DESCRIPTION
- Change internal implementation of `Replace`, `Determinize` and `FactorWeight` to share more code by creating the trait `FstImpl` and the struct `StateTable`.
