### PR TITLE
Serde binary format SymbolTable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix: when serializing an `Fst`, now uses the result of the `arc_type()` method instead of using an hardcoded value.
 - `Display` is no longer a trait bound of `Semiring`. However, it is required to implement `SerializableSemiring`.
 - Use `BufWriter` when serializing a `SymbolTable` object increasing the serialization speed.
-- Fix bug when the parsing of fst in binary format crashed because a symbol tables was attached to the fst. The symbol table are now retrieved directly from the fst file.
+- Fix bug when the parsing of fst in binary format crashed because a symbol table was attached to the fst. The symbol tables are now retrieved directly from the fst file.
 
 ## [0.4.0] - 2019-11-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `SerializableSemiring` trait and implement it for most `Semiring`s.
 - All `Fst` that implements `SerializableFst` with a `Semiring` implementing `SerializableSemiring` can now be serialized/deserialized consistently with OpenFst.
 - Added `arc_type()` method to `rustfst::Arc`.
+- Added `write` and `read` method to the `SymbolTable` API to serialize and deserialize SymbolTable in binary format consistently with OpenFst.
+- Added `unset_input_symbols` and `unset_output_symbols` methods to remove the symbol tables attached to a mutable fst.
 
 ### Changed
 - Make `KDELTA` public outside of the crate
@@ -42,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix: when serializing an `Fst`, now uses the result of the `arc_type()` method instead of using an hardcoded value.
 - `Display` is no longer a trait bound of `Semiring`. However, it is required to implement `SerializableSemiring`.
 - Use `BufWriter` when serializing a `SymbolTable` object increasing the serialization speed.
+- Fix bug when the parsing of fst in binary format crashed because a symbol tables was attached to the fst. The symbol table are now retrieved directly from the fst file.
 
 ## [0.4.0] - 2019-11-12
 

--- a/rustfst-tests-data/main.cpp
+++ b/rustfst-tests-data/main.cpp
@@ -717,6 +717,25 @@ void compute_fst_data(const F& fst_test_data, const string fst_name) {
     data["raw_vector_bin_path"] = "raw_vector.fst";
     raw_fst.Write(fst_name + "/raw_vector.fst");
 
+    fst::SymbolTable isymt;
+    isymt.AddSymbol("<eps>");
+    isymt.AddSymbol("lol");
+    isymt.AddSymbol("pouet");
+
+    fst::SymbolTable osymt;
+    osymt.AddSymbol("<epsilon>");
+    osymt.AddSymbol("carotte");
+    osymt.AddSymbol("world");
+    osymt.AddSymbol("hello");
+
+    fst::VectorFst<typename F::MyArc> fst_with_symt(raw_fst);
+
+    fst_with_symt.SetInputSymbols(&isymt);
+    fst_with_symt.SetOutputSymbols(&osymt);
+
+    data["raw_vector_with_symt_bin_path"] = "raw_vector_with_symt.fst";
+    fst_with_symt.Write(fst_name + "/raw_vector_with_symt.fst");
+
     fst::FstWriteOptions write_opts("<unspecified>");
     fst::ConstFst<typename F::MyArc> raw_const_fst(raw_fst);
     // Not aligned

--- a/rustfst-tests-data/main.cpp
+++ b/rustfst-tests-data/main.cpp
@@ -719,12 +719,12 @@ void compute_fst_data(const F& fst_test_data, const string fst_name) {
 
     fst::SymbolTable isymt;
     isymt.AddSymbol("<eps>");
-    isymt.AddSymbol("lol");
-    isymt.AddSymbol("pouet");
+    isymt.AddSymbol("good");
+    isymt.AddSymbol("day");
 
     fst::SymbolTable osymt;
     osymt.AddSymbol("<epsilon>");
-    osymt.AddSymbol("carotte");
+    osymt.AddSymbol("knock");
     osymt.AddSymbol("world");
     osymt.AddSymbol("hello");
 

--- a/rustfst/src/fst_impls/const_fst/serializable_fst.rs
+++ b/rustfst/src/fst_impls/const_fst/serializable_fst.rs
@@ -12,7 +12,7 @@ use nom::IResult;
 
 use crate::fst_impls::const_fst::data_structure::ConstState;
 use crate::fst_impls::ConstFst;
-use crate::fst_traits::{ExpandedFst, SerializableFst};
+use crate::fst_traits::{ExpandedFst, Fst, SerializableFst};
 use crate::parsers::bin_fst::fst_header::{FstFlags, FstHeader, OpenFstString, FST_MAGIC_NUMBER};
 use crate::parsers::bin_fst::utils_parsing::{
     parse_final_weight, parse_fst_arc, parse_start_state,
@@ -56,6 +56,8 @@ impl<W: 'static + SerializableSemiring> SerializableFst for ConstFst<W> {
             start: self.start.map(|v| v as i64).unwrap_or(-1),
             num_states: self.num_states() as i64,
             num_arcs: self.arcs.len() as i64,
+            isymt: self.input_symbols(),
+            osymt: self.output_symbols(),
         };
         hdr.write(&mut file)?;
 
@@ -212,9 +214,8 @@ fn parse_const_fst<W: SerializableSemiring>(i: &[u8]) -> IResult<&[u8], ConstFst
             start: parse_start_state(hdr.start),
             states: const_states,
             arcs: const_arcs,
-            // FIXME: Parse serialized symts
-            isymt: None,
-            osymt: None,
+            isymt: hdr.isymt,
+            osymt: hdr.osymt,
         },
     ))
 }

--- a/rustfst/src/fst_impls/vector_fst/mutable_fst.rs
+++ b/rustfst/src/fst_impls/vector_fst/mutable_fst.rs
@@ -254,4 +254,12 @@ impl<W: 'static + Semiring> MutableFst for VectorFst<W> {
     fn set_output_symbols(&mut self, symt: Rc<SymbolTable>) {
         self.osymt = Some(Rc::clone(&symt));
     }
+
+    fn unset_input_symbols(&mut self) -> Option<Rc<SymbolTable>> {
+        self.isymt.take()
+    }
+
+    fn unset_output_symbols(&mut self) -> Option<Rc<SymbolTable>> {
+        self.osymt.take()
+    }
 }

--- a/rustfst/src/fst_impls/vector_fst/serializable_fst.rs
+++ b/rustfst/src/fst_impls/vector_fst/serializable_fst.rs
@@ -10,7 +10,7 @@ use nom::IResult;
 
 use crate::fst_impls::vector_fst::VectorFstState;
 use crate::fst_impls::VectorFst;
-use crate::fst_traits::{ArcIterator, CoreFst, ExpandedFst, MutableFst, SerializableFst};
+use crate::fst_traits::{ArcIterator, CoreFst, ExpandedFst, Fst, MutableFst, SerializableFst};
 use crate::parsers::bin_fst::fst_header::{FstFlags, FstHeader, OpenFstString, FST_MAGIC_NUMBER};
 use crate::parsers::bin_fst::utils_parsing::{
     parse_final_weight, parse_fst_arc, parse_start_state,
@@ -58,6 +58,8 @@ impl<W: 'static + SerializableSemiring> SerializableFst for VectorFst<W> {
             start: self.start_state.map(|v| v as i64).unwrap_or(-1),
             num_states: self.num_states() as i64,
             num_arcs: num_arcs as i64,
+            isymt: self.input_symbols(),
+            osymt: self.output_symbols(),
         };
         hdr.write(&mut file)?;
 
@@ -143,9 +145,8 @@ fn parse_vector_fst<W: SerializableSemiring>(i: &[u8]) -> IResult<&[u8], VectorF
         VectorFst {
             start_state: parse_start_state(header.start),
             states,
-            // FIXME: Parse serialized symts
-            isymt: None,
-            osymt: None,
+            isymt: header.isymt,
+            osymt: header.osymt,
         },
     ))
 }

--- a/rustfst/src/fst_traits/mutable_fst.rs
+++ b/rustfst/src/fst_traits/mutable_fst.rs
@@ -281,6 +281,9 @@ pub trait MutableFst: Fst + for<'a> MutableArcIterator<'a> {
     /// Attaches an output `SymbolTable` to the Fst.
     /// The `SymbolTable` is not duplicated with the use of Rc.
     fn set_output_symbols(&mut self, symt: Rc<SymbolTable>);
+
+    fn unset_input_symbols(&mut self) -> Option<Rc<SymbolTable>>;
+    fn unset_output_symbols(&mut self) -> Option<Rc<SymbolTable>>;
 }
 
 /// Iterate over mutable arcs in a wFST.

--- a/rustfst/src/parsers/bin_symt/mod.rs
+++ b/rustfst/src/parsers/bin_symt/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod nom_parser;

--- a/rustfst/src/parsers/bin_symt/nom_parser.rs
+++ b/rustfst/src/parsers/bin_symt/nom_parser.rs
@@ -4,10 +4,10 @@ use nom::number::complete::{le_i32, le_i64};
 use nom::IResult;
 
 use crate::parsers::bin_fst::fst_header::OpenFstString;
-use crate::SymbolTable;
-use std::io::Write;
-use failure::Fallible;
 use crate::parsers::bin_fst::utils_serialization::{write_bin_i32, write_bin_i64};
+use crate::SymbolTable;
+use failure::Fallible;
+use std::io::Write;
 
 static SYMBOL_TABLE_MAGIC_NUMBER: i32 = 2_125_658_996;
 

--- a/rustfst/src/parsers/bin_symt/nom_parser.rs
+++ b/rustfst/src/parsers/bin_symt/nom_parser.rs
@@ -1,0 +1,30 @@
+use nom::combinator::verify;
+use nom::multi::count;
+use nom::number::complete::{le_i32, le_i64};
+use nom::IResult;
+
+use crate::parsers::bin_fst::fst_header::OpenFstString;
+use crate::SymbolTable;
+
+static SYMBOL_TABLE_MAGIC_NUMBER: i32 = 2_125_658_996;
+
+fn parse_row_symt(i: &[u8]) -> IResult<&[u8], (i64, OpenFstString)> {
+    let (i, symbol) = OpenFstString::parse(i)?;
+    let (i, key) = le_i64(i)?;
+    Ok((i, (key, symbol)))
+}
+
+pub(crate) fn parse_symbol_table_bin(i: &[u8]) -> IResult<&[u8], SymbolTable> {
+    let (i, _magic_number) = verify(le_i32, |v| *v == SYMBOL_TABLE_MAGIC_NUMBER)(i)?;
+    let (i, _name) = OpenFstString::parse(i)?;
+    let (i, _available_key) = le_i64(i)?;
+    let (i, num_symbols) = le_i64(i)?;
+    let (i, pairs_idx_symbols) = count(parse_row_symt, num_symbols as usize)(i)?;
+
+    let mut symt = SymbolTable::empty();
+    for (key, symbol) in pairs_idx_symbols.into_iter() {
+        symt.add_symbol_key(symbol, key as usize);
+    }
+
+    Ok((i, symt))
+}

--- a/rustfst/src/parsers/mod.rs
+++ b/rustfst/src/parsers/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod bin_fst;
+pub(crate) mod bin_symt;
 pub mod nom_utils;
 pub mod text_fst;
 pub(crate) mod text_symt;

--- a/rustfst/src/symbol_table.rs
+++ b/rustfst/src/symbol_table.rs
@@ -1,16 +1,16 @@
 use std::collections::hash_map::{Entry, Iter, Keys};
 use std::collections::HashMap;
 use std::fmt;
-use std::fs::{File, read};
+use std::fs::{read, File};
 use std::io::{BufWriter, LineWriter, Write};
 use std::path::Path;
 
 use failure::{Fallible, ResultExt};
 use itertools::Itertools;
 
-use crate::{EPS_SYMBOL, Label, Symbol};
 use crate::parsers::bin_symt::nom_parser::{parse_symbol_table_bin, write_bin_symt};
 use crate::parsers::text_symt::parsed_text_symt::ParsedTextSymt;
+use crate::{Label, Symbol, EPS_SYMBOL};
 
 /// A symbol table stores a bidirectional mapping between arc labels and "symbols" (strings).
 #[derive(PartialEq, Debug, Clone, Default)]

--- a/rustfst/src/tests_openfst/io/vector_fst_bin_deserializer.rs
+++ b/rustfst/src/tests_openfst/io/vector_fst_bin_deserializer.rs
@@ -1,7 +1,7 @@
 use failure::Fallible;
 
 use crate::fst_impls::VectorFst;
-use crate::fst_traits::SerializableFst;
+use crate::fst_traits::{MutableFst, SerializableFst};
 use crate::semirings::SerializableSemiring;
 use crate::tests_openfst::FstTestData;
 
@@ -16,6 +16,30 @@ where
         parsed_fst_bin,
         "{}",
         error_message_fst!(test_data.raw, parsed_fst_bin, "Deserializer VectorFst Bin")
+    );
+    Ok(())
+}
+
+pub fn test_vector_fst_bin_with_symt_deserializer<W>(
+    test_data: &FstTestData<VectorFst<W>>,
+) -> Fallible<()>
+where
+    W: SerializableSemiring + 'static,
+{
+    let mut parsed_fst_bin = VectorFst::<W>::read(&test_data.raw_vector_with_symt_bin_path)?;
+
+    parsed_fst_bin.unset_input_symbols();
+    parsed_fst_bin.unset_output_symbols();
+
+    assert_eq!(
+        test_data.raw,
+        parsed_fst_bin,
+        "{}",
+        error_message_fst!(
+            test_data.raw,
+            parsed_fst_bin,
+            "Deserializer VectorFst Bin With symt"
+        )
     );
     Ok(())
 }

--- a/rustfst/src/tests_openfst/mod.rs
+++ b/rustfst/src/tests_openfst/mod.rs
@@ -77,6 +77,7 @@ use crate::tests_openfst::algorithms::concat::{
     test_concat, test_concat_dynamic, ConcatOperationResult, ConcatTestData,
 };
 use crate::tests_openfst::algorithms::union::{test_union, test_union_dynamic};
+use crate::tests_openfst::io::vector_fst_bin_deserializer::test_vector_fst_bin_with_symt_deserializer;
 
 #[macro_use]
 mod macros;
@@ -147,6 +148,7 @@ pub struct ParsedFstTestData {
     concat: Vec<ConcatOperationResult>,
     closure_plus: ClosureOperationResult,
     closure_star: ClosureOperationResult,
+    raw_vector_with_symt_bin_path: String,
 }
 
 pub struct FstTestData<F: SerializableFst>
@@ -196,6 +198,7 @@ where
     pub concat: Vec<ConcatTestData<F>>,
     pub closure_plus: ClosureTestData<F>,
     pub closure_star: ClosureTestData<F>,
+    pub raw_vector_with_symt_bin_path: PathBuf,
 }
 
 impl<F: SerializableFst> FstTestData<F>
@@ -264,6 +267,9 @@ where
             concat: data.concat.iter().map(|v| v.parse()).collect(),
             closure_plus: data.closure_plus.parse(),
             closure_star: data.closure_star.parse(),
+            raw_vector_with_symt_bin_path: absolute_path_folder
+                .join(&data.raw_vector_with_symt_bin_path)
+                .to_path_buf(),
         }
     }
 }
@@ -418,6 +424,8 @@ where
     test_closure_star(&test_data)?;
 
     test_closure_star_dynamic(&test_data)?;
+
+    test_vector_fst_bin_with_symt_deserializer(&test_data)?;
 
     Ok(())
 }

--- a/rustfst/src/tests_openfst/test_symt.rs
+++ b/rustfst/src/tests_openfst/test_symt.rs
@@ -55,6 +55,17 @@ fn run_test_openfst_symt(test_name: &str) -> Fallible<()> {
         assert_eq!(symt_bin.len(), parsed_test_data.num_symbols);
     }
 
+    {
+        // Test serializing and parsing symt bin
+        let dir = tempdir()?;
+        let path_symt_serialized = dir.path().join("symt_serialized.bin");
+        symt.write(&path_symt_serialized)?;
+        let symt2 = SymbolTable::read(path_symt_serialized)?;
+        assert_eq!(symt_bin, symt2);
+    }
+
+    assert_eq!(symt, symt_bin);
+
     Ok(())
 }
 

--- a/rustfst/src/tests_openfst/test_symt.rs
+++ b/rustfst/src/tests_openfst/test_symt.rs
@@ -28,6 +28,10 @@ fn run_test_openfst_symt(test_name: &str) -> Fallible<()> {
 
     let mut path_symt_text = absolute_path_folder.clone();
     path_symt_text.push(parsed_test_data.symt_text);
+
+    let mut path_symt_bin = absolute_path_folder.clone();
+    path_symt_bin.push(parsed_test_data.symt_bin);
+
     let symt = SymbolTable::read_text(path_symt_text)?;
 
     {
@@ -42,6 +46,13 @@ fn run_test_openfst_symt(test_name: &str) -> Fallible<()> {
         symt.write_text(&path_symt_serialized)?;
         let symt2 = SymbolTable::read_text(path_symt_serialized)?;
         assert_eq!(symt, symt2);
+    }
+
+    let symt_bin = SymbolTable::read(path_symt_bin)?;
+
+    {
+        // Test Parsing Bin Symt
+        assert_eq!(symt_bin.len(), parsed_test_data.num_symbols);
     }
 
     Ok(())


### PR DESCRIPTION
Fix : #58 and https://github.com/Garvys/rustfst/issues/51

- Added `write` and `read` method to the `SymbolTable` API to serialize and deserialize SymbolTable in binary format consistently with OpenFst.
- Added `unset_input_symbols` and `unset_output_symbols` methods to remove the symbol tables attached to a mutable fst.
- Fix bug when the parsing of fst in binary format crashed because a symbol table was attached to the fst. The symbol tables are now retrieved directly from the fst file.