### PR TITLE
Task/dynamic fst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `input_symbols()` and `output_symbols()` to the `Fst` trait to retrieve previously attached `SymbolTable`.
 - Add `replace` fst operations.
 - Change internal implementation of `Replace`, `Determinize` and `FactorWeight` to share more code by creating the trait `FstImpl` and the struct `StateTable`.
+- Implement/Derive `Clone`/`PartielEq`/`PartialOrd`/`Debug` for all iternal structures when possible.
 
 ### Changed
 - Make `KDELTA` public outside of the crate
 - Fix serialization into a DOT file by putting the `label` into quotes.
-- remove `reserve` API from `MutableFst`, see `AllocableFst` for this API 
+- Remove `reserve` API from `MutableFst`, see `AllocableFst` for this API 
+- Remove `Fst` trait bound on `Display`.
 
 ## [0.4.0] - 2019-11-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `input_symbols()` and `output_symbols()` to the `Fst` trait to retrieve previously attached `SymbolTable`.
 - Add `replace` fst operations.
 - Change internal implementation of `Replace`, `Determinize` and `FactorWeight` to share more code by creating the trait `FstImpl` and the struct `StateTable`.
-- Implement/Derive `Clone`/`PartielEq`/`PartialOrd`/`Debug` for all iternal structures when possible.
+- Implement/Derive `Clone`/`PartialEq`/`PartialOrd`/`Debug` for all internal structures when possible.
 
 ### Changed
 - Make `KDELTA` public outside of the crate

--- a/rustfst/src/algorithms/cache/cache_impl.rs
+++ b/rustfst/src/algorithms/cache/cache_impl.rs
@@ -7,6 +7,7 @@ use crate::semirings::Semiring;
 use crate::Arc;
 use crate::StateId;
 
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
 pub struct CacheImpl<W: Semiring> {
     has_start: bool,
     cache_start_state: Option<StateId>,

--- a/rustfst/src/algorithms/cache/cache_impl.rs
+++ b/rustfst/src/algorithms/cache/cache_impl.rs
@@ -23,6 +23,10 @@ impl<W: Semiring> CacheImpl<W> {
         }
     }
 
+    pub fn num_known_states(&self) -> usize {
+        self.vector_cache_states.len()
+    }
+
     pub fn set_start(&mut self, start_state: Option<StateId>) {
         self.cache_start_state = start_state;
         self.has_start = true;

--- a/rustfst/src/algorithms/cache/cache_state.rs
+++ b/rustfst/src/algorithms/cache/cache_state.rs
@@ -4,6 +4,7 @@ use std::slice::IterMut as IterSliceMut;
 use crate::semirings::Semiring;
 use crate::Arc;
 
+#[derive(Clone, Debug, PartialOrd, PartialEq)]
 pub struct CacheState<W: Semiring> {
     arcs: Vec<Arc<W>>,
     final_weight: Option<W>,

--- a/rustfst/src/algorithms/cache/state_table.rs
+++ b/rustfst/src/algorithms/cache/state_table.rs
@@ -1,12 +1,26 @@
 use std::cell::{Ref, RefCell};
+use std::fmt;
 use std::hash::Hash;
 
 use bimap::BiHashMap;
 
 use crate::StateId;
 
+#[derive(Clone)]
 pub struct StateTable<T: Hash + Eq + Clone> {
     pub(crate) table: RefCell<BiHashMap<StateId, T>>,
+}
+
+impl<T: Hash + Eq + Clone + fmt::Debug> fmt::Debug for StateTable<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "StateTable {{ table : {:?} }}", self.table.borrow())
+    }
+}
+
+impl<T: Hash + Eq + Clone + PartialEq> PartialEq for StateTable<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.table.borrow().eq(&*other.table.borrow())
+    }
 }
 
 impl<T: Hash + Eq + Clone> StateTable<T> {

--- a/rustfst/src/algorithms/cache/vector_cache_state.rs
+++ b/rustfst/src/algorithms/cache/vector_cache_state.rs
@@ -5,6 +5,7 @@ use crate::semirings::Semiring;
 use crate::Arc;
 use crate::StateId;
 
+#[derive(Clone, Debug, PartialOrd, PartialEq)]
 pub struct VectorCacheState<W: Semiring> {
     cache_states: Vec<CacheState<W>>,
 }

--- a/rustfst/src/algorithms/cache/vector_cache_state.rs
+++ b/rustfst/src/algorithms/cache/vector_cache_state.rs
@@ -17,6 +17,10 @@ impl<W: Semiring> VectorCacheState<W> {
         }
     }
 
+    pub fn len(&self) -> usize {
+        self.cache_states.len()
+    }
+
     pub fn resize(&mut self, new_len: usize) {
         self.cache_states.resize_with(new_len, CacheState::new);
     }

--- a/rustfst/src/algorithms/determinize.rs
+++ b/rustfst/src/algorithms/determinize.rs
@@ -177,8 +177,11 @@ impl<'a, 'b, F: Fst, CD: CommonDivisor<F::W>> FstImpl<F::W> for DeterminizeFsaIm
 where
     F::W: WeaklyDivisibleSemiring + WeightQuantize + 'static,
 {
-    fn cache_impl(&mut self) -> &mut CacheImpl<<F as CoreFst>::W> {
+    fn cache_impl_mut(&mut self) -> &mut CacheImpl<<F as CoreFst>::W> {
         &mut self.cache_impl
+    }
+    fn cache_impl_ref(&self) -> &CacheImpl<<F as CoreFst>::W> {
+        &self.cache_impl
     }
 
     fn expand(&mut self, state: usize) -> Fallible<()> {

--- a/rustfst/src/algorithms/factor_weight.rs
+++ b/rustfst/src/algorithms/factor_weight.rs
@@ -92,8 +92,11 @@ impl<'a, F: Fst, FI: FactorIterator<F::W>> FstImpl<F::W> for FactorWeightImpl<'a
 where
     F::W: WeightQuantize + 'static,
 {
-    fn cache_impl(&mut self) -> &mut CacheImpl<<F as CoreFst>::W> {
+    fn cache_impl_mut(&mut self) -> &mut CacheImpl<<F as CoreFst>::W> {
         &mut self.cache_impl
+    }
+    fn cache_impl_ref(&self) -> &CacheImpl<<F as CoreFst>::W> {
+        &self.cache_impl
     }
 
     fn expand(&mut self, state: usize) -> Fallible<()> {

--- a/rustfst/src/algorithms/replace.rs
+++ b/rustfst/src/algorithms/replace.rs
@@ -124,8 +124,12 @@ impl<F: ExpandedFst> FstImpl<F::W> for ReplaceFstImpl<F>
 where
     F::W: 'static,
 {
-    fn cache_impl(&mut self) -> &mut CacheImpl<<F as CoreFst>::W> {
+    fn cache_impl_mut(&mut self) -> &mut CacheImpl<<F as CoreFst>::W> {
         &mut self.cache_impl
+    }
+
+    fn cache_impl_ref(&self) -> &CacheImpl<<F as CoreFst>::W> {
+        &self.cache_impl
     }
 
     fn expand(&mut self, state: usize) -> Fallible<()> {

--- a/rustfst/src/arc.rs
+++ b/rustfst/src/arc.rs
@@ -2,7 +2,7 @@ use crate::semirings::Semiring;
 use crate::{Label, StateId};
 
 /// Structure representing a transition from a state to another state in a FST.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, PartialOrd)]
 pub struct Arc<W: Semiring> {
     /// Input label.
     pub ilabel: Label,

--- a/rustfst/src/fst_traits/fst.rs
+++ b/rustfst/src/fst_traits/fst.rs
@@ -1,4 +1,4 @@
-use std::fmt::{Debug, Display};
+use std::fmt::Debug;
 use std::rc::Rc;
 
 use failure::Fallible;

--- a/rustfst/src/fst_traits/fst.rs
+++ b/rustfst/src/fst_traits/fst.rs
@@ -112,7 +112,7 @@ pub trait CoreFst {
 
 /// Trait defining the minimum interface necessary for a wFST.
 pub trait Fst:
-    CoreFst + PartialEq + Clone + for<'a> ArcIterator<'a> + for<'b> StateIterator<'b> + Display + Debug
+    CoreFst + PartialEq + Clone + for<'a> ArcIterator<'a> + for<'b> StateIterator<'b> + Debug
 {
     // TODO: Move niepsilons and noepsilons to required methods.
     /// Returns the number of arcs with epsilon input labels leaving a state.

--- a/rustfst/src/tests_openfst/algorithms/arc_map.rs
+++ b/rustfst/src/tests_openfst/algorithms/arc_map.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use failure::Fallible;
 use pretty_assertions::assert_eq;
 
@@ -14,7 +16,7 @@ use crate::tests_openfst::FstTestData;
 
 pub fn test_arc_map_identity<F>(test_data: &FstTestData<F>) -> Fallible<()>
 where
-    F: TextParser + MutableFst,
+    F: TextParser + MutableFst + Display,
     F::W: Semiring<Type = f32> + WeightQuantize,
 {
     // ArcMap IdentityMapper
@@ -36,7 +38,7 @@ where
 
 pub fn test_arc_map_invert<F>(test_data: &FstTestData<F>) -> Fallible<()>
 where
-    F: TextParser + MutableFst,
+    F: TextParser + MutableFst + Display,
     F::W: Semiring<Type = f32> + WeightQuantize + WeaklyDivisibleSemiring,
 {
     // ArcMap InvertWeightMapper
@@ -58,7 +60,7 @@ where
 
 pub fn test_arc_map_input_epsilon<F>(test_data: &FstTestData<F>) -> Fallible<()>
 where
-    F: TextParser + MutableFst,
+    F: TextParser + MutableFst + Display,
     F::W: Semiring<Type = f32> + WeightQuantize,
 {
     let mut fst_arc_map = test_data.raw.clone();
@@ -79,7 +81,7 @@ where
 
 pub fn test_arc_map_output_epsilon<F>(test_data: &FstTestData<F>) -> Fallible<()>
 where
-    F: TextParser + MutableFst,
+    F: TextParser + MutableFst + Display,
     F::W: Semiring<Type = f32> + WeightQuantize,
 {
     let mut fst_arc_map = test_data.raw.clone();
@@ -100,7 +102,7 @@ where
 
 pub fn test_arc_map_plus<F>(test_data: &FstTestData<F>) -> Fallible<()>
 where
-    F: TextParser + MutableFst,
+    F: TextParser + MutableFst + Display,
     F::W: Semiring<Type = f32> + WeightQuantize,
 {
     let mut fst_arc_map = test_data.raw.clone();
@@ -121,7 +123,7 @@ where
 
 pub fn test_arc_map_times<F>(test_data: &FstTestData<F>) -> Fallible<()>
 where
-    F: TextParser + MutableFst,
+    F: TextParser + MutableFst + Display,
     F::W: Semiring<Type = f32> + WeightQuantize,
 {
     let mut fst_arc_map = test_data.raw.clone();
@@ -142,7 +144,7 @@ where
 
 pub fn test_arc_map_quantize<F>(test_data: &FstTestData<F>) -> Fallible<()>
 where
-    F: TextParser + MutableFst,
+    F: TextParser + MutableFst + Display,
     F::W: Semiring<Type = f32> + WeightQuantize,
 {
     let mut fst_arc_map = test_data.raw.clone();
@@ -163,7 +165,7 @@ where
 
 pub fn test_arc_map_rmweight<F>(test_data: &FstTestData<F>) -> Fallible<()>
 where
-    F: TextParser + MutableFst,
+    F: TextParser + MutableFst + Display,
     F::W: Semiring<Type = f32> + WeightQuantize,
 {
     // ArcMap RmWeightMapper

--- a/rustfst/src/tests_openfst/algorithms/arcsort.rs
+++ b/rustfst/src/tests_openfst/algorithms/arcsort.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use failure::Fallible;
 
 use crate::algorithms::arc_compares::{ilabel_compare, olabel_compare};
@@ -11,7 +13,7 @@ use crate::tests_openfst::FstTestData;
 
 pub fn test_arcsort_ilabel<F>(test_data: &FstTestData<F>) -> Fallible<()>
 where
-    F: TextParser + MutableFst,
+    F: TextParser + MutableFst + Display,
     F::W: Semiring<Type = f32> + WeightQuantize,
 {
     let mut fst_arcsort = test_data.raw.clone();
@@ -34,7 +36,7 @@ where
 
 pub fn test_arcsort_olabel<F>(test_data: &FstTestData<F>) -> Fallible<()>
 where
-    F: TextParser + MutableFst,
+    F: TextParser + MutableFst + Display,
     F::W: Semiring<Type = f32> + WeightQuantize,
 {
     let mut fst_arcsort = test_data.raw.clone();

--- a/rustfst/src/tests_openfst/algorithms/connect.rs
+++ b/rustfst/src/tests_openfst/algorithms/connect.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use failure::Fallible;
 
 use crate::algorithms::connect;
@@ -10,7 +12,7 @@ use crate::tests_openfst::FstTestData;
 
 pub fn test_connect<F>(test_data: &FstTestData<F>) -> Fallible<()>
 where
-    F: TextParser + MutableFst,
+    F: TextParser + MutableFst + Display,
     F::W: Semiring<Type = f32>,
 {
     // Connect

--- a/rustfst/src/tests_openfst/algorithms/determinize.rs
+++ b/rustfst/src/tests_openfst/algorithms/determinize.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use failure::{format_err, Fallible};
 
 use serde_derive::{Deserialize, Serialize};
@@ -49,7 +51,7 @@ impl DeterminizeOperationResult {
 
 pub fn test_determinize<F>(test_data: &FstTestData<F>) -> Fallible<()>
 where
-    F: TextParser + MutableFst + AllocableFst,
+    F: TextParser + MutableFst + AllocableFst + Display,
     F::W: Semiring<Type = f32> + WeaklyDivisibleSemiring + WeightQuantize + 'static,
 {
     for determinize_data in &test_data.determinize {

--- a/rustfst/src/tests_openfst/algorithms/encode.rs
+++ b/rustfst/src/tests_openfst/algorithms/encode.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use failure::{format_err, Fallible, ResultExt};
 
 use serde_derive::{Deserialize, Serialize};
@@ -43,7 +45,7 @@ impl EncodeOperationResult {
 
 pub fn test_encode_decode<F>(test_data: &FstTestData<F>) -> Fallible<()>
 where
-    F: TextParser + MutableFst,
+    F: TextParser + MutableFst + Display,
     F::W: Semiring<Type = f32>,
 {
     for encode_test_data in &test_data.encode_decode {
@@ -72,7 +74,7 @@ where
 
 pub fn test_encode<F>(test_data: &FstTestData<F>) -> Fallible<()>
 where
-    F: TextParser + MutableFst,
+    F: TextParser + MutableFst + Display,
     F::W: Semiring<Type = f32>,
 {
     for encode_test_data in &test_data.encode {

--- a/rustfst/src/tests_openfst/algorithms/inverse.rs
+++ b/rustfst/src/tests_openfst/algorithms/inverse.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use failure::Fallible;
 
 use crate::algorithms::invert;
@@ -10,7 +12,7 @@ use crate::tests_openfst::FstTestData;
 
 pub fn test_invert<F>(test_data: &FstTestData<F>) -> Fallible<()>
 where
-    F: TextParser + MutableFst,
+    F: TextParser + MutableFst + Display,
     F::W: Semiring<Type = f32> + WeaklyDivisibleSemiring,
 {
     // Invert

--- a/rustfst/src/tests_openfst/algorithms/minimize.rs
+++ b/rustfst/src/tests_openfst/algorithms/minimize.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use failure::{format_err, Fallible};
 use serde_derive::{Deserialize, Serialize};
 
@@ -42,7 +44,7 @@ impl MinimizeOperationResult {
 
 pub fn test_minimize<F>(test_data: &FstTestData<F>) -> Fallible<()>
 where
-    F: TextParser + MutableFst + AllocableFst,
+    F: TextParser + MutableFst + AllocableFst + Display,
     F::W: Semiring<Type = f32> + WeaklyDivisibleSemiring + WeightQuantize + 'static,
 {
     for minimize_data in &test_data.minimize {

--- a/rustfst/src/tests_openfst/algorithms/project.rs
+++ b/rustfst/src/tests_openfst/algorithms/project.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use failure::Fallible;
 
 use crate::algorithms::{project, ProjectType};
@@ -10,7 +12,7 @@ use crate::tests_openfst::FstTestData;
 
 pub fn test_project_output<F>(test_data: &FstTestData<F>) -> Fallible<()>
 where
-    F: TextParser + MutableFst,
+    F: TextParser + MutableFst + Display,
     F::W: Semiring<Type = f32> + WeaklyDivisibleSemiring,
 {
     // Project output
@@ -31,7 +33,7 @@ where
 
 pub fn test_project_input<F>(test_data: &FstTestData<F>) -> Fallible<()>
 where
-    F: TextParser + MutableFst,
+    F: TextParser + MutableFst + Display,
     F::W: Semiring<Type = f32> + WeaklyDivisibleSemiring,
 {
     // Project input

--- a/rustfst/src/tests_openfst/algorithms/reverse.rs
+++ b/rustfst/src/tests_openfst/algorithms/reverse.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use failure::Fallible;
 
 use crate::algorithms::FinalArc;
@@ -43,7 +45,7 @@ where
 
 pub fn test_reverse<F>(test_data: &FstTestData<F>) -> Fallible<()>
 where
-    F: TextParser + MutableFst + AllocableFst,
+    F: TextParser + MutableFst + AllocableFst + Display,
     F::W: 'static + Semiring<Type = f32> + WeaklyDivisibleSemiring,
 {
     let fst_reverse: VectorFst<_> = reverse(&test_data.raw).unwrap();

--- a/rustfst/src/tests_openfst/algorithms/rm_epsilon.rs
+++ b/rustfst/src/tests_openfst/algorithms/rm_epsilon.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use failure::Fallible;
 
 use crate::algorithms::{isomorphic, rm_epsilon};
@@ -13,7 +15,7 @@ use crate::tests_openfst::FstTestData;
 
 pub fn test_rmepsilon<F>(test_data: &FstTestData<F>) -> Fallible<()>
 where
-    F: TextParser + MutableFst + ExpandedFst,
+    F: TextParser + MutableFst + ExpandedFst + Display,
     F::W: 'static + Semiring<Type = f32> + WeaklyDivisibleSemiring + StarSemiring,
 {
     // Remove epsilon

--- a/rustfst/src/tests_openfst/algorithms/shortest_path.rs
+++ b/rustfst/src/tests_openfst/algorithms/shortest_path.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use failure::{format_err, Fallible};
 use serde_derive::{Deserialize, Serialize};
 
@@ -46,7 +48,7 @@ impl ShorestPathOperationResult {
 
 pub fn test_shortest_path<F>(test_data: &FstTestData<F>) -> Fallible<()>
 where
-    F: TextParser + MutableFst,
+    F: TextParser + MutableFst + Display,
     F::W: Semiring<Type = f32> + WeaklyDivisibleSemiring + WeightQuantize + 'static,
     <<F as CoreFst>::W as Semiring>::ReverseWeight: WeaklyDivisibleSemiring + WeightQuantize,
     F::W: Into<<<F as CoreFst>::W as Semiring>::ReverseWeight>

--- a/rustfst/src/tests_openfst/algorithms/state_map.rs
+++ b/rustfst/src/tests_openfst/algorithms/state_map.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use failure::Fallible;
 
 use crate::algorithms::arc_sum;
@@ -10,7 +12,7 @@ use crate::tests_openfst::FstTestData;
 
 pub fn test_state_map_arc_sum<F>(test_data: &FstTestData<F>) -> Fallible<()>
 where
-    F: TextParser + MutableFst,
+    F: TextParser + MutableFst + Display,
     F::W: Semiring<Type = f32>,
 {
     let mut fst_state_map = test_data.raw.clone();
@@ -32,7 +34,7 @@ where
 
 pub fn test_state_map_arc_unique<F>(test_data: &FstTestData<F>) -> Fallible<()>
 where
-    F: TextParser + MutableFst,
+    F: TextParser + MutableFst + Display,
     F::W: Semiring<Type = f32>,
 {
     let mut fst_state_map = test_data.raw.clone();

--- a/rustfst/src/tests_openfst/algorithms/topsort.rs
+++ b/rustfst/src/tests_openfst/algorithms/topsort.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use failure::Fallible;
 
 use crate::algorithms::top_sort;
@@ -10,7 +12,7 @@ use crate::tests_openfst::FstTestData;
 
 pub fn test_topsort<F>(test_data: &FstTestData<F>) -> Fallible<()>
 where
-    F: TextParser + MutableFst,
+    F: TextParser + MutableFst + Display,
     F::W: Semiring<Type = f32>,
 {
     let mut fst_topsort = test_data.raw.clone();

--- a/rustfst/src/tests_openfst/algorithms/weight_pushing.rs
+++ b/rustfst/src/tests_openfst/algorithms/weight_pushing.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use failure::Fallible;
 
 use crate::algorithms::{push_weights, ReweightType};
@@ -5,12 +7,11 @@ use crate::fst_traits::TextParser;
 use crate::fst_traits::{CoreFst, MutableFst};
 use crate::semirings::Semiring;
 use crate::semirings::WeaklyDivisibleSemiring;
-
 use crate::tests_openfst::FstTestData;
 
 pub fn test_weight_pushing_initial<F>(test_data: &FstTestData<F>) -> Fallible<()>
 where
-    F: TextParser + MutableFst,
+    F: TextParser + MutableFst + Display,
     F::W: Semiring<Type = f32> + WeaklyDivisibleSemiring,
     <<F as CoreFst>::W as Semiring>::ReverseWeight: 'static,
 {
@@ -36,7 +37,7 @@ where
 
 pub fn test_weight_pushing_final<F>(test_data: &FstTestData<F>) -> Fallible<()>
 where
-    F: TextParser + MutableFst,
+    F: TextParser + MutableFst + Display,
     F::W: Semiring<Type = f32> + WeaklyDivisibleSemiring,
     <<F as CoreFst>::W as Semiring>::ReverseWeight: 'static,
 {


### PR DESCRIPTION
This PR is the first step toward supporting Dynamic FSTs.
- Remove `Fst` trait bound on `Display`.
- Implement/Derive `Clone`/`PartialEq`/`PartialOrd`/`Debug` for all internal structures when possible.
