### PR TITLE
W to Into<W>

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -11,7 +11,7 @@ cargo clean -p rustfst-cli
 cargo build --all
 cargo test --all
 cargo check --benches --all # running benches on travis is useless
-cargo doc --all
+cargo doc --all --no-deps
 
 ./build_bench.sh
 python3 --version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `plus` and `times` methods of `Semiring` now takes a `Borrow` instead of an `AsRef`. Remove trait bounds on `AsRef<Self>`, `Default` and `Sized`.
 - Add checks on `fst_type` and `arc_type` when loading a binary fst. As a result, for instance, loading a `ConstFst` with a `VectorFst` file will trigger a nice error.
 - `SymbolTable` attached to an `Fst` are now used when drawing it.
+- Change parameter from W to Into<W> for `add_arc`, `set_final_unchecked` and `set_final` methods.
+- `MutableFst` now has a trait bound on `ExpandedFst`.
 
 ## [0.4.0] - 2019-11-12
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ use rustfst::prelude::*;
 
 fn main() -> Fallible<()> {
     // Creates a empty wFST
-    let mut fst = VectorFst::new();
+    let mut fst = VectorFst::<TropicalWeight>::new();
 
     // Add some states
     let s0 = fst.add_state();
@@ -58,14 +58,14 @@ fn main() -> Fallible<()> {
     fst.set_start(s0)?;
 
     // Add an arc from s0 to s1
-    fst.add_arc(s0, Arc::new(3, 5, TropicalWeight::new(10.0), s1))?;
+    fst.add_arc(s0, Arc::new(3, 5, 10.0, s1))?;
 
     // Add an arc from s0 to s2
-    fst.add_arc(s0, Arc::new(5, 7, TropicalWeight::new(18.0), s2))?;
+    fst.add_arc(s0, Arc::new(5, 7, 18.0, s2))?;
 
     // Set s1 and s2 as final states
-    fst.set_final(s1, TropicalWeight::new(31.0))?;
-    fst.set_final(s2, TropicalWeight::new(45.0))?;
+    fst.set_final(s1, 31.0)?;
+    fst.set_final(s2, 45.0)?;
 
     // Iter over all the paths in the wFST
     for p in fst.paths_iter() {

--- a/rustfst/src/algorithms/all_pairs_shortest_distance.rs
+++ b/rustfst/src/algorithms/all_pairs_shortest_distance.rs
@@ -19,14 +19,14 @@ use crate::semirings::{Semiring, StarSemiring};
 /// # use rustfst::Arc;
 /// # use failure::Fallible;
 /// # fn main() -> Fallible<()> {
-/// let mut fst = VectorFst::new();
+/// let mut fst = VectorFst::<IntegerWeight>::new();
 /// let s0 = fst.add_state();
 /// let s1 = fst.add_state();
 /// let s2 = fst.add_state();
 ///
-/// fst.add_arc(s0, Arc::new(32, 23, IntegerWeight::new(18), s1));
-/// fst.add_arc(s0, Arc::new(32, 23, IntegerWeight::new(21), s2));
-/// fst.add_arc(s1, Arc::new(32, 23, IntegerWeight::new(55), s2));
+/// fst.add_arc(s0, Arc::new(32, 23, 18, s1));
+/// fst.add_arc(s0, Arc::new(32, 23, 21, s2));
+/// fst.add_arc(s1, Arc::new(32, 23, 55, s2));
 ///
 /// let dists = all_pairs_shortest_distance(&fst)?;
 ///

--- a/rustfst/src/algorithms/closure.rs
+++ b/rustfst/src/algorithms/closure.rs
@@ -19,6 +19,17 @@ pub enum ClosureType {
 /// then the closure transduces `x` to `y` with weight `a`,
 /// `xx` to `yy` with weight `a ⊗ a`, `xxx` to `yyy` with weight `a ⊗ a ⊗ a`, etc.
 ///  If closure_star then the empty string is transduced to itself with weight `1` as well.
+///
+/// # Example
+///
+/// ## Input
+/// ![closure_in](https://raw.githubusercontent.com/Garvys/rustfst-images-doc/master/images/closure_in.svg?sanitize=true)
+///
+/// ## Closure Plus
+/// ![closure_out_closure_plus](https://raw.githubusercontent.com/Garvys/rustfst-images-doc/master/images/closure_out_closure_plus.svg?sanitize=true)
+///
+/// ## Closure Star
+/// ![closure_out_closure_star](https://raw.githubusercontent.com/Garvys/rustfst-images-doc/master/images/closure_out_closure_star.svg?sanitize=true)
 pub fn closure<F>(fst: &mut F, closure_type: ClosureType)
 where
     F: MutableFst,

--- a/rustfst/src/algorithms/determinize.rs
+++ b/rustfst/src/algorithms/determinize.rs
@@ -462,16 +462,16 @@ mod tests {
 
     #[test]
     fn test_determinize() -> Fallible<()> {
-        let mut input_fst = VectorFst::new();
+        let mut input_fst = VectorFst::<TropicalWeight>::new();
         let s0 = input_fst.add_state();
         let s1 = input_fst.add_state();
 
         input_fst.set_start(s0)?;
         input_fst.set_final(s1, TropicalWeight::one())?;
 
-        input_fst.add_arc(s0, Arc::new(1, 1, TropicalWeight::new(2.0), s1))?;
-        input_fst.add_arc(s0, Arc::new(1, 1, TropicalWeight::new(2.0), s1))?;
-        input_fst.add_arc(s0, Arc::new(1, 1, TropicalWeight::new(2.0), s1))?;
+        input_fst.add_arc(s0, Arc::new(1, 1, 2.0, s1))?;
+        input_fst.add_arc(s0, Arc::new(1, 1, 2.0, s1))?;
+        input_fst.add_arc(s0, Arc::new(1, 1, 2.0, s1))?;
 
         let mut ref_fst = VectorFst::new();
         let s0 = ref_fst.add_state();
@@ -491,7 +491,7 @@ mod tests {
 
     #[test]
     fn test_determinize_2() -> Fallible<()> {
-        let mut input_fst = VectorFst::new();
+        let mut input_fst = VectorFst::<TropicalWeight>::new();
         let s0 = input_fst.add_state();
         let s1 = input_fst.add_state();
         let s2 = input_fst.add_state();
@@ -500,11 +500,11 @@ mod tests {
         input_fst.set_start(s0)?;
         input_fst.set_final(s3, TropicalWeight::one())?;
 
-        input_fst.add_arc(s0, Arc::new(1, 1, TropicalWeight::new(2.0), s1))?;
-        input_fst.add_arc(s0, Arc::new(1, 1, TropicalWeight::new(3.0), s2))?;
+        input_fst.add_arc(s0, Arc::new(1, 1, 2.0, s1))?;
+        input_fst.add_arc(s0, Arc::new(1, 1, 3.0, s2))?;
 
-        input_fst.add_arc(s1, Arc::new(2, 2, TropicalWeight::new(4.0), s3))?;
-        input_fst.add_arc(s2, Arc::new(2, 2, TropicalWeight::new(3.0), s3))?;
+        input_fst.add_arc(s1, Arc::new(2, 2, 4.0, s3))?;
+        input_fst.add_arc(s2, Arc::new(2, 2, 3.0, s3))?;
 
         let mut ref_fst = VectorFst::new();
         let s0 = ref_fst.add_state();

--- a/rustfst/src/algorithms/inversion.rs
+++ b/rustfst/src/algorithms/inversion.rs
@@ -5,7 +5,7 @@ use crate::fst_traits::{ExpandedFst, MutableFst};
 /// This operation inverts the transduction corresponding to an FST
 /// by exchanging the FST's input and output labels.
 ///
-/// # Example
+/// # Example 1
 /// ```
 /// # use rustfst::fst;
 /// # use rustfst::utils::{acceptor, transducer};
@@ -17,6 +17,15 @@ use crate::fst_traits::{ExpandedFst, MutableFst};
 ///
 /// assert_eq!(fst, fst![3 => 2]);
 /// ```
+///
+/// # Example 2
+///
+/// ## Input
+/// ![invert_in](https://raw.githubusercontent.com/Garvys/rustfst-images-doc/master/images/invert_in.svg?sanitize=true)
+///
+/// ## Invert
+/// ![invert_out](https://raw.githubusercontent.com/Garvys/rustfst-images-doc/master/images/invert_out.svg?sanitize=true)
+///
 pub fn invert<F: ExpandedFst + MutableFst>(fst: &mut F) {
     for state in 0..fst.num_states() {
         for arc in unsafe { fst.arcs_iter_unchecked_mut(state) } {

--- a/rustfst/src/algorithms/projection.rs
+++ b/rustfst/src/algorithms/projection.rs
@@ -11,17 +11,9 @@ pub enum ProjectType {
 
 /// This operation projects an FST onto its domain or range by either copying
 /// each arc's input label to its output label or vice versa.
-///
-/// # Example
-///
-/// ## Input
-///
-/// ![project_in](https://raw.githubusercontent.com/Garvys/rustfst-images-doc/master/images/project_in.svg?sanitize=true)
+/// # Example 1
 ///
 /// ## Project input
-///
-/// ![project_out_project-input](https://raw.githubusercontent.com/Garvys/rustfst-images-doc/master/images/project_out_project-input.svg?sanitize=true)
-///
 /// ```
 /// # #[macro_use] extern crate rustfst;
 /// # use failure::Fallible;
@@ -30,16 +22,14 @@ pub enum ProjectType {
 /// # use rustfst::fst_impls::VectorFst;
 /// # use rustfst::algorithms::{project, ProjectType};
 /// # fn main() -> Fallible<()> {
-/// # let mut fst : VectorFst<IntegerWeight> = fst![2 => 3];
+/// let mut fst : VectorFst<IntegerWeight> = fst![2 => 3];
 /// project(&mut fst, ProjectType::ProjectInput);
-/// # assert_eq!(fst, fst![2]);
+/// assert_eq!(fst, fst![2]);
 /// # Ok(())
 /// # }
 /// ```
 ///
 /// ## Project output
-///
-/// ![project_out_project-input](https://raw.githubusercontent.com/Garvys/rustfst-images-doc/master/images/project_out_project-output.svg?sanitize=true)
 ///
 /// ```rust
 /// # #[macro_use] extern crate rustfst;
@@ -49,12 +39,26 @@ pub enum ProjectType {
 /// # use rustfst::fst_impls::VectorFst;
 /// # use rustfst::algorithms::{project, ProjectType};
 /// # fn main() -> Fallible<()> {
-/// # let mut fst : VectorFst<IntegerWeight> = fst![2 => 3];
+/// let mut fst : VectorFst<IntegerWeight> = fst![2 => 3];
 /// project(&mut fst, ProjectType::ProjectOutput);
-/// # assert_eq!(fst, fst![3]);
+/// assert_eq!(fst, fst![3]);
 /// # Ok(())
 /// # }
 /// ```
+///
+/// # Example 2
+///
+/// ## Input
+///
+/// ![project_in](https://raw.githubusercontent.com/Garvys/rustfst-images-doc/master/images/project_in.svg?sanitize=true)
+///
+/// ## Project input
+///
+/// ![project_out_project-input](https://raw.githubusercontent.com/Garvys/rustfst-images-doc/master/images/project_out_project-input.svg?sanitize=true)
+///
+/// ## Project output
+///
+/// ![project_out_project-input](https://raw.githubusercontent.com/Garvys/rustfst-images-doc/master/images/project_out_project-output.svg?sanitize=true)
 pub fn project<F: MutableFst>(fst: &mut F, project_type: ProjectType) {
     match project_type {
         ProjectType::ProjectInput => {

--- a/rustfst/src/algorithms/projection.rs
+++ b/rustfst/src/algorithms/projection.rs
@@ -1,4 +1,4 @@
-use crate::fst_traits::{ExpandedFst, MutableFst};
+use crate::fst_traits::MutableFst;
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, Copy)]
 /// Different types of labels projection in a FST.
@@ -55,7 +55,7 @@ pub enum ProjectType {
 /// # Ok(())
 /// # }
 /// ```
-pub fn project<F: ExpandedFst + MutableFst>(fst: &mut F, project_type: ProjectType) {
+pub fn project<F: MutableFst>(fst: &mut F, project_type: ProjectType) {
     match project_type {
         ProjectType::ProjectInput => {
             for state in 0..fst.num_states() {
@@ -76,13 +76,13 @@ pub fn project<F: ExpandedFst + MutableFst>(fst: &mut F, project_type: ProjectTy
 
 #[cfg(test)]
 mod tests {
-    use crate::proptest_fst::proptest_fst;
+    use proptest::prelude::*;
 
     use crate::fst_properties::FstProperties;
+    use crate::fst_traits::ExpandedFst;
+    use crate::proptest_fst::proptest_fst;
 
     use super::*;
-
-    use proptest::prelude::*;
 
     proptest! {
         #[test]

--- a/rustfst/src/algorithms/push.rs
+++ b/rustfst/src/algorithms/push.rs
@@ -11,7 +11,7 @@ use crate::algorithms::{
     FactorWeightType, ReweightType,
 };
 use crate::fst_impls::VectorFst;
-use crate::fst_traits::{AllocableFst, CoreFst, ExpandedFst, Fst, MutableFst};
+use crate::fst_traits::{AllocableFst, CoreFst, ExpandedFst, MutableFst};
 use crate::semirings::{DivideType, Semiring};
 use crate::semirings::{
     GallicWeightLeft, GallicWeightRight, StringWeightLeft, StringWeightRight,
@@ -38,7 +38,7 @@ pub fn push_weights<F>(
     remove_total_weight: bool,
 ) -> Fallible<()>
 where
-    F: Fst + ExpandedFst + MutableFst,
+    F: MutableFst,
     F::W: WeaklyDivisibleSemiring,
     <<F as CoreFst>::W as Semiring>::ReverseWeight: 'static,
 {
@@ -86,7 +86,7 @@ where
 
 fn remove_weight<F>(fst: &mut F, weight: F::W, at_final: bool) -> Fallible<()>
 where
-    F: MutableFst + ExpandedFst,
+    F: MutableFst,
     F::W: WeaklyDivisibleSemiring,
 {
     if weight.is_one() || weight.is_zero() {

--- a/rustfst/src/algorithms/relabel_pairs.rs
+++ b/rustfst/src/algorithms/relabel_pairs.rs
@@ -81,18 +81,18 @@ mod tests {
     #[test]
     fn test_projection_input_generic() -> Fallible<()> {
         // Initial FST
-        let mut fst = VectorFst::new();
+        let mut fst = VectorFst::<IntegerWeight>::new();
         let s0 = fst.add_state();
         let s1 = fst.add_state();
         let s2 = fst.add_state();
         fst.set_start(s0)?;
 
-        fst.add_arc(s0, Arc::new(3, 18, IntegerWeight::new(10), s1))?;
-        fst.add_arc(s0, Arc::new(2, 5, IntegerWeight::new(10), s1))?;
-        fst.add_arc(s0, Arc::new(5, 9, IntegerWeight::new(18), s2))?;
-        fst.add_arc(s0, Arc::new(5, 7, IntegerWeight::new(18), s2))?;
-        fst.set_final(s1, IntegerWeight::new(31))?;
-        fst.set_final(s2, IntegerWeight::new(45))?;
+        fst.add_arc(s0, Arc::new(3, 18, 10, s1))?;
+        fst.add_arc(s0, Arc::new(2, 5, 10, s1))?;
+        fst.add_arc(s0, Arc::new(5, 9, 18, s2))?;
+        fst.add_arc(s0, Arc::new(5, 7, 18, s2))?;
+        fst.set_final(s1, 31)?;
+        fst.set_final(s2, 45)?;
 
         // Expected FST
         // Initial FST

--- a/rustfst/src/algorithms/reverse.rs
+++ b/rustfst/src/algorithms/reverse.rs
@@ -18,7 +18,7 @@ pub fn reverse<W, F1, F2>(ifst: &F1) -> Fallible<F2>
 where
     W: Semiring,
     F1: ExpandedFst<W = W>,
-    F2: MutableFst<W = W::ReverseWeight> + ExpandedFst<W = W::ReverseWeight> + AllocableFst,
+    F2: MutableFst<W = W::ReverseWeight> + AllocableFst,
 {
     let mut ofst = F2::new();
     ofst.reserve_states(ifst.num_states());

--- a/rustfst/src/algorithms/reweight.rs
+++ b/rustfst/src/algorithms/reweight.rs
@@ -1,6 +1,6 @@
 use failure::Fallible;
 
-use crate::fst_traits::{ExpandedFst, Fst, MutableFst};
+use crate::fst_traits::MutableFst;
 use crate::semirings::{DivideType, Semiring, WeaklyDivisibleSemiring};
 
 /// Different types of reweighting.
@@ -22,7 +22,7 @@ pub enum ReweightType {
 /// reweighting towards the final states.
 pub fn reweight<F>(fst: &mut F, potentials: &[F::W], reweight_type: ReweightType) -> Fallible<()>
 where
-    F: Fst + ExpandedFst + MutableFst,
+    F: MutableFst,
     F::W: WeaklyDivisibleSemiring,
 {
     let zero = F::W::zero();

--- a/rustfst/src/algorithms/rm_epsilon.rs
+++ b/rustfst/src/algorithms/rm_epsilon.rs
@@ -84,14 +84,14 @@ where
 ///
 /// let fst_no_epsilon : VectorFst<_> = rm_epsilon(&fst).unwrap();
 ///
-/// let mut fst_no_epsilon_ref = VectorFst::new();
+/// let mut fst_no_epsilon_ref = VectorFst::<IntegerWeight>::new();
 /// let s0 = fst_no_epsilon_ref.add_state();
 /// let s1 = fst_no_epsilon_ref.add_state();
-/// fst_no_epsilon_ref.add_arc(s0, Arc::new(32, 25, IntegerWeight::new(78), s1));
-/// fst_no_epsilon_ref.add_arc(s1, Arc::new(32, 25, IntegerWeight::new(78 * 13), s1));
+/// fst_no_epsilon_ref.add_arc(s0, Arc::new(32, 25, 78, s1));
+/// fst_no_epsilon_ref.add_arc(s1, Arc::new(32, 25, 78 * 13, s1));
 /// fst_no_epsilon_ref.set_start(s0).unwrap();
-/// fst_no_epsilon_ref.set_final(s0, IntegerWeight::new(5));
-/// fst_no_epsilon_ref.set_final(s1, IntegerWeight::new(5 * 13));
+/// fst_no_epsilon_ref.set_final(s0, 5);
+/// fst_no_epsilon_ref.set_final(s1, 5 * 13);
 ///
 /// assert_eq!(fst_no_epsilon, fst_no_epsilon_ref);
 /// ```

--- a/rustfst/src/algorithms/rm_epsilon.rs
+++ b/rustfst/src/algorithms/rm_epsilon.rs
@@ -99,7 +99,7 @@ pub fn rm_epsilon<W, F1, F2>(fst: &F1) -> Fallible<F2>
 where
     W: StarSemiring,
     F1: ExpandedFst<W = W>,
-    F2: MutableFst<W = W> + ExpandedFst<W = W>,
+    F2: MutableFst<W = W>,
 {
     let fst_epsilon: F2 = compute_fst_epsilon(fst, true)?;
     let dists_fst_epsilon = all_pairs_shortest_distance(&fst_epsilon)?;

--- a/rustfst/src/algorithms/rm_final_epsilon.rs
+++ b/rustfst/src/algorithms/rm_final_epsilon.rs
@@ -6,14 +6,14 @@ use unsafe_unwrap::UnsafeUnwrap;
 use crate::algorithms::connect;
 use crate::algorithms::dfs_visit::dfs_visit;
 use crate::algorithms::visitors::SccVisitor;
-use crate::fst_traits::{ExpandedFst, MutableFst};
+use crate::fst_traits::MutableFst;
 use crate::semirings::Semiring;
 use crate::EPS_LABEL;
 
 /// Removes final states that have epsilon-only input arcs.
 pub fn rm_final_epsilon<F>(ifst: &mut F) -> Fallible<()>
 where
-    F: MutableFst + ExpandedFst,
+    F: MutableFst,
 {
     let mut visitors = SccVisitor::new(ifst, false, true);
     dfs_visit(ifst, &mut visitors, false);

--- a/rustfst/src/algorithms/shortest_distance.rs
+++ b/rustfst/src/algorithms/shortest_distance.rs
@@ -20,15 +20,15 @@ use crate::StateId;
 /// # use rustfst::fst_traits::MutableFst;
 /// # use rustfst::algorithms::single_source_shortest_distance;
 /// # use rustfst::Arc;
-/// let mut fst = VectorFst::new();
+/// let mut fst = VectorFst::<IntegerWeight>::new();
 /// let s0 = fst.add_state();
 /// let s1 = fst.add_state();
 /// let s2 = fst.add_state();
 ///
 /// fst.set_start(s0).unwrap();
-/// fst.add_arc(s0, Arc::new(32, 23, IntegerWeight::new(18), s1));
-/// fst.add_arc(s0, Arc::new(32, 23, IntegerWeight::new(21), s2));
-/// fst.add_arc(s1, Arc::new(32, 23, IntegerWeight::new(55), s2));
+/// fst.add_arc(s0, Arc::new(32, 23, 18, s1));
+/// fst.add_arc(s0, Arc::new(32, 23, 21, s2));
+/// fst.add_arc(s1, Arc::new(32, 23, 55, s2));
 ///
 /// let dists = single_source_shortest_distance(&fst, s1).unwrap();
 ///
@@ -108,24 +108,27 @@ pub fn _shortest_distance<F: ExpandedFst>(fst: &F) -> Fallible<Vec<<F as CoreFst
 /// # use rustfst::fst_traits::MutableFst;
 /// # use rustfst::algorithms::shortest_distance;
 /// # use rustfst::Arc;
-/// let mut fst = VectorFst::new();
+/// # use failure::Fallible;
+/// fn main() -> Fallible<()> {
+/// let mut fst = VectorFst::<IntegerWeight>::new();
 /// let s0 = fst.add_state();
 /// let s1 = fst.add_state();
 /// let s2 = fst.add_state();
 ///
 /// fst.set_start(s0).unwrap();
-/// fst.add_arc(s0, Arc::new(32, 23, IntegerWeight::new(18), s1));
-/// fst.add_arc(s0, Arc::new(32, 23, IntegerWeight::new(21), s2));
-/// fst.add_arc(s1, Arc::new(32, 23, IntegerWeight::new(55), s2));
+/// fst.add_arc(s0, Arc::new(32, 23, 18, s1));
+/// fst.add_arc(s0, Arc::new(32, 23, 21, s2));
+/// fst.add_arc(s1, Arc::new(32, 23, 55, s2));
 ///
-/// let dists = shortest_distance(&fst, false).unwrap();
+/// let dists = shortest_distance(&fst, false)?;
 ///
 /// assert_eq!(dists, vec![
 ///     IntegerWeight::one(),
 ///     IntegerWeight::new(18),
 ///     IntegerWeight::new(21 + 18*55),
 /// ]);
-///
+/// # Ok(())
+/// # }
 /// ```
 pub fn shortest_distance<F: ExpandedFst>(fst: &F, reverse: bool) -> Fallible<Vec<<F as CoreFst>::W>>
 where

--- a/rustfst/src/algorithms/shortest_path.rs
+++ b/rustfst/src/algorithms/shortest_path.rs
@@ -303,7 +303,7 @@ where
             let mut arc: Arc<W> = Arc::new(
                 rarc.ilabel,
                 rarc.olabel,
-                hack_convert_reverse_reverse(rarc.weight.reverse()?),
+                hack_convert_reverse_reverse::<W>(rarc.weight.reverse()?),
                 rarc.nextstate,
             );
             let weight = p.1.times(&arc.weight)?;

--- a/rustfst/src/algorithms/union.rs
+++ b/rustfst/src/algorithms/union.rs
@@ -1,6 +1,7 @@
 use std::rc::Rc;
 
 use failure::Fallible;
+use unsafe_unwrap::UnsafeUnwrap;
 
 use crate::algorithms::ReplaceFst;
 use crate::arc::Arc;
@@ -10,7 +11,6 @@ use crate::fst_traits::{
 };
 use crate::semirings::Semiring;
 use crate::{SymbolTable, EPS_LABEL};
-use unsafe_unwrap::UnsafeUnwrap;
 
 /// Performs the union of two wFSTs. If A transduces string `x` to `y` with weight `a`
 /// and `B` transduces string `w` to `v` with weight `b`, then their union transduces `x` to `y`
@@ -45,7 +45,7 @@ use unsafe_unwrap::UnsafeUnwrap;
 pub fn union<W, F1, F2>(fst_1: &mut F1, fst_2: &F2) -> Fallible<()>
 where
     W: Semiring,
-    F1: ExpandedFst<W = W> + AllocableFst<W = W> + MutableFst<W = W>,
+    F1: AllocableFst<W = W> + MutableFst<W = W>,
     F2: ExpandedFst<W = W>,
 {
     let numstates1 = fst_1.num_states();

--- a/rustfst/src/algorithms/weight_convert.rs
+++ b/rustfst/src/algorithms/weight_convert.rs
@@ -4,6 +4,7 @@ use crate::algorithms::{FinalArc, MapFinalAction};
 use crate::fst_traits::{AllocableFst, ExpandedFst, MutableFst};
 use crate::semirings::Semiring;
 use crate::{Arc, EPS_LABEL};
+use unsafe_unwrap::UnsafeUnwrap;
 
 /// The WeightConverter interfaces defines how a weight should be turned into another one.
 /// Useful for changing the semiring of an FST.
@@ -89,7 +90,7 @@ where
                                 mapped_final_arc.ilabel,
                                 mapped_final_arc.olabel,
                                 mapped_final_arc.weight,
-                                superfinal.unwrap(),
+                                unsafe { superfinal.unsafe_unwrap() },
                             ),
                         )?;
 

--- a/rustfst/src/algorithms/weight_converters/to_gallic_converter.rs
+++ b/rustfst/src/algorithms/weight_converters/to_gallic_converter.rs
@@ -19,10 +19,10 @@ macro_rules! impl_to_gallic_converter {
             fn arc_map(&mut self, arc: &Arc<W>) -> Fallible<Arc<$gallic<W>>> {
                 let new_arc = if arc.olabel == EPS_LABEL {
                     let w = ($string_weight::one(), arc.weight.clone());
-                    Arc::new(arc.ilabel, arc.ilabel, w.into(), arc.nextstate)
+                    Arc::new(arc.ilabel, arc.ilabel, w, arc.nextstate)
                 } else {
                     let w = (arc.olabel, arc.weight.clone());
-                    Arc::new(arc.ilabel, arc.ilabel, w.into(), arc.nextstate)
+                    Arc::new(arc.ilabel, arc.ilabel, w, arc.nextstate)
                 };
                 Ok(new_arc)
             }

--- a/rustfst/src/arc.rs
+++ b/rustfst/src/arc.rs
@@ -21,21 +21,20 @@ impl<W: Semiring> Arc<W> {
     ///
     /// ```
     /// # use rustfst::Arc;
-    /// # use rustfst::semirings::{BooleanWeight, Semiring};
-    /// let arc = Arc::new(0, 1, BooleanWeight::one(), 2);
+    /// # use rustfst::semirings::{TropicalWeight, Semiring};
+    /// let arc = Arc::<TropicalWeight>::new(0, 1, 1.3, 2);
     ///
     /// assert_eq!(arc.ilabel, 0);
     /// assert_eq!(arc.olabel, 1);
-    /// assert_eq!(arc.weight, BooleanWeight::one());
+    /// assert_eq!(arc.weight, TropicalWeight::new(1.3));
     /// assert_eq!(arc.nextstate, 2);
     ///
     /// ```
-    #[inline]
-    pub fn new(ilabel: Label, olabel: Label, weight: W, nextstate: StateId) -> Self {
+    pub fn new<S: Into<W>>(ilabel: Label, olabel: Label, weight: S, nextstate: StateId) -> Self {
         Arc {
             ilabel,
             olabel,
-            weight,
+            weight: weight.into(),
             nextstate,
         }
     }
@@ -46,9 +45,9 @@ impl<W: Semiring> Arc<W> {
     ///
     /// ```
     /// # use rustfst::Arc;
-    /// # use rustfst::semirings::{BooleanWeight, Semiring};
-    /// let mut arc_1 = Arc::new(0, 1, BooleanWeight::one(), 2);
-    /// let arc_2 = Arc::new(1, 2, BooleanWeight::zero(), 3);
+    /// # use rustfst::semirings::{Semiring, TropicalWeight};
+    /// let mut arc_1 = Arc::<TropicalWeight>::new(0, 1, 1.3, 2);
+    /// let arc_2 = Arc::new(1, 2, 1.2, 3);
     ///
     /// arc_1.set_value(&arc_2);
     ///

--- a/rustfst/src/fst_impls/const_fst/iterators.rs
+++ b/rustfst/src/fst_impls/const_fst/iterators.rs
@@ -138,7 +138,7 @@ mod tests {
         fst.add_arc(s2, arc_2_3.clone())?;
         fst.add_arc(s2, arc_2_3_bis.clone())?;
 
-        let const_fst: ConstFst<_> = fst.into();
+        let const_fst: ConstFst<ProbabilityWeight> = fst.into();
 
         let states = const_fst
             .states_index_iter()
@@ -172,7 +172,7 @@ mod tests {
         fst.add_arc(s2, arc_2_3.clone())?;
         fst.add_arc(s2, arc_2_3_bis.clone())?;
 
-        let const_fst: ConstFst<_> = fst.into();
+        let const_fst: ConstFst<ProbabilityWeight> = fst.into();
 
         let mut arcs_ref = vec![];
         for state_index in const_fst.states_index_iter() {

--- a/rustfst/src/fst_impls/vector_fst/iterators.rs
+++ b/rustfst/src/fst_impls/vector_fst/iterators.rs
@@ -147,11 +147,11 @@ mod tests {
     use super::*;
 
     use crate::fst_traits::MutableFst;
-    use crate::semirings::{ProbabilityWeight, Semiring};
+    use crate::semirings::ProbabilityWeight;
 
     #[test]
     fn test_states_index_iterator() -> Fallible<()> {
-        let mut fst = VectorFst::new();
+        let mut fst = VectorFst::<ProbabilityWeight>::new();
 
         // States
         let s1 = fst.add_state();
@@ -161,11 +161,11 @@ mod tests {
         fst.set_start(s1)?;
 
         // Arcs
-        let arc_1_2 = Arc::new(0, 0, ProbabilityWeight::new(1.0), s2);
-        let arc_1_2_bis = Arc::new(0, 0, ProbabilityWeight::new(1.0), s2);
+        let arc_1_2 = Arc::new(0, 0, 1.0, s2);
+        let arc_1_2_bis = Arc::new(0, 0, 1.0, s2);
 
-        let arc_2_3 = Arc::new(0, 0, ProbabilityWeight::new(1.0), s3);
-        let arc_2_3_bis = Arc::new(0, 0, ProbabilityWeight::new(1.0), s3);
+        let arc_2_3 = Arc::new(0, 0, 1.0, s3);
+        let arc_2_3_bis = Arc::new(0, 0, 1.0, s3);
 
         fst.add_arc(s1, arc_1_2.clone())?;
         fst.add_arc(s1, arc_1_2_bis.clone())?;
@@ -183,7 +183,7 @@ mod tests {
 
     #[test]
     fn test_arcs_index_iterator() -> Fallible<()> {
-        let mut fst = VectorFst::new();
+        let mut fst = VectorFst::<ProbabilityWeight>::new();
 
         // States
         let s1 = fst.add_state();
@@ -193,11 +193,11 @@ mod tests {
         fst.set_start(s1)?;
 
         // Arcs
-        let arc_1_2 = Arc::new(0, 0, ProbabilityWeight::new(1.0), s2);
-        let arc_1_2_bis = Arc::new(0, 0, ProbabilityWeight::new(1.0), s2);
+        let arc_1_2 = Arc::new(0, 0, 1.0, s2);
+        let arc_1_2_bis = Arc::new(0, 0, 1.0, s2);
 
-        let arc_2_3 = Arc::new(0, 0, ProbabilityWeight::new(1.0), s3);
-        let arc_2_3_bis = Arc::new(0, 0, ProbabilityWeight::new(1.0), s3);
+        let arc_2_3 = Arc::new(0, 0, 1.0, s3);
+        let arc_2_3_bis = Arc::new(0, 0, 1.0, s3);
 
         fst.add_arc(s1, arc_1_2.clone())?;
         fst.add_arc(s1, arc_1_2_bis.clone())?;
@@ -221,7 +221,7 @@ mod tests {
 
     #[test]
     fn test_arcs_index_iterator_with_modify() -> Fallible<()> {
-        let mut fst = VectorFst::new();
+        let mut fst = VectorFst::<ProbabilityWeight>::new();
 
         // States
         let s1 = fst.add_state();
@@ -231,11 +231,11 @@ mod tests {
         fst.set_start(s1)?;
 
         // Arcs
-        let arc_1_2 = Arc::new(0, 0, ProbabilityWeight::new(1.0), s2);
-        let arc_1_2_bis = Arc::new(0, 0, ProbabilityWeight::new(1.0), s2);
+        let arc_1_2 = Arc::new(0, 0, 1.0, s2);
+        let arc_1_2_bis = Arc::new(0, 0, 1.0, s2);
 
-        let arc_2_3 = Arc::new(0, 0, ProbabilityWeight::new(1.0), s3);
-        let arc_2_3_bis = Arc::new(0, 0, ProbabilityWeight::new(1.0), s3);
+        let arc_2_3 = Arc::new(0, 0, 1.0, s3);
+        let arc_2_3_bis = Arc::new(0, 0, 1.0, s3);
 
         fst.add_arc(s1, arc_1_2.clone())?;
         fst.add_arc(s1, arc_1_2_bis.clone())?;

--- a/rustfst/src/fst_impls/vector_fst/mutable_fst.rs
+++ b/rustfst/src/fst_impls/vector_fst/mutable_fst.rs
@@ -41,17 +41,17 @@ impl<W: 'static + Semiring> MutableFst for VectorFst<W> {
         self.start_state = Some(state_id);
     }
 
-    fn set_final(&mut self, state_id: StateId, final_weight: W) -> Fallible<()> {
+    fn set_final<S: Into<W>>(&mut self, state_id: StateId, final_weight: S) -> Fallible<()> {
         if let Some(state) = self.states.get_mut(state_id) {
-            state.final_weight = Some(final_weight);
+            state.final_weight = Some(final_weight.into());
             Ok(())
         } else {
             bail!("Stateid {:?} doesn't exist", state_id);
         }
     }
 
-    unsafe fn set_final_unchecked(&mut self, state_id: usize, final_weight: Self::W) {
-        self.states.get_unchecked_mut(state_id).final_weight = Some(final_weight);
+    unsafe fn set_final_unchecked<S: Into<W>>(&mut self, state_id: usize, final_weight: S) {
+        self.states.get_unchecked_mut(state_id).final_weight = Some(final_weight.into());
     }
 
     fn add_state(&mut self) -> StateId {
@@ -263,3 +263,9 @@ impl<W: 'static + Semiring> MutableFst for VectorFst<W> {
         self.osymt.take()
     }
 }
+
+//#[test]
+//fn lol() {
+//    let mut fst = VectorFst::<crate::semirings::TropicalWeight>::new();
+//    fst.set_final(0, 1.0).unwrap();
+//}

--- a/rustfst/src/fst_impls/vector_fst/test.rs
+++ b/rustfst/src/fst_impls/vector_fst/test.rs
@@ -16,7 +16,7 @@ mod tests {
 
     #[test]
     fn test_small_fst() -> Fallible<()> {
-        let mut fst = VectorFst::new();
+        let mut fst = VectorFst::<ProbabilityWeight>::new();
 
         // States
         let s1 = fst.add_state();
@@ -25,12 +25,12 @@ mod tests {
         fst.set_start(s1)?;
 
         // Arcs
-        let arc_1 = Arc::new(3, 5, ProbabilityWeight::new(10.0), s2);
+        let arc_1 = Arc::new(3, 5, 10.0, s2);
         fst.add_arc(s1, arc_1.clone())?;
 
         assert_eq!(fst.num_arcs(s1).unwrap(), 1);
 
-        let arc_2 = Arc::new(5, 7, ProbabilityWeight::new(18.0), s2);
+        let arc_2 = Arc::new(5, 7, 18.0, s2);
         fst.add_arc(s1, arc_2.clone())?;
         assert_eq!(fst.num_arcs(s1).unwrap(), 2);
         assert_eq!(fst.arcs_iter(s1)?.count(), 2);
@@ -57,7 +57,7 @@ mod tests {
 
     #[test]
     fn test_mutable_iter_arcs_small() -> Fallible<()> {
-        let mut fst = VectorFst::new();
+        let mut fst = VectorFst::<ProbabilityWeight>::new();
 
         // States
         let s1 = fst.add_state();
@@ -66,12 +66,12 @@ mod tests {
         fst.set_start(s1)?;
 
         // Arcs
-        let arc_1 = Arc::new(3, 5, ProbabilityWeight::new(10.0), s2);
+        let arc_1 = Arc::new(3, 5, 10.0, s2);
         fst.add_arc(s1, arc_1.clone())?;
-        let arc_2 = Arc::new(5, 7, ProbabilityWeight::new(18.0), s2);
+        let arc_2 = Arc::new(5, 7, 18.0, s2);
         fst.add_arc(s1, arc_2.clone())?;
 
-        let new_arc_1 = Arc::new(15, 29, ProbabilityWeight::new(33.0), s2 + 55);
+        let new_arc_1 = Arc::new(15, 29, 33.0, s2 + 55);
 
         // Modify first arc leaving s1
         fst.arcs_iter_mut(s1)?

--- a/rustfst/src/fst_traits/fst.rs
+++ b/rustfst/src/fst_traits/fst.rs
@@ -124,7 +124,7 @@ pub trait Fst:
     /// # use rustfst::semirings::{Semiring, IntegerWeight};
     /// # use rustfst::EPS_LABEL;
     /// # use rustfst::Arc;
-    /// let mut fst = VectorFst::new();
+    /// let mut fst = VectorFst::<IntegerWeight>::new();
     /// let s0 = fst.add_state();
     /// let s1 = fst.add_state();
     ///
@@ -151,7 +151,7 @@ pub trait Fst:
     /// # use rustfst::semirings::{Semiring, IntegerWeight};
     /// # use rustfst::EPS_LABEL;
     /// # use rustfst::Arc;
-    /// let mut fst = VectorFst::new();
+    /// let mut fst = VectorFst::<IntegerWeight>::new();
     /// let s0 = fst.add_state();
     /// let s1 = fst.add_state();
     ///

--- a/rustfst/src/fst_traits/mutable_fst.rs
+++ b/rustfst/src/fst_traits/mutable_fst.rs
@@ -6,8 +6,8 @@ use failure::Fallible;
 use crate::algorithms::{ArcMapper, ClosureType};
 use crate::arc::Arc;
 use crate::fst_traits::{CoreFst, ExpandedFst};
-use crate::StateId;
 use crate::symbol_table::SymbolTable;
+use crate::StateId;
 
 /// Trait defining the methods to modify a wFST.
 pub trait MutableFst: ExpandedFst + for<'a> MutableArcIterator<'a> {

--- a/rustfst/src/fst_traits/mutable_fst.rs
+++ b/rustfst/src/fst_traits/mutable_fst.rs
@@ -6,12 +6,12 @@ use failure::Fallible;
 
 use crate::algorithms::{ArcMapper, ClosureType};
 use crate::arc::Arc;
-use crate::fst_traits::{CoreFst, ExpandedFst, Fst};
+use crate::fst_traits::{CoreFst, ExpandedFst};
 use crate::symbol_table::SymbolTable;
 use crate::StateId;
 
 /// Trait defining the methods to modify a wFST.
-pub trait MutableFst: Fst + for<'a> MutableArcIterator<'a> {
+pub trait MutableFst: ExpandedFst + for<'a> MutableArcIterator<'a> {
     /// Creates an empty wFST.
     fn new() -> Self;
 

--- a/rustfst/src/fst_traits/mutable_fst.rs
+++ b/rustfst/src/fst_traits/mutable_fst.rs
@@ -1,5 +1,4 @@
 use std::cmp::Ordering;
-use std::collections::HashMap;
 use std::rc::Rc;
 
 use failure::Fallible;
@@ -7,8 +6,8 @@ use failure::Fallible;
 use crate::algorithms::{ArcMapper, ClosureType};
 use crate::arc::Arc;
 use crate::fst_traits::{CoreFst, ExpandedFst};
-use crate::symbol_table::SymbolTable;
 use crate::StateId;
+use crate::symbol_table::SymbolTable;
 
 /// Trait defining the methods to modify a wFST.
 pub trait MutableFst: ExpandedFst + for<'a> MutableArcIterator<'a> {
@@ -229,38 +228,6 @@ pub trait MutableFst: ExpandedFst + for<'a> MutableArcIterator<'a> {
     unsafe fn unique_arcs_unchecked(&mut self, state: StateId);
 
     unsafe fn sum_arcs_unchecked(&mut self, state: StateId);
-
-    // TODO: Remove
-    fn add_fst<F: ExpandedFst<W = Self::W>>(
-        &mut self,
-        fst_to_add: &F,
-    ) -> Fallible<HashMap<StateId, StateId>> {
-        // Map old states id to new ones
-        let mut mapping_states = HashMap::new();
-
-        // First pass to add the necessary states
-        for old_state_id in fst_to_add.states_iter() {
-            let new_state_id = self.add_state();
-            mapping_states.insert(old_state_id, new_state_id);
-        }
-
-        // Second pass to add the arcs
-        for old_state_id in fst_to_add.states_iter() {
-            for old_arc in fst_to_add.arcs_iter(old_state_id)? {
-                self.add_arc(
-                    mapping_states[&old_state_id],
-                    Arc::new(
-                        old_arc.ilabel,
-                        old_arc.olabel,
-                        old_arc.weight.clone(),
-                        mapping_states[&old_arc.nextstate],
-                    ),
-                )?;
-            }
-        }
-
-        Ok(mapping_states)
-    }
 
     /// This operation computes the concatenative closure.
     /// If A transduces string `x` to `y` with weight `a`,

--- a/rustfst/src/fst_traits/mutable_fst.rs
+++ b/rustfst/src/fst_traits/mutable_fst.rs
@@ -63,8 +63,8 @@ pub trait MutableFst: Fst + for<'a> MutableArcIterator<'a> {
     /// assert_eq!(fst.final_weight(s1).unwrap(), Some(&BooleanWeight::one()));
     /// assert_eq!(fst.final_weight(s2).unwrap(), Some(&BooleanWeight::one()));
     /// ```
-    fn set_final(&mut self, state_id: StateId, final_weight: <Self as CoreFst>::W) -> Fallible<()>;
-    unsafe fn set_final_unchecked(&mut self, state_id: StateId, final_weight: <Self as CoreFst>::W);
+    fn set_final<S: Into<Self::W>>(&mut self, state_id: StateId, final_weight: S) -> Fallible<()>;
+    unsafe fn set_final_unchecked<S: Into<Self::W>>(&mut self, state_id: StateId, final_weight: S);
 
     /// Adds a new state to the current FST. The identifier of the new state is returned
     ///
@@ -193,10 +193,10 @@ pub trait MutableFst: Fst + for<'a> MutableArcIterator<'a> {
     /// fst.add_arc(s1, Arc::new(3, 5, BooleanWeight::new(true), s2));
     /// assert_eq!(fst.num_arcs(s1).unwrap(), 1);
     /// ```
-    fn add_arc(&mut self, source: StateId, arc: Arc<<Self as CoreFst>::W>) -> Fallible<()>;
-    unsafe fn add_arc_unchecked(&mut self, source: StateId, arc: Arc<<Self as CoreFst>::W>);
+    fn add_arc(&mut self, source: StateId, arc: Arc<Self::W>) -> Fallible<()>;
+    unsafe fn add_arc_unchecked(&mut self, source: StateId, arc: Arc<Self::W>);
 
-    unsafe fn set_arcs_unchecked(&mut self, source: StateId, arcs: Vec<Arc<<Self as CoreFst>::W>>);
+    unsafe fn set_arcs_unchecked(&mut self, source: StateId, arcs: Vec<Arc<Self::W>>);
 
     /// Remove the final weight of a specific state.
     fn delete_final_weight(&mut self, source: StateId) -> Fallible<()>;
@@ -230,6 +230,7 @@ pub trait MutableFst: Fst + for<'a> MutableArcIterator<'a> {
 
     unsafe fn sum_arcs_unchecked(&mut self, state: StateId);
 
+    // TODO: Remove
     fn add_fst<F: ExpandedFst<W = Self::W>>(
         &mut self,
         fst_to_add: &F,

--- a/rustfst/src/lib.rs
+++ b/rustfst/src/lib.rs
@@ -36,7 +36,7 @@
 //!
 //! fn main() -> Fallible<()> {
 //!     // Creates a empty wFST
-//!     let mut fst = VectorFst::new();
+//!     let mut fst = VectorFst::<TropicalWeight>::new();
 //!
 //!     // Add some states
 //!     let s0 = fst.add_state();
@@ -47,14 +47,14 @@
 //!     fst.set_start(s0)?;
 //!
 //!     // Add an arc from s0 to s1
-//!     fst.add_arc(s0, Arc::new(3, 5, TropicalWeight::new(10.0), s1))?;
+//!     fst.add_arc(s0, Arc::new(3, 5, 10.0, s1))?;
 //!
 //!     // Add an arc from s0 to s2
-//!     fst.add_arc(s0, Arc::new(5, 7, TropicalWeight::new(18.0), s2))?;
+//!     fst.add_arc(s0, Arc::new(5, 7, 18.0, s2))?;
 //!
 //!     // Set s1 and s2 as final states
-//!     fst.set_final(s1, TropicalWeight::new(31.0))?;
-//!     fst.set_final(s2, TropicalWeight::new(45.0))?;
+//!     fst.set_final(s1, 31.0)?;
+//!     fst.set_final(s2, 45.0)?;
 //!
 //!     // Iter over all the paths in the wFST
 //!     for p in fst.paths_iter() {

--- a/rustfst/src/semirings/boolean_weight.rs
+++ b/rustfst/src/semirings/boolean_weight.rs
@@ -67,6 +67,12 @@ impl StarSemiring for BooleanWeight {
     }
 }
 
+impl Into<BooleanWeight> for bool {
+    fn into(self) -> BooleanWeight {
+        BooleanWeight::new(self)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rustfst/src/semirings/integer_weight.rs
+++ b/rustfst/src/semirings/integer_weight.rs
@@ -77,3 +77,9 @@ impl StarSemiring for IntegerWeight {
         Self::new(i32::max_value())
     }
 }
+
+impl Into<IntegerWeight> for i32 {
+    fn into(self) -> IntegerWeight {
+        IntegerWeight::new(self)
+    }
+}

--- a/rustfst/src/semirings/log_weight.rs
+++ b/rustfst/src/semirings/log_weight.rs
@@ -153,3 +153,9 @@ test_semiring_serializable!(
     LogWeight,
     LogWeight::new(0.3) LogWeight::new(0.5) LogWeight::new(0.0) LogWeight::new(-1.2)
 );
+
+impl Into<LogWeight> for f32 {
+    fn into(self) -> LogWeight {
+        LogWeight::new(self)
+    }
+}

--- a/rustfst/src/semirings/probability_weight.rs
+++ b/rustfst/src/semirings/probability_weight.rs
@@ -101,3 +101,9 @@ impl WeaklyDivisibleSemiring for ProbabilityWeight {
 impl_quantize_f32!(ProbabilityWeight);
 
 partial_eq_and_hash_f32!(ProbabilityWeight);
+
+impl Into<ProbabilityWeight> for f32 {
+    fn into(self) -> ProbabilityWeight {
+        ProbabilityWeight::new(self)
+    }
+}

--- a/rustfst/src/semirings/tropical_weight.rs
+++ b/rustfst/src/semirings/tropical_weight.rs
@@ -144,3 +144,9 @@ test_semiring_serializable!(
     TropicalWeight,
     TropicalWeight::one() TropicalWeight::zero() TropicalWeight::new(0.3) TropicalWeight::new(0.5) TropicalWeight::new(0.0) TropicalWeight::new(-1.2)
 );
+
+impl Into<TropicalWeight> for f32 {
+    fn into(self) -> TropicalWeight {
+        TropicalWeight::new(self)
+    }
+}


### PR DESCRIPTION
- Change parameter from `W` to `Into<W>` for `add_arc`, `set_final_unchecked` and `set_final` methods.
- `MutableFst` now has a trait bound on `ExpandedFst`.
- Refactor tests
- Add images in doc for closure and invert