### PR TITLE
Borrow instead of AsRef in Semiring API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Display` is no longer a trait bound of `Semiring`. However, it is required to implement `SerializableSemiring`.
 - Use `BufWriter` when serializing a `SymbolTable` object increasing the serialization speed.
 - Fix bug when the parsing of fst in binary format crashed because a symbol table was attached to the fst. The symbol tables are now retrieved directly from the fst file.
+- `plus` and `times` methods of `Semiring` now takes a `Borrow` instead of an `AsRef`. Remove trait bounds on `AsRef<Self>`, `Default` and `Sized`.
+- Add checks on `fst_type` and `arc_type` when loading a binary fst. As a result, for instance, loading a `ConstFst` with a `VectorFst` file will trigger a nice error.
 
 ## [0.4.0] - 2019-11-12
 

--- a/rustfst-cli/src/cmds/push.rs
+++ b/rustfst-cli/src/cmds/push.rs
@@ -24,11 +24,8 @@ impl UnaryFstAlgorithm for PushAlgorithm {
         "push".to_string()
     }
 
-    fn run_algorithm(
-        &self,
-        mut fst: VectorFst<TropicalWeight>,
-    ) -> Fallible<VectorFst<TropicalWeight>> {
-        push(&mut fst, self.reweight_type, self.push_type)
+    fn run_algorithm(&self, fst: VectorFst<TropicalWeight>) -> Fallible<VectorFst<TropicalWeight>> {
+        push(&fst, self.reweight_type, self.push_type)
     }
 }
 

--- a/rustfst-cli/src/cmds/reverse.rs
+++ b/rustfst-cli/src/cmds/reverse.rs
@@ -22,11 +22,8 @@ impl UnaryFstAlgorithm for ReverseAlgorithm {
         "reverse".to_string()
     }
 
-    fn run_algorithm(
-        &self,
-        mut fst: VectorFst<TropicalWeight>,
-    ) -> Fallible<VectorFst<TropicalWeight>> {
-        reverse(&mut fst)
+    fn run_algorithm(&self, fst: VectorFst<TropicalWeight>) -> Fallible<VectorFst<TropicalWeight>> {
+        reverse(&fst)
     }
 }
 

--- a/rustfst-cli/src/unary_fst_algorithm.rs
+++ b/rustfst-cli/src/unary_fst_algorithm.rs
@@ -13,7 +13,7 @@ fn duration_to_seconds(duration: &Duration) -> f64 {
     duration.as_secs() as f64 + duration.subsec_nanos() as f64 * 1.0e-9
 }
 
-fn standard_deviation(data: &Vec<f64>) -> f64 {
+fn standard_deviation(data: &[f64]) -> f64 {
     let sum: f64 = data.iter().sum();
     let mean: f64 = sum / data.len() as f64;
 

--- a/rustfst/src/algorithms/arc_mappers/invert_weight_mapper.rs
+++ b/rustfst/src/algorithms/arc_mappers/invert_weight_mapper.rs
@@ -9,7 +9,8 @@ pub struct InvertWeightMapper {}
 
 #[inline]
 pub fn map_weight<W: WeaklyDivisibleSemiring>(weight: &mut W) -> Fallible<()> {
-    Ok(weight.set_value(W::one().divide(weight, DivideType::DivideAny)?.take_value()))
+    weight.set_value(W::one().divide(weight, DivideType::DivideAny)?.take_value());
+    Ok(())
 }
 
 impl<S: WeaklyDivisibleSemiring> ArcMapper<S> for InvertWeightMapper {

--- a/rustfst/src/algorithms/composition.rs
+++ b/rustfst/src/algorithms/composition.rs
@@ -56,7 +56,7 @@ where
         let (q1, q2, q) = queue.pop_front().unwrap();
 
         if let (Some(rho_1), Some(rho_2)) = (fst_1.final_weight(q1)?, fst_2.final_weight(q2)?) {
-            composed_fst.set_final(q, rho_1.times(&rho_2)?)?;
+            composed_fst.set_final(q, rho_1.times(rho_2)?)?;
         }
 
         let arcs_it1 = fst_1.arcs_iter(q1)?;

--- a/rustfst/src/algorithms/factor_weight.rs
+++ b/rustfst/src/algorithms/factor_weight.rs
@@ -138,7 +138,7 @@ where
         {
             let one = F::W::one();
             let weight = match elt.state {
-                None => elt.weight.clone(),
+                None => elt.weight,
                 Some(s) => elt
                     .weight
                     .times(self.fst.borrow().final_weight(s)?.unwrap_or_else(|| &one))

--- a/rustfst/src/algorithms/minimize.rs
+++ b/rustfst/src/algorithms/minimize.rs
@@ -1,5 +1,6 @@
 use std::cmp::max;
 use std::cmp::Ordering;
+use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::collections::HashSet;
 
@@ -381,14 +382,16 @@ fn pre_partition<W: Semiring, F: MutableFst<W = W> + ExpandedFst<W = W>>(
                 &mut hash_to_class_nonfinal
             };
 
-            // TODO: Find a way to avoid the double lookup
-            if this_map.contains_key(&ilabels) {
-                state_to_initial_class[s] = this_map[&ilabels];
-            } else {
-                this_map.insert(ilabels, next_class);
-                state_to_initial_class[s] = next_class;
-                next_class += 1;
-            }
+            match this_map.entry(ilabels) {
+                Entry::Occupied(e) => {
+                    state_to_initial_class[s] = *e.get();
+                }
+                Entry::Vacant(e) => {
+                    e.insert(next_class);
+                    state_to_initial_class[s] = next_class;
+                    next_class += 1;
+                }
+            };
         }
     }
     partition.allocate_classes(next_class);

--- a/rustfst/src/algorithms/mod.rs
+++ b/rustfst/src/algorithms/mod.rs
@@ -92,10 +92,6 @@ pub use self::{
     weight_convert::{weight_convert, WeightConverter},
 };
 
-#[allow(unused)]
 pub use self::factor_weight::{
     factor_weight, FactorIterator, FactorWeightFst, FactorWeightOptions, FactorWeightType,
 };
-
-#[allow(unused)]
-pub(crate) use self::partition::Partition;

--- a/rustfst/src/algorithms/push.rs
+++ b/rustfst/src/algorithms/push.rs
@@ -58,7 +58,7 @@ where
     Ok(())
 }
 
-fn compute_total_weight<F>(fst: &F, dist: &Vec<F::W>, reverse: bool) -> Fallible<F::W>
+fn compute_total_weight<F>(fst: &F, dist: &[F::W], reverse: bool) -> Fallible<F::W>
 where
     F: ExpandedFst,
 {
@@ -98,14 +98,12 @@ where
                 final_weight.divide_assign(&weight, DivideType::DivideRight)?;
             }
         }
-    } else {
-        if let Some(start) = fst.start() {
-            for arc in unsafe { fst.arcs_iter_unchecked_mut(start) } {
-                arc.weight.divide_assign(&weight, DivideType::DivideLeft)?;
-            }
-            if let Some(final_weight) = unsafe { fst.final_weight_unchecked_mut(start) } {
-                final_weight.divide_assign(&weight, DivideType::DivideLeft)?;
-            }
+    } else if let Some(start) = fst.start() {
+        for arc in unsafe { fst.arcs_iter_unchecked_mut(start) } {
+            arc.weight.divide_assign(&weight, DivideType::DivideLeft)?;
+        }
+        if let Some(final_weight) = unsafe { fst.final_weight_unchecked_mut(start) } {
+            final_weight.divide_assign(&weight, DivideType::DivideLeft)?;
         }
     }
     Ok(())

--- a/rustfst/src/algorithms/reweight.rs
+++ b/rustfst/src/algorithms/reweight.rs
@@ -39,7 +39,7 @@ where
                 ReweightType::ReweightToInitial => {}
                 ReweightType::ReweightToFinal => {
                     if let Some(final_weight) = fst.final_weight(state)? {
-                        let new_weight = F::W::zero().times(&final_weight)?;
+                        let new_weight = F::W::zero().times(final_weight)?;
                         fst.set_final(state, new_weight)?;
                     }
                 }
@@ -105,9 +105,9 @@ where
 
             if let Some(final_weight) = fst.final_weight(start_state)? {
                 let new_weight = match reweight_type {
-                    ReweightType::ReweightToInitial => d_s.times(&final_weight)?,
+                    ReweightType::ReweightToInitial => d_s.times(final_weight)?,
                     ReweightType::ReweightToFinal => {
-                        (F::W::one().divide(&d_s, DivideType::DivideRight)?).times(&final_weight)?
+                        (F::W::one().divide(&d_s, DivideType::DivideRight)?).times(final_weight)?
                     }
                 };
 

--- a/rustfst/src/algorithms/rm_epsilon.rs
+++ b/rustfst/src/algorithms/rm_epsilon.rs
@@ -138,7 +138,7 @@ where
                 }
                 let rho_prime_p = unsafe { output_fst.final_weight_unchecked(p).unsafe_unwrap() };
                 let rho_q = unsafe { fst_no_epsilon.final_weight_unchecked(*q).unsafe_unwrap() };
-                let new_weight = rho_prime_p.plus(&w_prime.times(&rho_q)?)?;
+                let new_weight = rho_prime_p.plus(&w_prime.times(rho_q)?)?;
                 output_fst.set_final(p, new_weight)?;
             }
         }

--- a/rustfst/src/algorithms/rm_final_epsilon.rs
+++ b/rustfst/src/algorithms/rm_final_epsilon.rs
@@ -43,24 +43,23 @@ where
         arcs_to_del.clear();
 
         for (idx, arc) in unsafe { ifst.arcs_iter_unchecked(state).enumerate() } {
-            if finals.contains(&arc.nextstate) {
-                if arc.ilabel == EPS_LABEL && arc.olabel == EPS_LABEL {
-                    unsafe {
-                        if weight.is_none() {
-                            weight = Some(
-                                ifst.final_weight_unchecked(state)
-                                    .cloned()
-                                    .unwrap_or_else(F::W::zero),
-                            );
-                        }
-                        weight.as_mut().unsafe_unwrap().plus_assign(
-                            ifst.final_weight_unchecked(arc.nextstate)
-                                .unsafe_unwrap()
-                                .times(&arc.weight)?,
-                        )?
-                    };
-                    arcs_to_del.push(idx);
-                }
+            if finals.contains(&arc.nextstate) && arc.ilabel == EPS_LABEL && arc.olabel == EPS_LABEL
+            {
+                unsafe {
+                    if weight.is_none() {
+                        weight = Some(
+                            ifst.final_weight_unchecked(state)
+                                .cloned()
+                                .unwrap_or_else(F::W::zero),
+                        );
+                    }
+                    weight.as_mut().unsafe_unwrap().plus_assign(
+                        ifst.final_weight_unchecked(arc.nextstate)
+                            .unsafe_unwrap()
+                            .times(&arc.weight)?,
+                    )?
+                };
+                arcs_to_del.push(idx);
             }
         }
 

--- a/rustfst/src/algorithms/shortest_path.rs
+++ b/rustfst/src/algorithms/shortest_path.rs
@@ -174,7 +174,7 @@ where
             }
         } else {
             let pos = parent[d.unwrap()].unwrap().1;
-            let mut arc = ifst.arcs_iter(state)?.skip(pos).next().unwrap().clone();
+            let mut arc = ifst.arcs_iter(state)?.nth(pos).unwrap().clone();
             arc.nextstate = d_p.unwrap();
             ofst.add_arc(s_p.unwrap(), arc)?;
         }

--- a/rustfst/src/algorithms/shortest_path.rs
+++ b/rustfst/src/algorithms/shortest_path.rs
@@ -120,7 +120,7 @@ where
         let sd = distance[s].clone();
 
         if let Some(final_weight) = ifst.final_weight(s)? {
-            let plus = f_distance.plus(&sd.times(&final_weight)?)?;
+            let plus = f_distance.plus(&sd.times(final_weight)?)?;
             if f_distance != plus {
                 f_distance = plus;
                 *f_parent = Some(s);

--- a/rustfst/src/fst_impls/const_fst/iterators.rs
+++ b/rustfst/src/fst_impls/const_fst/iterators.rs
@@ -11,7 +11,7 @@ use std::ops::Range;
 
 impl<W: Semiring> ConstFst<W> {
     fn state_range(&self) -> Range<usize> {
-        (0..self.states.len())
+        0..self.states.len()
     }
 
     fn arc_range(&self, state: &ConstState<W>) -> Range<usize> {
@@ -56,14 +56,14 @@ pub struct ArcIndexIter(Range<usize>);
 impl std::iter::Iterator for StateIndexIter {
     type Item = StateIndex;
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(|it| StateIndex(it))
+        self.0.next().map(StateIndex)
     }
 }
 
 impl std::iter::Iterator for ArcIndexIter {
     type Item = ArcIndex;
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(|it| ArcIndex(it))
+        self.0.next().map(ArcIndex)
     }
 }
 

--- a/rustfst/src/fst_impls/const_fst/serializable_fst.rs
+++ b/rustfst/src/fst_impls/const_fst/serializable_fst.rs
@@ -184,10 +184,15 @@ fn parse_const_state<W: SerializableSemiring>(i: &[u8]) -> IResult<&[u8], ConstS
     ))
 }
 
-fn parse_const_fst<W: SerializableSemiring>(i: &[u8]) -> IResult<&[u8], ConstFst<W>> {
+fn parse_const_fst<W: SerializableSemiring + 'static>(i: &[u8]) -> IResult<&[u8], ConstFst<W>> {
     let stream_len = i.len();
 
-    let (mut i, hdr) = FstHeader::parse(i, CONST_MIN_FILE_VERSION)?;
+    let (mut i, hdr) = FstHeader::parse(
+        i,
+        CONST_MIN_FILE_VERSION,
+        ConstFst::<W>::fst_type(),
+        Arc::<W>::arc_type(),
+    )?;
     let aligned = hdr.version == CONST_ALIGNED_FILE_VERSION;
     let pos = stream_len - i.len();
 

--- a/rustfst/src/fst_impls/const_fst/serializable_fst.rs
+++ b/rustfst/src/fst_impls/const_fst/serializable_fst.rs
@@ -192,19 +192,15 @@ fn parse_const_fst<W: SerializableSemiring>(i: &[u8]) -> IResult<&[u8], ConstFst
     let pos = stream_len - i.len();
 
     // Align input
-    if aligned && hdr.num_states > 0 {
-        if pos % CONST_ARCH_ALIGNMENT > 0 {
-            i = take(CONST_ARCH_ALIGNMENT - (pos % CONST_ARCH_ALIGNMENT))(i)?.0;
-        }
+    if aligned && hdr.num_states > 0 && pos % CONST_ARCH_ALIGNMENT > 0 {
+        i = take(CONST_ARCH_ALIGNMENT - (pos % CONST_ARCH_ALIGNMENT))(i)?.0;
     }
     let (mut i, const_states) = count(parse_const_state, hdr.num_states as usize)(i)?;
     let pos = stream_len - i.len();
 
     // Align input
-    if aligned && hdr.num_arcs > 0 {
-        if pos % CONST_ARCH_ALIGNMENT > 0 {
-            i = take(CONST_ARCH_ALIGNMENT - (pos % CONST_ARCH_ALIGNMENT))(i)?.0;
-        }
+    if aligned && hdr.num_arcs > 0 && pos % CONST_ARCH_ALIGNMENT > 0 {
+        i = take(CONST_ARCH_ALIGNMENT - (pos % CONST_ARCH_ALIGNMENT))(i)?.0;
     }
     let (i, const_arcs) = count(parse_fst_arc, hdr.num_arcs as usize)(i)?;
 

--- a/rustfst/src/fst_impls/vector_fst/data_structure.rs
+++ b/rustfst/src/fst_impls/vector_fst/data_structure.rs
@@ -22,13 +22,19 @@ pub struct VectorFst<W: Semiring> {
 // and num_output_epsilons inside the data structure as it would mean having to maintain them
 // when the object is modified. Which is not trivial with the MutableArcIterator API for instance.
 // Same goes for ArcMap. For not-mutable fst however, it is usefull.
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) struct VectorFstState<W: Semiring> {
     pub(crate) final_weight: Option<W>,
     pub(crate) arcs: Vec<Arc<W>>,
 }
 
 impl<W: Semiring> VectorFstState<W> {
+    pub fn new() -> Self {
+        Self {
+            final_weight: None,
+            arcs: vec![],
+        }
+    }
     pub fn num_arcs(&self) -> usize {
         self.arcs.len()
     }

--- a/rustfst/src/fst_impls/vector_fst/iterators.rs
+++ b/rustfst/src/fst_impls/vector_fst/iterators.rs
@@ -15,7 +15,7 @@ use std::ops::Range;
 impl<'a, W: Semiring> StateIterator<'a> for VectorFst<W> {
     type Iter = Range<StateId>;
     fn states_iter(&'a self) -> Self::Iter {
-        (0..self.states.len())
+        0..self.states.len()
     }
 }
 
@@ -64,14 +64,14 @@ pub struct ArcIndexIter(Range<usize>);
 impl std::iter::Iterator for StateIndexIter {
     type Item = StateIndex;
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(|it| StateIndex(it))
+        self.0.next().map(StateIndex)
     }
 }
 
 impl std::iter::Iterator for ArcIndexIter {
     type Item = ArcIndex;
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(|it| ArcIndex(it))
+        self.0.next().map(ArcIndex)
     }
 }
 

--- a/rustfst/src/fst_impls/vector_fst/mutable_fst.rs
+++ b/rustfst/src/fst_impls/vector_fst/mutable_fst.rs
@@ -56,13 +56,13 @@ impl<W: 'static + Semiring> MutableFst for VectorFst<W> {
 
     fn add_state(&mut self) -> StateId {
         let id = self.states.len();
-        self.states.insert(id, VectorFstState::default());
+        self.states.insert(id, VectorFstState::new());
         id
     }
 
     fn add_states(&mut self, n: usize) {
         let len = self.states.len();
-        self.states.resize_with(len + n, VectorFstState::default);
+        self.states.resize_with(len + n, VectorFstState::new);
     }
 
     fn del_state(&mut self, state_to_remove: StateId) -> Fallible<()> {

--- a/rustfst/src/fst_impls/vector_fst/mutable_fst.rs
+++ b/rustfst/src/fst_impls/vector_fst/mutable_fst.rs
@@ -135,7 +135,7 @@ impl<W: 'static + Semiring> MutableFst for VectorFst<W> {
     }
 
     unsafe fn del_arcs_id_sorted_unchecked(&mut self, state: usize, to_del: &Vec<usize>) {
-        let ref mut arcs = self.states.get_unchecked_mut(state).arcs;
+        let arcs = &mut self.states.get_unchecked_mut(state).arcs;
         for i in to_del.iter().rev() {
             arcs.remove(*i);
         }

--- a/rustfst/src/fst_impls/vector_fst/serializable_fst.rs
+++ b/rustfst/src/fst_impls/vector_fst/serializable_fst.rs
@@ -85,7 +85,7 @@ impl<W: 'static + SerializableSemiring> SerializableFst for VectorFst<W> {
         let start_state = parsed_fst_text.start();
         let num_states = parsed_fst_text.num_states();
 
-        let states = vec![VectorFstState::<W>::default(); num_states];
+        let states = vec![VectorFstState::<W>::new(); num_states];
 
         let mut fst = VectorFst {
             states,

--- a/rustfst/src/fst_impls/vector_fst/serializable_fst.rs
+++ b/rustfst/src/fst_impls/vector_fst/serializable_fst.rs
@@ -137,8 +137,13 @@ fn parse_vector_fst_state<W: SerializableSemiring>(i: &[u8]) -> IResult<&[u8], V
     ))
 }
 
-fn parse_vector_fst<W: SerializableSemiring>(i: &[u8]) -> IResult<&[u8], VectorFst<W>> {
-    let (i, header) = FstHeader::parse(i, VECTOR_MIN_FILE_VERSION)?;
+fn parse_vector_fst<W: SerializableSemiring + 'static>(i: &[u8]) -> IResult<&[u8], VectorFst<W>> {
+    let (i, header) = FstHeader::parse(
+        i,
+        VECTOR_MIN_FILE_VERSION,
+        VectorFst::<W>::fst_type(),
+        Arc::<W>::arc_type(),
+    )?;
     let (i, states) = count(parse_vector_fst_state, header.num_states as usize)(i)?;
     Ok((
         i,

--- a/rustfst/src/fst_properties/compute_fst_properties.rs
+++ b/rustfst/src/fst_properties/compute_fst_properties.rs
@@ -17,7 +17,7 @@ pub fn compute_fst_properties<F: Fst + ExpandedFst>(fst: &F) -> Fallible<FstProp
 
     let mut visitor = SccVisitor::new(fst, true, true);
     dfs_visit(fst, &mut visitor, false);
-    let ref sccs = unsafe { visitor.scc.unsafe_unwrap() };
+    let sccs = unsafe { &visitor.scc.unsafe_unwrap() };
 
     comp_props |= FstProperties::ACCESSIBLE;
     if unsafe { visitor.access.unsafe_unwrap().iter().any(|v| !*v) } {

--- a/rustfst/src/parsers/bin_fst/fst_header.rs
+++ b/rustfst/src/parsers/bin_fst/fst_header.rs
@@ -57,10 +57,19 @@ fn optionally_parse_symt(i: &[u8], parse_symt: bool) -> IResult<&[u8], Option<Sy
 }
 
 impl FstHeader {
-    pub(crate) fn parse(i: &[u8], min_file_version: i32) -> IResult<&[u8], FstHeader> {
+    pub(crate) fn parse<S1: AsRef<str>, S2: AsRef<str>>(
+        i: &[u8],
+        min_file_version: i32,
+        fst_loading_type: S1,
+        arc_loading_type: S2,
+    ) -> IResult<&[u8], FstHeader> {
         let (i, magic_number) = verify(le_i32, |v: &i32| *v == FST_MAGIC_NUMBER)(i)?;
-        let (i, fst_type) = OpenFstString::parse(i)?;
-        let (i, arc_type) = OpenFstString::parse(i)?;
+        let (i, fst_type) = verify(OpenFstString::parse, |v| {
+            v.s.as_str() == fst_loading_type.as_ref()
+        })(i)?;
+        let (i, arc_type) = verify(OpenFstString::parse, |v| {
+            v.s.as_str() == arc_loading_type.as_ref()
+        })(i)?;
         let (i, version) = verify(le_i32, |v: &i32| *v >= min_file_version)(i)?;
         let (i, flags) = map_res(le_u32, |v: u32| {
             FstFlags::from_bits(v).ok_or_else(|| "Could not parse Fst Flags")

--- a/rustfst/src/parsers/bin_fst/fst_header.rs
+++ b/rustfst/src/parsers/bin_fst/fst_header.rs
@@ -85,8 +85,8 @@ impl FstHeader {
                 start,
                 num_states,
                 num_arcs,
-                isymt: isymt.map(|s| Rc::new(s)),
-                osymt: osymt.map(|s| Rc::new(s)),
+                isymt: isymt.map(Rc::new),
+                osymt: osymt.map(Rc::new),
             },
         ))
     }

--- a/rustfst/src/parsers/text_fst/parsed_text_fst.rs
+++ b/rustfst/src/parsers/text_fst/parsed_text_fst.rs
@@ -50,15 +50,17 @@ pub struct FinalState<W: SerializableSemiring> {
     pub weight: Option<W>,
 }
 
-impl<W: SerializableSemiring> ParsedTextFst<W> {
-    pub fn new() -> Self {
+impl<W: SerializableSemiring> Default for ParsedTextFst<W> {
+    fn default() -> Self {
         Self {
             transitions: vec![],
             final_states: vec![],
             start_state: None,
         }
     }
+}
 
+impl<W: SerializableSemiring> ParsedTextFst<W> {
     /// Loads an FST from a loaded string in text format usually called `At&T FSM format`.
     ///
     /// # Format:
@@ -75,12 +77,12 @@ impl<W: SerializableSemiring> ParsedTextFst<W> {
     ///
     /// ## Example:
     /// ```text
-    /// 0	1	32	32
-    /// 1	2	45	45
-    /// 2	3	18	18	0.25
-    /// 3	4	45	45
-    /// 4	5	5	5	0.31
-    /// 3	0.67
+    /// 0   1   32  32
+    /// 1   2   45  45
+    /// 2   3   18  18  0.25
+    /// 3   4   45  45
+    /// 4   5   5   5   0.31
+    /// 3   0.67
     /// ```
     pub fn from_string(fst_string: &str) -> Fallible<Self> {
         let (_, vec_rows_parsed) =
@@ -90,7 +92,7 @@ impl<W: SerializableSemiring> ParsedTextFst<W> {
     }
 
     fn from_vec_rows_parsed(v: Vec<RowParsed<W>>) -> Self {
-        let mut parsed_fst = ParsedTextFst::new();
+        let mut parsed_fst = ParsedTextFst::default();
 
         parsed_fst.start_state = v.first().map(|v| match v {
             RowParsed::Transition(t) => t.state,
@@ -124,12 +126,12 @@ impl<W: SerializableSemiring> ParsedTextFst<W> {
     ///
     /// ## Example:
     /// ```text
-    /// 0	1	32	32
-    /// 1	2	45	45
-    /// 2	3	18	18	0.25
-    /// 3	4	45	45
-    /// 4	5	5	5	0.31
-    /// 3	0.67
+    /// 0   1   32  32
+    /// 1   2   45  45
+    /// 2   3   18  18  0.25
+    /// 3   4   45  45
+    /// 4   5   5   5   0.31
+    /// 3   0.67
     /// ```
     pub fn from_path<P: AsRef<Path>>(path_fst_text: P) -> Fallible<Self> {
         let fst_string = read_to_string(path_fst_text)?;

--- a/rustfst/src/parsers/text_fst/parsed_text_fst.rs
+++ b/rustfst/src/parsers/text_fst/parsed_text_fst.rs
@@ -17,7 +17,7 @@ pub enum RowParsed<W: SerializableSemiring> {
 /// Struct representing a parsed fst in text format. It contains a vector of transitions
 /// and a vector final states. The first state in the vector of transition is the start state.
 /// This container doesn't depend on any Semiring.
-#[derive(Debug, PartialEq, Default)]
+#[derive(Debug, PartialEq)]
 pub struct ParsedTextFst<W: SerializableSemiring> {
     pub transitions: Vec<Transition<W>>,
     pub final_states: Vec<FinalState<W>>,
@@ -51,6 +51,14 @@ pub struct FinalState<W: SerializableSemiring> {
 }
 
 impl<W: SerializableSemiring> ParsedTextFst<W> {
+    pub fn new() -> Self {
+        Self {
+            transitions: vec![],
+            final_states: vec![],
+            start_state: None,
+        }
+    }
+
     /// Loads an FST from a loaded string in text format usually called `At&T FSM format`.
     ///
     /// # Format:
@@ -82,7 +90,7 @@ impl<W: SerializableSemiring> ParsedTextFst<W> {
     }
 
     fn from_vec_rows_parsed(v: Vec<RowParsed<W>>) -> Self {
-        let mut parsed_fst = ParsedTextFst::default();
+        let mut parsed_fst = ParsedTextFst::new();
 
         parsed_fst.start_state = v.first().map(|v| match v {
             RowParsed::Transition(t) => t.state,

--- a/rustfst/src/semirings/boolean_weight.rs
+++ b/rustfst/src/semirings/boolean_weight.rs
@@ -1,7 +1,7 @@
 use failure::Fallible;
 
 use crate::semirings::{CompleteSemiring, Semiring, SemiringProperties, StarSemiring};
-
+use std::borrow::Borrow;
 /// Boolean semiring: (&, |, false, true).
 #[derive(Clone, Debug, PartialEq, PartialOrd, Default, Eq, Copy, Hash)]
 pub struct BooleanWeight {
@@ -23,12 +23,12 @@ impl Semiring for BooleanWeight {
         BooleanWeight { value }
     }
 
-    fn plus_assign<P: AsRef<Self>>(&mut self, rhs: P) -> Fallible<()> {
-        self.value |= rhs.as_ref().value;
+    fn plus_assign<P: Borrow<Self>>(&mut self, rhs: P) -> Fallible<()> {
+        self.value |= rhs.borrow().value;
         Ok(())
     }
-    fn times_assign<P: AsRef<Self>>(&mut self, rhs: P) -> Fallible<()> {
-        self.value &= rhs.as_ref().value;
+    fn times_assign<P: Borrow<Self>>(&mut self, rhs: P) -> Fallible<()> {
+        self.value &= rhs.borrow().value;
         Ok(())
     }
 
@@ -54,12 +54,6 @@ impl Semiring for BooleanWeight {
             | SemiringProperties::COMMUTATIVE
             | SemiringProperties::IDEMPOTENT
             | SemiringProperties::PATH
-    }
-}
-
-impl AsRef<BooleanWeight> for BooleanWeight {
-    fn as_ref(&self) -> &BooleanWeight {
-        &self
     }
 }
 

--- a/rustfst/src/semirings/integer_weight.rs
+++ b/rustfst/src/semirings/integer_weight.rs
@@ -1,3 +1,4 @@
+use std::borrow::Borrow;
 use std::i32;
 
 use failure::Fallible;
@@ -25,13 +26,13 @@ impl Semiring for IntegerWeight {
         IntegerWeight { value }
     }
 
-    fn plus_assign<P: AsRef<Self>>(&mut self, rhs: P) -> Fallible<()> {
-        self.value += rhs.as_ref().value;
+    fn plus_assign<P: Borrow<Self>>(&mut self, rhs: P) -> Fallible<()> {
+        self.value += rhs.borrow().value;
         Ok(())
     }
 
-    fn times_assign<P: AsRef<Self>>(&mut self, rhs: P) -> Fallible<()> {
-        self.value *= rhs.as_ref().value;
+    fn times_assign<P: Borrow<Self>>(&mut self, rhs: P) -> Fallible<()> {
+        self.value *= rhs.borrow().value;
         Ok(())
     }
 

--- a/rustfst/src/semirings/log_weight.rs
+++ b/rustfst/src/semirings/log_weight.rs
@@ -1,3 +1,4 @@
+use std::borrow::Borrow;
 use std::f32;
 use std::hash::{Hash, Hasher};
 
@@ -46,9 +47,9 @@ impl Semiring for LogWeight {
         }
     }
 
-    fn plus_assign<P: AsRef<Self>>(&mut self, rhs: P) -> Fallible<()> {
+    fn plus_assign<P: Borrow<Self>>(&mut self, rhs: P) -> Fallible<()> {
         let f1 = self.value();
-        let f2 = rhs.as_ref().value();
+        let f2 = rhs.borrow().value();
         self.value.0 = if f1 == &f32::INFINITY {
             *f2
         } else if f2 == &f32::INFINITY {
@@ -61,9 +62,9 @@ impl Semiring for LogWeight {
         Ok(())
     }
 
-    fn times_assign<P: AsRef<Self>>(&mut self, rhs: P) -> Fallible<()> {
+    fn times_assign<P: Borrow<Self>>(&mut self, rhs: P) -> Fallible<()> {
         let f1 = self.value();
-        let f2 = rhs.as_ref().value();
+        let f2 = rhs.borrow().value();
         if f1 == &f32::INFINITY {
         } else if f2 == &f32::INFINITY {
             self.value.0 = *f2;

--- a/rustfst/src/semirings/log_weight.rs
+++ b/rustfst/src/semirings/log_weight.rs
@@ -50,9 +50,9 @@ impl Semiring for LogWeight {
     fn plus_assign<P: Borrow<Self>>(&mut self, rhs: P) -> Fallible<()> {
         let f1 = self.value();
         let f2 = rhs.borrow().value();
-        self.value.0 = if f1 == &f32::INFINITY {
+        self.value.0 = if f1.eq(&f32::INFINITY) {
             *f2
-        } else if f2 == &f32::INFINITY {
+        } else if f2.eq(&f32::INFINITY) {
             *f1
         } else if f1 > f2 {
             f2 - ln_pos_exp(f1 - f2)
@@ -65,8 +65,8 @@ impl Semiring for LogWeight {
     fn times_assign<P: Borrow<Self>>(&mut self, rhs: P) -> Fallible<()> {
         let f1 = self.value();
         let f2 = rhs.borrow().value();
-        if f1 == &f32::INFINITY {
-        } else if f2 == &f32::INFINITY {
+        if f1.eq(&f32::INFINITY) {
+        } else if f2.eq(&f32::INFINITY) {
             self.value.0 = *f2;
         } else {
             self.value.0 += f2;

--- a/rustfst/src/semirings/power_weight.rs
+++ b/rustfst/src/semirings/power_weight.rs
@@ -54,18 +54,6 @@ where
     }
 }
 
-impl<W, N> Default for PowerWeight<W, N>
-where
-    W: Semiring,
-    N: ArrayLength<W>,
-{
-    fn default() -> Self {
-        Self {
-            weights: GenericArray::clone_from_slice(vec![W::default(); N::to_usize()].as_slice()),
-        }
-    }
-}
-
 impl<W, N> Clone for PowerWeight<W, N>
 where
     W: Semiring,

--- a/rustfst/src/semirings/probability_weight.rs
+++ b/rustfst/src/semirings/probability_weight.rs
@@ -1,3 +1,4 @@
+use std::borrow::Borrow;
 use std::f32;
 use std::hash::{Hash, Hasher};
 
@@ -37,13 +38,13 @@ impl Semiring for ProbabilityWeight {
         }
     }
 
-    fn plus_assign<P: AsRef<Self>>(&mut self, rhs: P) -> Fallible<()> {
-        self.value.0 += rhs.as_ref().value.0;
+    fn plus_assign<P: Borrow<Self>>(&mut self, rhs: P) -> Fallible<()> {
+        self.value.0 += rhs.borrow().value.0;
         Ok(())
     }
 
-    fn times_assign<P: AsRef<Self>>(&mut self, rhs: P) -> Fallible<()> {
-        self.value.0 *= rhs.as_ref().value.0;
+    fn times_assign<P: Borrow<Self>>(&mut self, rhs: P) -> Fallible<()> {
+        self.value.0 *= rhs.borrow().value.0;
         Ok(())
     }
 

--- a/rustfst/src/semirings/product_weight.rs
+++ b/rustfst/src/semirings/product_weight.rs
@@ -1,14 +1,17 @@
+use std::borrow::Borrow;
 use std::fmt;
 use std::fmt::Debug;
+use std::io::Write;
 
 use failure::Fallible;
+use nom::IResult;
 
 use crate::semirings::{
     DivideType, Semiring, SemiringProperties, SerializableSemiring, WeaklyDivisibleSemiring,
     WeightQuantize,
 };
-use nom::IResult;
-use std::io::Write;
+#[cfg(test)]
+use crate::semirings::{LogWeight, TropicalWeight};
 
 /// Product semiring: W1 * W2.
 #[derive(Debug, Eq, PartialOrd, PartialEq, Clone, Default, Hash)]
@@ -54,15 +57,15 @@ where
         Self { weight }
     }
 
-    fn plus_assign<P: AsRef<Self>>(&mut self, rhs: P) -> Fallible<()> {
-        self.weight.0.plus_assign(&rhs.as_ref().weight.0)?;
-        self.weight.1.plus_assign(&rhs.as_ref().weight.1)?;
+    fn plus_assign<P: Borrow<Self>>(&mut self, rhs: P) -> Fallible<()> {
+        self.weight.0.plus_assign(&rhs.borrow().weight.0)?;
+        self.weight.1.plus_assign(&rhs.borrow().weight.1)?;
         Ok(())
     }
 
-    fn times_assign<P: AsRef<Self>>(&mut self, rhs: P) -> Fallible<()> {
-        self.weight.0.times_assign(&rhs.as_ref().weight.0)?;
-        self.weight.1.times_assign(&rhs.as_ref().weight.1)?;
+    fn times_assign<P: Borrow<Self>>(&mut self, rhs: P) -> Fallible<()> {
+        self.weight.0.times_assign(&rhs.borrow().weight.0)?;
+        self.weight.1.times_assign(&rhs.borrow().weight.1)?;
         Ok(())
     }
 
@@ -189,8 +192,6 @@ where
     }
 }
 
-#[cfg(test)]
-use crate::semirings::{LogWeight, TropicalWeight};
 test_semiring_serializable!(
     tests_product_weight_serializable,
     ProductWeight::<TropicalWeight, LogWeight>,

--- a/rustfst/src/semirings/semiring.rs
+++ b/rustfst/src/semirings/semiring.rs
@@ -1,3 +1,4 @@
+use std::borrow::Borrow;
 use std::fmt::Debug;
 use std::fmt::Display;
 use std::hash::Hash;
@@ -31,9 +32,7 @@ bitflags! {
 /// `0` is an annihilator for `*`.
 /// Thus, a semiring is a ring that may lack negation.
 /// For more information : https://cs.nyu.edu/~mohri/pub/hwa.pdf
-pub trait Semiring:
-    Clone + PartialEq + PartialOrd + Debug + Default + AsRef<Self> + Hash + Eq + Sized
-{
+pub trait Semiring: Clone + PartialEq + PartialOrd + Debug + Hash + Eq {
     type Type: Clone;
     type ReverseWeight: Semiring;
 
@@ -42,19 +41,19 @@ pub trait Semiring:
 
     fn new(value: Self::Type) -> Self;
 
-    fn plus<P: AsRef<Self>>(&self, rhs: P) -> Fallible<Self> {
+    fn plus<P: Borrow<Self>>(&self, rhs: P) -> Fallible<Self> {
         let mut w = self.clone();
         w.plus_assign(rhs)?;
         Ok(w)
     }
-    fn plus_assign<P: AsRef<Self>>(&mut self, rhs: P) -> Fallible<()>;
+    fn plus_assign<P: Borrow<Self>>(&mut self, rhs: P) -> Fallible<()>;
 
-    fn times<P: AsRef<Self>>(&self, rhs: P) -> Fallible<Self> {
+    fn times<P: Borrow<Self>>(&self, rhs: P) -> Fallible<Self> {
         let mut w = self.clone();
         w.times_assign(rhs)?;
         Ok(w)
     }
-    fn times_assign<P: AsRef<Self>>(&mut self, rhs: P) -> Fallible<()>;
+    fn times_assign<P: Borrow<Self>>(&mut self, rhs: P) -> Fallible<()>;
 
     /// Borrow underneath value.
     fn value(&self) -> &Self::Type;

--- a/rustfst/src/semirings/string_weight.rs
+++ b/rustfst/src/semirings/string_weight.rs
@@ -1,3 +1,4 @@
+use std::borrow::Borrow;
 use std::fmt;
 use std::io::Write;
 
@@ -18,19 +19,19 @@ use crate::semirings::{
 use crate::Label;
 
 /// String semiring: (identity, ., Infinity, Epsilon)
-#[derive(Clone, Debug, PartialOrd, Default, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialOrd, PartialEq, Eq, Hash)]
 pub struct StringWeightRestrict {
     pub(crate) value: StringWeightVariant,
 }
 
 /// String semiring: (longest_common_prefix, ., Infinity, Epsilon)
-#[derive(Clone, Debug, PartialOrd, Default, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialOrd, PartialEq, Eq, Hash)]
 pub struct StringWeightLeft {
     pub(crate) value: StringWeightVariant,
 }
 
 /// String semiring: (longest_common_suffix, ., Infinity, Epsilon)
-#[derive(Clone, Debug, PartialOrd, Default, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialOrd, PartialEq, Eq, Hash)]
 pub struct StringWeightRight {
     pub(crate) value: StringWeightVariant,
 }
@@ -74,22 +75,22 @@ macro_rules! string_semiring {
                 Self { value }
             }
 
-            fn plus_assign<P: AsRef<Self>>(&mut self, rhs: P) -> Fallible<()> {
+            fn plus_assign<P: Borrow<Self>>(&mut self, rhs: P) -> Fallible<()> {
                 if self.is_zero() {
-                    self.set_value(rhs.as_ref().value().clone());
-                } else if rhs.as_ref().is_zero() {
+                    self.set_value(rhs.borrow().value().clone());
+                } else if rhs.borrow().is_zero() {
                     // Do nothing
                 } else {
                     let l1 = self.value.unwrap_labels();
-                    let l2 = rhs.as_ref().value.unwrap_labels();
+                    let l2 = rhs.borrow().value.unwrap_labels();
 
                     match $string_type {
                         StringType::StringRestrict => {
-                            if self != rhs.as_ref() {
+                            if self != rhs.borrow() {
                                 bail!(
                                     "Unequal arguments : non-functional FST ? w1 = {:?} w2 = {:?}",
                                     &self,
-                                    &rhs.as_ref()
+                                    &rhs.borrow()
                                 );
                             }
                         }
@@ -119,9 +120,9 @@ macro_rules! string_semiring {
                 };
                 Ok(())
             }
-            fn times_assign<P: AsRef<Self>>(&mut self, rhs: P) -> Fallible<()> {
+            fn times_assign<P: Borrow<Self>>(&mut self, rhs: P) -> Fallible<()> {
                 if let StringWeightVariant::Labels(ref mut labels_left) = self.value {
-                    if let StringWeightVariant::Labels(ref labels_right) = rhs.as_ref().value {
+                    if let StringWeightVariant::Labels(ref labels_right) = rhs.borrow().value {
                         for l in labels_right {
                             labels_left.push(*l);
                         }

--- a/rustfst/src/semirings/tropical_weight.rs
+++ b/rustfst/src/semirings/tropical_weight.rs
@@ -1,3 +1,4 @@
+use std::borrow::Borrow;
 use std::f32;
 use std::hash::{Hash, Hasher};
 use std::io::Write;
@@ -43,16 +44,16 @@ impl Semiring for TropicalWeight {
         }
     }
 
-    fn plus_assign<P: AsRef<Self>>(&mut self, rhs: P) -> Fallible<()> {
-        if rhs.as_ref().value < self.value {
-            self.value = rhs.as_ref().value;
+    fn plus_assign<P: Borrow<Self>>(&mut self, rhs: P) -> Fallible<()> {
+        if rhs.borrow().value < self.value {
+            self.value = rhs.borrow().value;
         }
         Ok(())
     }
 
-    fn times_assign<P: AsRef<Self>>(&mut self, rhs: P) -> Fallible<()> {
+    fn times_assign<P: Borrow<Self>>(&mut self, rhs: P) -> Fallible<()> {
         let f1 = self.value();
-        let f2 = rhs.as_ref().value();
+        let f2 = rhs.borrow().value();
         if f1 == &f32::INFINITY {
         } else if f2 == &f32::INFINITY {
             self.value.0 = *f2;

--- a/rustfst/src/semirings/tropical_weight.rs
+++ b/rustfst/src/semirings/tropical_weight.rs
@@ -54,8 +54,8 @@ impl Semiring for TropicalWeight {
     fn times_assign<P: Borrow<Self>>(&mut self, rhs: P) -> Fallible<()> {
         let f1 = self.value();
         let f2 = rhs.borrow().value();
-        if f1 == &f32::INFINITY {
-        } else if f2 == &f32::INFINITY {
+        if f1.eq(&f32::INFINITY) {
+        } else if f2.eq(&f32::INFINITY) {
             self.value.0 = *f2;
         } else {
             self.value.0 += f2;

--- a/rustfst/src/symbol_table.rs
+++ b/rustfst/src/symbol_table.rs
@@ -82,7 +82,7 @@ impl SymbolTable {
     pub(crate) fn add_symbol_key<S: Into<String>>(&mut self, sym: S, key: usize) {
         let sym = sym.into();
         self.symbol_to_label.insert(sym.clone(), key);
-        self.label_to_symbol.insert(key, sym.clone());
+        self.label_to_symbol.insert(key, sym);
         // TODO: Add some checks here
     }
 


### PR DESCRIPTION
- `plus` and `times` methods of `Semiring` now takes a `Borrow` instead of an `AsRef`. Remove trait bounds on `AsRef<Self>`, `Default` and `Sized`.
- Add checks on `fst_type` and `arc_type` when loading a binary fst. As a result, for instance, loading a `ConstFst` with a `VectorFst` file will trigger a nice error.