### PR TITLE
RmEpsilon revamp : Dynamic version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `union` -> `UnionFst`
     - `concat` -> `ConcatFst`
     - `closure` -> `ClosureFst`
+    - `rmepsilon` -> `RmEpsilonFst`
 - Added `delete_final_weight_unchecked` to the `Fst` trait and implement it for `VectorFst`.
 - Added `SerializableSemiring` trait and implement it for most `Semiring`s.
 - All `Fst` that implements `SerializableFst` with a `Semiring` implementing `SerializableSemiring` can now be serialized/deserialized consistently with OpenFst.
@@ -55,6 +56,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `MutableFst` now has a trait bound on `ExpandedFst`.
 - `DrawingConfig` parameters `size`, `ranksep` and `nodesep` are now optional.
 - Fix SymbolTable conservation for `Reverse` and `ShortestPath`.
+- `RmEpsilon` now mutates its input.
+- `dfs_visit` now accepts an `ArcFilter` to be able to skip some arcs.
+- `AutoQueue` and `TopOrderQueue` now take an `ArcFilter` in input.
+- Remove `Fst` trait bound on `Clone` and `PartialEq`. However this is mandatory to be an `ExpandedFst`.
+- `rmepsilon` no longer requires the `Semiring` to be a `StarSemiring`.
+- Revamped RmEpsilon and ShortestDistance implementations in order to be closer to OpenFst's one.
 
 ## [0.4.0] - 2019-11-12
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ fn main() -> Fallible<()> {
     project(&mut fst, ProjectType::ProjectInput);
 
     // - Remove epsilon transitions.
-    fst = rm_epsilon(&fst)?;
+    rm_epsilon(&mut fst)?;
 
     // - Compute an equivalent FST but deterministic.
     fst = determinize(&fst, DeterminizeType::DeterminizeFunctional)?;

--- a/rustfst-tests-data/main.cpp
+++ b/rustfst-tests-data/main.cpp
@@ -81,7 +81,7 @@ template<class F>
 void compute_fst_remove_epsilon(const F& raw_fst, json& j) {
     auto fst_out = *raw_fst.Copy();
     // Connect = false
-    fst::RmEpsilon(&fst_out, false);
+    fst::RmEpsilon(&fst_out);
     j["rmepsilon"]["result"] = fst_to_string(fst_out);
 }
 

--- a/rustfst-tests-data/main.cpp
+++ b/rustfst-tests-data/main.cpp
@@ -79,10 +79,16 @@ void compute_fst_reverse(const F& raw_fst, json& j) {
 
 template<class F>
 void compute_fst_remove_epsilon(const F& raw_fst, json& j) {
+    using Arc = typename F::Arc;
     auto fst_out = *raw_fst.Copy();
-    // Connect = false
+
+    auto dyn_rmeps = fst::VectorFst<Arc>(fst::RmEpsilonFst<Arc>(raw_fst));
+
     fst::RmEpsilon(&fst_out);
-    j["rmepsilon"]["result"] = fst_to_string(fst_out);
+    j["rmepsilon"]["result_static"] = fst_to_string(fst_out);
+    j["rmepsilon"]["result_dynamic"] = fst_to_string(dyn_rmeps);
+
+
 }
 
 template<class F>

--- a/rustfst/src/algorithms/arc_filters.rs
+++ b/rustfst/src/algorithms/arc_filters.rs
@@ -3,12 +3,13 @@ use crate::Arc;
 use crate::EPS_LABEL;
 
 /// Base trait to restrict which arcs are traversed in an FST.
-pub trait ArcFilter<S: Semiring> {
+pub trait ArcFilter<S: Semiring> : Clone {
     /// If true, Arc should be kept, else Arc should be ignored.
     fn keep(&self, arc: &Arc<S>) -> bool;
 }
 
 /// True for all arcs.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AnyArcFilter {}
 
 impl<S: Semiring> ArcFilter<S> for AnyArcFilter {
@@ -18,6 +19,7 @@ impl<S: Semiring> ArcFilter<S> for AnyArcFilter {
 }
 
 /// True for (input/output) epsilon arcs.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct EpsilonArcFilter {}
 
 impl<S: Semiring> ArcFilter<S> for EpsilonArcFilter {
@@ -27,6 +29,7 @@ impl<S: Semiring> ArcFilter<S> for EpsilonArcFilter {
 }
 
 /// True for input epsilon arcs.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct InputEpsilonArcFilter {}
 
 impl<S: Semiring> ArcFilter<S> for InputEpsilonArcFilter {
@@ -36,6 +39,7 @@ impl<S: Semiring> ArcFilter<S> for InputEpsilonArcFilter {
 }
 
 /// True for output epsilon arcs.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct OutputEpsilonArcFilter {}
 
 impl<S: Semiring> ArcFilter<S> for OutputEpsilonArcFilter {

--- a/rustfst/src/algorithms/arc_filters.rs
+++ b/rustfst/src/algorithms/arc_filters.rs
@@ -3,7 +3,7 @@ use crate::Arc;
 use crate::EPS_LABEL;
 
 /// Base trait to restrict which arcs are traversed in an FST.
-pub trait ArcFilter<S: Semiring> : Clone {
+pub trait ArcFilter<S: Semiring>: Clone {
     /// If true, Arc should be kept, else Arc should be ignored.
     fn keep(&self, arc: &Arc<S>) -> bool;
 }

--- a/rustfst/src/algorithms/closure.rs
+++ b/rustfst/src/algorithms/closure.rs
@@ -74,7 +74,7 @@ where
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct ClosureFst<F: Fst + 'static>(ReplaceFst<F, F>)
 where
     F::W: 'static;

--- a/rustfst/src/algorithms/connect.rs
+++ b/rustfst/src/algorithms/connect.rs
@@ -7,6 +7,7 @@ use crate::fst_traits::{CoreFst, ExpandedFst, MutableFst};
 use crate::Arc;
 use crate::StateId;
 use crate::NO_STATE_ID;
+use crate::algorithms::arc_filters::AnyArcFilter;
 
 /// This operation trims an FST, removing states and arcs that are not on successful paths.
 ///
@@ -46,7 +47,7 @@ use crate::NO_STATE_ID;
 ///
 pub fn connect<F: ExpandedFst + MutableFst>(fst: &mut F) -> Fallible<()> {
     let mut visitor = ConnectVisitor::new(fst);
-    dfs_visit(fst, &mut visitor, false);
+    dfs_visit(fst, &mut visitor, AnyArcFilter{}, false);
     let mut dstates = Vec::with_capacity(visitor.access.len());
     for s in 0..visitor.access.len() {
         if !visitor.access[s] || !visitor.coaccess[s] {

--- a/rustfst/src/algorithms/connect.rs
+++ b/rustfst/src/algorithms/connect.rs
@@ -1,13 +1,13 @@
 use failure::Fallible;
 use unsafe_unwrap::UnsafeUnwrap;
 
+use crate::algorithms::arc_filters::AnyArcFilter;
 use crate::algorithms::dfs_visit::{dfs_visit, Visitor};
 use crate::fst_traits::Fst;
 use crate::fst_traits::{CoreFst, ExpandedFst, MutableFst};
 use crate::Arc;
 use crate::StateId;
 use crate::NO_STATE_ID;
-use crate::algorithms::arc_filters::AnyArcFilter;
 
 /// This operation trims an FST, removing states and arcs that are not on successful paths.
 ///
@@ -47,7 +47,7 @@ use crate::algorithms::arc_filters::AnyArcFilter;
 ///
 pub fn connect<F: ExpandedFst + MutableFst>(fst: &mut F) -> Fallible<()> {
     let mut visitor = ConnectVisitor::new(fst);
-    dfs_visit(fst, &mut visitor, AnyArcFilter{}, false);
+    dfs_visit(fst, &mut visitor, &AnyArcFilter {}, false);
     let mut dstates = Vec::with_capacity(visitor.access.len());
     for s in 0..visitor.access.len() {
         if !visitor.access[s] || !visitor.coaccess[s] {

--- a/rustfst/src/algorithms/dfs_visit.rs
+++ b/rustfst/src/algorithms/dfs_visit.rs
@@ -3,9 +3,8 @@ use crate::fst_traits::{ArcIterator, ExpandedFst, Fst};
 use crate::semirings::Semiring;
 use crate::StateId;
 
-use unsafe_unwrap::UnsafeUnwrap;
 use crate::algorithms::arc_filters::ArcFilter;
-use failure::_core::borrow::Borrow;
+use unsafe_unwrap::UnsafeUnwrap;
 
 #[derive(PartialOrd, PartialEq, Copy, Clone)]
 enum DfsStateColor {
@@ -92,13 +91,12 @@ impl<I: Iterator> OpenFstIterator<I> {
     }
 }
 
-pub fn dfs_visit<'a, F: Fst + ExpandedFst, V: Visitor<'a, F>, A: ArcFilter<F::W>, B: Borrow<A>>(
+pub fn dfs_visit<'a, F: Fst + ExpandedFst, V: Visitor<'a, F>, A: ArcFilter<F::W>>(
     fst: &'a F,
     visitor: &mut V,
-    arc_filter: B,
+    arc_filter: &A,
     access_only: bool,
 ) {
-    let arc_filter = arc_filter.borrow();
     visitor.init_visit(fst);
     let start = fst.start();
     if start.is_none() {

--- a/rustfst/src/algorithms/dynamic_fst.rs
+++ b/rustfst/src/algorithms/dynamic_fst.rs
@@ -20,18 +20,6 @@ macro_rules! dynamic_fst {
             }
         }
 
-//        impl<$($a: $b $( < $c >)? ),*> PartialEq for $dyn_fst {
-//            fn eq(&self, other: &Self) -> bool {
-//                let ptr = self.fst_impl.get();
-//                let fst_impl = unsafe { ptr.as_ref().unwrap() };
-//
-//                let ptr_other = other.fst_impl.get();
-//                let fst_impl_other = unsafe { ptr_other.as_ref().unwrap() };
-//
-//                fst_impl.eq(fst_impl_other)
-//            }
-//        }
-
         impl<$($a: $b $( < $c >)? ),*> std::fmt::Debug for $dyn_fst
         where
             $($d: $e,)?
@@ -43,23 +31,6 @@ macro_rules! dynamic_fst {
                 write!(f, "{:?} {{ {:?} }}", $name, &fst_impl)
             }
         }
-
-//        impl<$($a: $b $( < $c >)? ),*> Clone for $dyn_fst
-//        where
-//            $($d: $e,)?
-//            F::W: 'static,
-//            $($a : 'static),*
-//        {
-//            fn clone(&self) -> Self {
-//                let ptr = self.fst_impl.get();
-//                let fst_impl = unsafe { ptr.as_ref().unwrap() };
-//                Self {
-//                    fst_impl: UnsafeCell::new(fst_impl.clone()),
-//                    isymt: self.input_symbols(),
-//                    osymt: self.output_symbols(),
-//                }
-//            }
-//        }
 
         impl<$($a: $b $( < $c >)? ),*> CoreFst for $dyn_fst
         where

--- a/rustfst/src/algorithms/dynamic_fst.rs
+++ b/rustfst/src/algorithms/dynamic_fst.rs
@@ -20,17 +20,17 @@ macro_rules! dynamic_fst {
             }
         }
 
-        impl<$($a: $b $( < $c >)? ),*> PartialEq for $dyn_fst {
-            fn eq(&self, other: &Self) -> bool {
-                let ptr = self.fst_impl.get();
-                let fst_impl = unsafe { ptr.as_ref().unwrap() };
-
-                let ptr_other = other.fst_impl.get();
-                let fst_impl_other = unsafe { ptr_other.as_ref().unwrap() };
-
-                fst_impl.eq(fst_impl_other)
-            }
-        }
+//        impl<$($a: $b $( < $c >)? ),*> PartialEq for $dyn_fst {
+//            fn eq(&self, other: &Self) -> bool {
+//                let ptr = self.fst_impl.get();
+//                let fst_impl = unsafe { ptr.as_ref().unwrap() };
+//
+//                let ptr_other = other.fst_impl.get();
+//                let fst_impl_other = unsafe { ptr_other.as_ref().unwrap() };
+//
+//                fst_impl.eq(fst_impl_other)
+//            }
+//        }
 
         impl<$($a: $b $( < $c >)? ),*> std::fmt::Debug for $dyn_fst
         where
@@ -44,22 +44,22 @@ macro_rules! dynamic_fst {
             }
         }
 
-        impl<$($a: $b $( < $c >)? ),*> Clone for $dyn_fst
-        where
-            $($d: $e,)?
-            F::W: 'static,
-            $($a : 'static),*
-        {
-            fn clone(&self) -> Self {
-                let ptr = self.fst_impl.get();
-                let fst_impl = unsafe { ptr.as_ref().unwrap() };
-                Self {
-                    fst_impl: UnsafeCell::new(fst_impl.clone()),
-                    isymt: self.input_symbols(),
-                    osymt: self.output_symbols(),
-                }
-            }
-        }
+//        impl<$($a: $b $( < $c >)? ),*> Clone for $dyn_fst
+//        where
+//            $($d: $e,)?
+//            F::W: 'static,
+//            $($a : 'static),*
+//        {
+//            fn clone(&self) -> Self {
+//                let ptr = self.fst_impl.get();
+//                let fst_impl = unsafe { ptr.as_ref().unwrap() };
+//                Self {
+//                    fst_impl: UnsafeCell::new(fst_impl.clone()),
+//                    isymt: self.input_symbols(),
+//                    osymt: self.output_symbols(),
+//                }
+//            }
+//        }
 
         impl<$($a: $b $( < $c >)? ),*> CoreFst for $dyn_fst
         where

--- a/rustfst/src/algorithms/mod.rs
+++ b/rustfst/src/algorithms/mod.rs
@@ -82,7 +82,7 @@ pub use self::{
     replace::{replace, BorrowFst, ReplaceFst},
     reverse::reverse,
     reweight::{reweight, ReweightType},
-    rm_epsilon::rm_epsilon,
+    rm_epsilon::{rm_epsilon, RmEpsilonFst},
     rm_final_epsilon::rm_final_epsilon,
     shortest_distance::shortest_distance,
     shortest_path::shortest_path,

--- a/rustfst/src/algorithms/mod.rs
+++ b/rustfst/src/algorithms/mod.rs
@@ -84,7 +84,7 @@ pub use self::{
     reweight::{reweight, ReweightType},
     rm_epsilon::rm_epsilon,
     rm_final_epsilon::rm_final_epsilon,
-    shortest_distance::{shortest_distance, single_source_shortest_distance},
+    shortest_distance::shortest_distance,
     shortest_path::shortest_path,
     state_sort::state_sort,
     top_sort::top_sort,

--- a/rustfst/src/algorithms/push.rs
+++ b/rustfst/src/algorithms/push.rs
@@ -39,7 +39,7 @@ pub fn push_weights<F>(
 ) -> Fallible<()>
 where
     F: MutableFst,
-    F::W: WeaklyDivisibleSemiring,
+    F::W: WeaklyDivisibleSemiring + 'static,
     <<F as CoreFst>::W as Semiring>::ReverseWeight: 'static,
 {
     let dist = shortest_distance(fst, reweight_type == ReweightType::ReweightToInitial)?;

--- a/rustfst/src/algorithms/queues/auto_queue.rs
+++ b/rustfst/src/algorithms/queues/auto_queue.rs
@@ -18,6 +18,13 @@ pub struct AutoQueue {
     queue: Box<dyn Queue>,
 }
 
+//impl Clone for AutoQueue {
+//    fn clone(&self) -> Self {
+//        self.queue.
+//        unimplemented!()
+//    }
+//}
+
 impl AutoQueue {
     pub fn new<F: MutableFst + ExpandedFst, A: ArcFilter<F::W>>(
         fst: &F,

--- a/rustfst/src/algorithms/queues/auto_queue.rs
+++ b/rustfst/src/algorithms/queues/auto_queue.rs
@@ -18,13 +18,6 @@ pub struct AutoQueue {
     queue: Box<dyn Queue>,
 }
 
-//impl Clone for AutoQueue {
-//    fn clone(&self) -> Self {
-//        self.queue.
-//        unimplemented!()
-//    }
-//}
-
 impl AutoQueue {
     pub fn new<F: MutableFst + ExpandedFst, A: ArcFilter<F::W>>(
         fst: &F,

--- a/rustfst/src/algorithms/queues/auto_queue.rs
+++ b/rustfst/src/algorithms/queues/auto_queue.rs
@@ -11,6 +11,7 @@ use super::{
     natural_less, FifoQueue, LifoQueue, NaturalShortestFirstQueue, SccQueue, StateOrderQueue,
     TopOrderQueue, TrivialQueue,
 };
+use crate::algorithms::arc_filters::ArcFilter;
 
 #[derive(Debug)]
 pub struct AutoQueue {
@@ -18,7 +19,7 @@ pub struct AutoQueue {
 }
 
 impl AutoQueue {
-    pub fn new<F: MutableFst + ExpandedFst>(fst: &F, distance: Option<&Vec<F::W>>) -> Fallible<Self>
+    pub fn new<F: MutableFst + ExpandedFst, A: ArcFilter<F::W>>(fst: &F, distance: Option<&Vec<F::W>>, arc_filter: &A) -> Fallible<Self>
     where
         F::W: 'static,
     {
@@ -29,14 +30,14 @@ impl AutoQueue {
         if props.contains(FstProperties::TOP_SORTED) || fst.start().is_none() {
             queue = Box::new(StateOrderQueue::default());
         } else if props.contains(FstProperties::ACYCLIC) {
-            queue = Box::new(TopOrderQueue::new(fst));
+            queue = Box::new(TopOrderQueue::new(fst, arc_filter));
         } else if props.contains(FstProperties::UNWEIGHTED)
             && F::W::properties().contains(SemiringProperties::IDEMPOTENT)
         {
             queue = Box::new(LifoQueue::default());
         } else {
             let mut scc_visitor = SccVisitor::new(fst, true, false);
-            dfs_visit(fst, &mut scc_visitor, false);
+            dfs_visit(fst, &mut scc_visitor, arc_filter, false);
             let sccs: Vec<_> = scc_visitor
                 .scc
                 .unwrap()
@@ -65,6 +66,7 @@ impl AutoQueue {
                 &mut queue_types,
                 &mut all_trivial,
                 &mut unweighted,
+                arc_filter
             )?;
 
             if unweighted {

--- a/rustfst/src/algorithms/queues/fifo_queue.rs
+++ b/rustfst/src/algorithms/queues/fifo_queue.rs
@@ -4,7 +4,7 @@ use crate::algorithms::{Queue, QueueType};
 use crate::StateId;
 
 /// First-in, first-out (queue) queue discipline.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct FifoQueue(VecDeque<StateId>);
 
 impl Queue for FifoQueue {

--- a/rustfst/src/algorithms/queues/fifo_queue.rs
+++ b/rustfst/src/algorithms/queues/fifo_queue.rs
@@ -4,7 +4,7 @@ use crate::algorithms::{Queue, QueueType};
 use crate::StateId;
 
 /// First-in, first-out (queue) queue discipline.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct FifoQueue(VecDeque<StateId>);
 
 impl Queue for FifoQueue {

--- a/rustfst/src/algorithms/queues/lifo_queue.rs
+++ b/rustfst/src/algorithms/queues/lifo_queue.rs
@@ -2,7 +2,7 @@ use crate::algorithms::{Queue, QueueType};
 use crate::StateId;
 
 /// Last-in, first-out (stack) queue discipline.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct LifoQueue(Vec<StateId>);
 
 impl Queue for LifoQueue {

--- a/rustfst/src/algorithms/queues/shortest_first_queue.rs
+++ b/rustfst/src/algorithms/queues/shortest_first_queue.rs
@@ -30,6 +30,7 @@ pub fn natural_less<W: Semiring>(w1: &W, w2: &W) -> Fallible<bool> {
     Ok((&w1.plus(w2)? == w1) && (w1 != w2))
 }
 
+#[derive(Clone)]
 pub struct ShortestFirstQueue<C: Clone + FnMut(&StateId, &StateId) -> Ordering> {
     heap: BinaryHeap<StateId, FnComparator<C>>,
 }

--- a/rustfst/src/algorithms/queues/state_order_queue.rs
+++ b/rustfst/src/algorithms/queues/state_order_queue.rs
@@ -1,7 +1,7 @@
 use crate::algorithms::{Queue, QueueType};
 use crate::StateId;
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct StateOrderQueue {
     front: StateId,
     back: Option<StateId>,

--- a/rustfst/src/algorithms/queues/top_order_queue.rs
+++ b/rustfst/src/algorithms/queues/top_order_queue.rs
@@ -1,9 +1,9 @@
+use crate::algorithms::arc_filters::ArcFilter;
 use crate::algorithms::dfs_visit::dfs_visit;
 use crate::algorithms::top_sort::TopOrderVisitor;
 use crate::algorithms::{Queue, QueueType};
 use crate::fst_traits::{ExpandedFst, MutableFst};
 use crate::StateId;
-use crate::algorithms::arc_filters::ArcFilter;
 
 /// Topological-order queue discipline, templated on the StateId. States are
 /// ordered in the queue topologically. The FST must be acyclic.
@@ -18,7 +18,7 @@ pub struct TopOrderQueue {
 impl TopOrderQueue {
     pub fn new<F: MutableFst + ExpandedFst, A: ArcFilter<F::W>>(fst: &F, arc_filter: &A) -> Self {
         let mut visitor = TopOrderVisitor::new();
-        dfs_visit(fst, &mut visitor, false, arc_filter);
+        dfs_visit(fst, &mut visitor, arc_filter, false);
         if !visitor.acyclic {
             panic!("Unexpectted Acyclic FST for TopOprerQueue");
         }

--- a/rustfst/src/algorithms/queues/top_order_queue.rs
+++ b/rustfst/src/algorithms/queues/top_order_queue.rs
@@ -7,7 +7,7 @@ use crate::StateId;
 
 /// Topological-order queue discipline, templated on the StateId. States are
 /// ordered in the queue topologically. The FST must be acyclic.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TopOrderQueue {
     order: Vec<StateId>,
     state: Vec<Option<StateId>>,

--- a/rustfst/src/algorithms/queues/top_order_queue.rs
+++ b/rustfst/src/algorithms/queues/top_order_queue.rs
@@ -3,6 +3,7 @@ use crate::algorithms::top_sort::TopOrderVisitor;
 use crate::algorithms::{Queue, QueueType};
 use crate::fst_traits::{ExpandedFst, MutableFst};
 use crate::StateId;
+use crate::algorithms::arc_filters::ArcFilter;
 
 /// Topological-order queue discipline, templated on the StateId. States are
 /// ordered in the queue topologically. The FST must be acyclic.
@@ -15,9 +16,9 @@ pub struct TopOrderQueue {
 }
 
 impl TopOrderQueue {
-    pub fn new<F: MutableFst + ExpandedFst>(fst: &F) -> Self {
+    pub fn new<F: MutableFst + ExpandedFst, A: ArcFilter<F::W>>(fst: &F, arc_filter: &A) -> Self {
         let mut visitor = TopOrderVisitor::new();
-        dfs_visit(fst, &mut visitor, false);
+        dfs_visit(fst, &mut visitor, false, arc_filter);
         if !visitor.acyclic {
             panic!("Unexpectted Acyclic FST for TopOprerQueue");
         }

--- a/rustfst/src/algorithms/queues/trivial_queue.rs
+++ b/rustfst/src/algorithms/queues/trivial_queue.rs
@@ -4,7 +4,7 @@ use crate::StateId;
 /// Trivial queue discipline; one may enqueue at most one state at a time. It
 /// can be used for strongly connected components with only one state and no
 /// self-loops.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct TrivialQueue {
     state: Option<StateId>,
 }

--- a/rustfst/src/algorithms/replace.rs
+++ b/rustfst/src/algorithms/replace.rs
@@ -15,7 +15,7 @@ use crate::fst_traits::{ArcIterator, CoreFst, ExpandedFst, Fst, MutableFst, Stat
 use crate::semirings::Semiring;
 use crate::{Arc, Label, StateId, SymbolTable, EPS_LABEL};
 
-pub trait BorrowFst<F>: Borrow<F> + std::fmt::Debug + PartialEq + Clone {}
+pub trait BorrowFst<F>: Borrow<F> + std::fmt::Debug {}
 
 /// This specifies what labels to output on the call or return arc.
 #[derive(PartialOrd, PartialEq, Copy, Clone, Debug, Eq)]
@@ -468,9 +468,41 @@ pub struct ReplaceFst<F: Fst, B: BorrowFst<F>> {
     pub(crate) osymt: Option<Rc<SymbolTable>>,
 }
 
+        impl<F: Fst + Clone, B: BorrowFst<F> + Clone> Clone for ReplaceFst<F, B>
+        where
+            F: 'static,
+            F::W: 'static,
+            B: 'static
+        {
+            fn clone(&self) -> Self {
+                let ptr = self.fst_impl.get();
+                let fst_impl = unsafe { ptr.as_ref().unwrap() };
+                Self {
+                    fst_impl: UnsafeCell::new(fst_impl.clone()),
+                    isymt: self.input_symbols(),
+                    osymt: self.output_symbols(),
+                }
+            }
+        }
+
+        impl<F: Fst + PartialEq, B: BorrowFst<F> + PartialEq> PartialEq for ReplaceFst<F, B>
+        where F::W: 'static
+        {
+            fn eq(&self, other: &Self) -> bool {
+                let ptr = self.fst_impl.get();
+                let fst_impl = unsafe { ptr.as_ref().unwrap() };
+
+                let ptr_other = other.fst_impl.get();
+                let fst_impl_other = unsafe { ptr_other.as_ref().unwrap() };
+
+                fst_impl.eq(fst_impl_other)
+            }
+        }
+
 impl<F: Fst, B: BorrowFst<F>> ReplaceFst<F, B>
 where
     F::W: 'static,
+    B: 'static
 {
     pub fn new(fst_list: Vec<(Label, B)>, root: Label, epsilon_on_replace: bool) -> Fallible<Self> {
         let mut isymt = None;

--- a/rustfst/src/algorithms/replace.rs
+++ b/rustfst/src/algorithms/replace.rs
@@ -468,41 +468,42 @@ pub struct ReplaceFst<F: Fst, B: BorrowFst<F>> {
     pub(crate) osymt: Option<Rc<SymbolTable>>,
 }
 
-        impl<F: Fst + Clone, B: BorrowFst<F> + Clone> Clone for ReplaceFst<F, B>
-        where
-            F: 'static,
-            F::W: 'static,
-            B: 'static
-        {
-            fn clone(&self) -> Self {
-                let ptr = self.fst_impl.get();
-                let fst_impl = unsafe { ptr.as_ref().unwrap() };
-                Self {
-                    fst_impl: UnsafeCell::new(fst_impl.clone()),
-                    isymt: self.input_symbols(),
-                    osymt: self.output_symbols(),
-                }
-            }
+impl<F: Fst + Clone, B: BorrowFst<F> + Clone> Clone for ReplaceFst<F, B>
+where
+    F: 'static,
+    F::W: 'static,
+    B: 'static,
+{
+    fn clone(&self) -> Self {
+        let ptr = self.fst_impl.get();
+        let fst_impl = unsafe { ptr.as_ref().unwrap() };
+        Self {
+            fst_impl: UnsafeCell::new(fst_impl.clone()),
+            isymt: self.input_symbols(),
+            osymt: self.output_symbols(),
         }
+    }
+}
 
-        impl<F: Fst + PartialEq, B: BorrowFst<F> + PartialEq> PartialEq for ReplaceFst<F, B>
-        where F::W: 'static
-        {
-            fn eq(&self, other: &Self) -> bool {
-                let ptr = self.fst_impl.get();
-                let fst_impl = unsafe { ptr.as_ref().unwrap() };
+impl<F: Fst + PartialEq, B: BorrowFst<F> + PartialEq> PartialEq for ReplaceFst<F, B>
+where
+    F::W: 'static,
+{
+    fn eq(&self, other: &Self) -> bool {
+        let ptr = self.fst_impl.get();
+        let fst_impl = unsafe { ptr.as_ref().unwrap() };
 
-                let ptr_other = other.fst_impl.get();
-                let fst_impl_other = unsafe { ptr_other.as_ref().unwrap() };
+        let ptr_other = other.fst_impl.get();
+        let fst_impl_other = unsafe { ptr_other.as_ref().unwrap() };
 
-                fst_impl.eq(fst_impl_other)
-            }
-        }
+        fst_impl.eq(fst_impl_other)
+    }
+}
 
 impl<F: Fst, B: BorrowFst<F>> ReplaceFst<F, B>
 where
     F::W: 'static,
-    B: 'static
+    B: 'static,
 {
     pub fn new(fst_list: Vec<(Label, B)>, root: Label, epsilon_on_replace: bool) -> Fallible<Self> {
         let mut isymt = None;

--- a/rustfst/src/algorithms/rm_epsilon.rs
+++ b/rustfst/src/algorithms/rm_epsilon.rs
@@ -4,18 +4,18 @@ use std::collections::HashMap;
 use failure::Fallible;
 use unsafe_unwrap::UnsafeUnwrap;
 
-use crate::{Arc, EPS_LABEL, Label, StateId};
-use crate::algorithms::Queue;
 use crate::algorithms::arc_filters::{ArcFilter, EpsilonArcFilter};
 use crate::algorithms::dfs_visit::dfs_visit;
 use crate::algorithms::queues::AutoQueue;
 use crate::algorithms::shortest_distance::{ShortestDistanceConfig, ShortestDistanceState};
 use crate::algorithms::top_sort::TopOrderVisitor;
 use crate::algorithms::visitors::SccVisitor;
+use crate::algorithms::Queue;
 use crate::fst_properties::FstProperties;
 use crate::fst_traits::CoreFst;
 use crate::fst_traits::MutableFst;
 use crate::semirings::Semiring;
+use crate::{Arc, Label, StateId, EPS_LABEL};
 
 pub struct RmEpsilonConfig<W: Semiring, Q: Queue> {
     sd_opts: ShortestDistanceConfig<W, Q, EpsilonArcFilter>,
@@ -56,26 +56,31 @@ impl<W: Semiring, Q: Queue> RmEpsilonConfig<W, Q> {
 /// # use rustfst::algorithms::rm_epsilon;
 /// # use rustfst::Arc;
 /// # use rustfst::EPS_LABEL;
+/// # use failure::Fallible;
+/// # fn main() -> Fallible<()> {
 /// let mut fst = VectorFst::new();
 /// let s0 = fst.add_state();
 /// let s1 = fst.add_state();
 /// fst.add_arc(s0, Arc::new(32, 25, IntegerWeight::new(78), s1));
 /// fst.add_arc(s1, Arc::new(EPS_LABEL, EPS_LABEL, IntegerWeight::new(13), s0));
-/// fst.set_start(s0).unwrap();
-/// fst.set_final(s0, IntegerWeight::new(5));
+/// fst.set_start(s0)?;
+/// fst.set_final(s0, IntegerWeight::new(5))?;
 ///
-/// let fst_no_epsilon : VectorFst<_> = rm_epsilon(&fst).unwrap();
+/// let mut fst_no_epsilon = fst.clone();
+/// rm_epsilon(&mut fst_no_epsilon)?;
 ///
 /// let mut fst_no_epsilon_ref = VectorFst::<IntegerWeight>::new();
 /// let s0 = fst_no_epsilon_ref.add_state();
 /// let s1 = fst_no_epsilon_ref.add_state();
 /// fst_no_epsilon_ref.add_arc(s0, Arc::new(32, 25, 78, s1));
 /// fst_no_epsilon_ref.add_arc(s1, Arc::new(32, 25, 78 * 13, s1));
-/// fst_no_epsilon_ref.set_start(s0).unwrap();
-/// fst_no_epsilon_ref.set_final(s0, 5);
-/// fst_no_epsilon_ref.set_final(s1, 5 * 13);
+/// fst_no_epsilon_ref.set_start(s0)?;
+/// fst_no_epsilon_ref.set_final(s0, 5)?;
+/// fst_no_epsilon_ref.set_final(s1, 5 * 13)?;
 ///
 /// assert_eq!(fst_no_epsilon, fst_no_epsilon_ref);
+/// # Ok(())
+/// # }
 /// ```
 pub fn rm_epsilon<F: MutableFst>(fst: &mut F) -> Fallible<()>
 where

--- a/rustfst/src/algorithms/rm_epsilon.rs
+++ b/rustfst/src/algorithms/rm_epsilon.rs
@@ -1,21 +1,26 @@
+use std::cell::UnsafeCell;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
+use std::rc::Rc;
+use std::slice::Iter as IterSlice;
 
 use failure::Fallible;
 use unsafe_unwrap::UnsafeUnwrap;
 
+use crate::{Arc, EPS_LABEL, Label, StateId, SymbolTable};
 use crate::algorithms::arc_filters::{ArcFilter, EpsilonArcFilter};
+use crate::algorithms::cache::{CacheImpl, FstImpl};
 use crate::algorithms::dfs_visit::dfs_visit;
+use crate::algorithms::dynamic_fst::StatesIteratorDynamicFst;
+use crate::algorithms::Queue;
 use crate::algorithms::queues::AutoQueue;
 use crate::algorithms::shortest_distance::{ShortestDistanceConfig, ShortestDistanceState};
 use crate::algorithms::top_sort::TopOrderVisitor;
 use crate::algorithms::visitors::SccVisitor;
-use crate::algorithms::Queue;
 use crate::fst_properties::FstProperties;
-use crate::fst_traits::CoreFst;
-use crate::fst_traits::MutableFst;
+use crate::fst_traits::{MutableFst, StateIterator};
+use crate::fst_traits::{ArcIterator, CoreFst, Fst};
 use crate::semirings::Semiring;
-use crate::{Arc, Label, StateId, EPS_LABEL};
 
 pub struct RmEpsilonConfig<W: Semiring, Q: Queue> {
     sd_opts: ShortestDistanceConfig<W, Q, EpsilonArcFilter>,
@@ -309,5 +314,205 @@ where
         self.expand_id += 1;
 
         Ok((arcs, final_weight))
+    }
+}
+
+pub(crate) struct RmEpsilonImpl<'a, F: MutableFst, Q: Queue> {
+    rmeps_state: RmEpsilonState<'a, F, Q>,
+    cache_impl: CacheImpl<F::W>,
+}
+
+impl<'a, F: MutableFst, Q: Queue> FstImpl for RmEpsilonImpl<'a, F, Q>
+where
+    F::W: 'static,
+{
+    type W = F::W;
+
+    fn cache_impl_mut(&mut self) -> &mut CacheImpl<Self::W> {
+        &mut self.cache_impl
+    }
+
+    fn cache_impl_ref(&self) -> &CacheImpl<Self::W> {
+        &self.cache_impl
+    }
+
+    fn expand(&mut self, state: usize) -> Fallible<()> {
+        let (arcs, final_weight) = self.rmeps_state.expand(state)?;
+        let zero = F::W::zero();
+
+        for arc in arcs.into_iter().rev() {
+            self.cache_impl.push_arc(state, arc)?;
+        }
+        if final_weight != zero {
+            self.cache_impl
+                .set_final_weight(state, Some(final_weight))?;
+        } else {
+            self.cache_impl.set_final_weight(state, None)?;
+        }
+
+        Ok(())
+    }
+
+    fn compute_start(&mut self) -> Fallible<Option<usize>> {
+        Ok(self.rmeps_state.fst.start())
+    }
+
+    fn compute_final(&mut self, state: usize) -> Fallible<Option<Self::W>> {
+        // A bit hacky as the final weight is computed inside the expand function.
+        // Should in theory never be called
+        self.expand(state)?;
+        let weight = self.cache_impl.final_weight(state)?;
+        Ok(weight.cloned())
+    }
+}
+
+pub struct RmEpsilonFst<'a, F: MutableFst, Q: Queue> {
+    pub(crate) fst_impl: UnsafeCell<RmEpsilonImpl<'a, F, Q>>,
+    pub(crate) isymt: Option<Rc<SymbolTable>>,
+    pub(crate) osymt: Option<Rc<SymbolTable>>,
+}
+
+impl<'a, F: MutableFst, Q: Queue> RmEpsilonFst<'a, F, Q>
+where
+    F::W: 'static,
+{
+    fn num_known_states(&self) -> usize {
+        let ptr = self.fst_impl.get();
+        let fst_impl = unsafe { ptr.as_ref().unwrap() };
+        fst_impl.num_known_states()
+    }
+}
+
+impl<'a, F: MutableFst, Q: Queue> PartialEq for RmEpsilonFst<'a, F, Q> {
+    fn eq(&self, other: &Self) -> bool {
+        let ptr = self.fst_impl.get();
+        let fst_impl = unsafe { ptr.as_ref().unwrap() };
+
+        let ptr_other = other.fst_impl.get();
+        let fst_impl_other = unsafe { ptr_other.as_ref().unwrap() };
+
+        fst_impl.eq(fst_impl_other)
+    }
+}
+
+impl<'a, F: MutableFst, Q: Queue> std::fmt::Debug for RmEpsilonFst<'a, F, Q>
+where
+    F::W: 'static,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let ptr = self.fst_impl.get();
+        let fst_impl = unsafe { ptr.as_ref().unwrap() };
+        write!(f, "RmEpsilonFst {{ {:?} }}", &fst_impl)
+    }
+}
+
+impl<'a, F: MutableFst, Q: Queue> Clone for RmEpsilonFst<'a, F, Q>
+where
+    F::W: 'static,
+{
+    fn clone(&self) -> Self {
+        let ptr = self.fst_impl.get();
+        let fst_impl = unsafe { ptr.as_ref().unwrap() };
+        Self {
+            fst_impl: UnsafeCell::new(fst_impl.clone()),
+            isymt: self.input_symbols(),
+            osymt: self.output_symbols(),
+        }
+    }
+}
+
+impl<'a, F: MutableFst, Q: Queue> CoreFst for RmEpsilonFst<'a, F, Q>
+where
+    F::W: 'static,
+{
+    type W = F::W;
+
+    fn start(&self) -> Option<usize> {
+        let ptr = self.fst_impl.get();
+        let fst_impl = unsafe { ptr.as_mut().unwrap() };
+        fst_impl.start().unwrap()
+    }
+
+    fn final_weight(&self, state_id: usize) -> Fallible<Option<&Self::W>> {
+        let ptr = self.fst_impl.get();
+        let fst_impl = unsafe { ptr.as_mut().unwrap() };
+        fst_impl.final_weight(state_id)
+    }
+
+    unsafe fn final_weight_unchecked(&self, state_id: usize) -> Option<&Self::W> {
+        self.final_weight(state_id).unwrap()
+    }
+
+    fn num_arcs(&self, s: usize) -> Fallible<usize> {
+        let ptr = self.fst_impl.get();
+        let fst_impl = unsafe { ptr.as_mut().unwrap() };
+        fst_impl.num_arcs(s)
+    }
+
+    unsafe fn num_arcs_unchecked(&self, s: usize) -> usize {
+        self.num_arcs(s).unwrap()
+    }
+}
+
+impl<'a, 'b, F: MutableFst, Q: Queue> ArcIterator<'a> for RmEpsilonFst<'b, F, Q>
+where
+    F::W: 'static,
+{
+    type Iter = IterSlice<'a, Arc<F::W>>;
+
+    fn arcs_iter(&'a self, state_id: usize) -> Fallible<Self::Iter> {
+        let ptr = self.fst_impl.get();
+        let fst_impl = unsafe { ptr.as_mut().unwrap() };
+        fst_impl.arcs_iter(state_id)
+    }
+
+    unsafe fn arcs_iter_unchecked(&'a self, state_id: usize) -> Self::Iter {
+        self.arcs_iter(state_id).unwrap()
+    }
+}
+
+impl<'a, 'b, F: MutableFst, Q: Queue> Iterator
+    for StatesIteratorDynamicFst<'a, RmEpsilonFst<'b, F, Q>>
+where
+    F::W: 'static,
+{
+    type Item = StateId;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.s < self.fst.num_known_states() {
+            let s_cur = self.s;
+            // Force expansion of the state
+            self.fst.arcs_iter(s_cur).unwrap();
+            self.s += 1;
+            Some(s_cur)
+        } else {
+            None
+        }
+    }
+}
+
+impl<'a, 'b, F: MutableFst, Q: Queue> StateIterator<'a> for RmEpsilonFst<'b, F, Q>
+where
+    F::W: 'static,
+    'a: 'b
+{
+    type Iter = StatesIteratorDynamicFst<'a, RmEpsilonFst<'b, F, Q>>;
+
+    fn states_iter(&'a self) -> Self::Iter {
+        self.start();
+        StatesIteratorDynamicFst { fst: &self, s: 0 }
+    }
+}
+
+impl<'a, F: MutableFst, Q: Queue> Fst for RmEpsilonFst<'a, F, Q>
+where
+    F::W: 'static,
+{
+    fn input_symbols(&self) -> Option<Rc<SymbolTable>> {
+        self.isymt.clone()
+    }
+
+    fn output_symbols(&self) -> Option<Rc<SymbolTable>> {
+        self.osymt.clone()
     }
 }

--- a/rustfst/src/algorithms/rm_final_epsilon.rs
+++ b/rustfst/src/algorithms/rm_final_epsilon.rs
@@ -3,13 +3,13 @@ use std::collections::HashSet;
 use failure::Fallible;
 use unsafe_unwrap::UnsafeUnwrap;
 
+use crate::algorithms::arc_filters::AnyArcFilter;
 use crate::algorithms::connect;
 use crate::algorithms::dfs_visit::dfs_visit;
 use crate::algorithms::visitors::SccVisitor;
 use crate::fst_traits::MutableFst;
 use crate::semirings::Semiring;
 use crate::EPS_LABEL;
-use crate::algorithms::arc_filters::AnyArcFilter;
 
 /// Removes final states that have epsilon-only input arcs.
 pub fn rm_final_epsilon<F>(ifst: &mut F) -> Fallible<()>
@@ -17,7 +17,7 @@ where
     F: MutableFst,
 {
     let mut visitors = SccVisitor::new(ifst, false, true);
-    dfs_visit(ifst, &mut visitors, AnyArcFilter{}, false);
+    dfs_visit(ifst, &mut visitors, &AnyArcFilter {}, false);
 
     let mut finals = HashSet::new();
 

--- a/rustfst/src/algorithms/rm_final_epsilon.rs
+++ b/rustfst/src/algorithms/rm_final_epsilon.rs
@@ -9,6 +9,7 @@ use crate::algorithms::visitors::SccVisitor;
 use crate::fst_traits::MutableFst;
 use crate::semirings::Semiring;
 use crate::EPS_LABEL;
+use crate::algorithms::arc_filters::AnyArcFilter;
 
 /// Removes final states that have epsilon-only input arcs.
 pub fn rm_final_epsilon<F>(ifst: &mut F) -> Fallible<()>
@@ -16,7 +17,7 @@ where
     F: MutableFst,
 {
     let mut visitors = SccVisitor::new(ifst, false, true);
-    dfs_visit(ifst, &mut visitors, false);
+    dfs_visit(ifst, &mut visitors, AnyArcFilter{}, false);
 
     let mut finals = HashSet::new();
 

--- a/rustfst/src/algorithms/shortest_distance.rs
+++ b/rustfst/src/algorithms/shortest_distance.rs
@@ -49,11 +49,11 @@ pub fn single_source_shortest_distance<F: ExpandedFst>(
     // Check whether the wFST contains the state
     if state_id < fst.num_states() {
         while d.len() <= state_id {
-            d.push(<F as CoreFst>::W::zero());
-            r.push(<F as CoreFst>::W::zero());
+            d.push(F::W::zero());
+            r.push(F::W::zero());
         }
-        d[state_id] = <F as CoreFst>::W::one();
-        r[state_id] = <F as CoreFst>::W::one();
+        d[state_id] = F::W::one();
+        r[state_id] = F::W::one();
 
         let mut queue = VecDeque::new();
         queue.push_back(state_id);
@@ -61,17 +61,17 @@ pub fn single_source_shortest_distance<F: ExpandedFst>(
         while !queue.is_empty() {
             let state_cour = unsafe { queue.pop_front().unsafe_unwrap() };
             while d.len() <= state_cour {
-                d.push(<F as CoreFst>::W::zero());
-                r.push(<F as CoreFst>::W::zero());
+                d.push(F::W::zero());
+                r.push(F::W::zero());
             }
             let r2 = &r[state_cour].clone();
-            r[state_cour] = <F as CoreFst>::W::zero();
+            r[state_cour] = F::W::zero();
 
             for arc in unsafe { fst.arcs_iter_unchecked(state_cour) } {
                 let nextstate = arc.nextstate;
                 while d.len() <= nextstate {
-                    d.push(<F as CoreFst>::W::zero());
-                    r.push(<F as CoreFst>::W::zero());
+                    d.push(F::W::zero());
+                    r.push(F::W::zero());
                 }
                 if d[nextstate] != d[nextstate].plus(&r2.times(&arc.weight)?)? {
                     d[nextstate] = d[nextstate].plus(&r2.times(&arc.weight)?)?;
@@ -157,62 +157,24 @@ where
     }
 }
 
-#[cfg(test)]
-mod tests {
-    //    use super::*;
-    //    use crate::fst_traits::StateIterator;
-    //    use crate::semirings::{IntegerWeight, Semiring};
-    //    use crate::test_data::vector_fst::get_vector_fsts_for_tests;
 
-    //    #[test]
-    //    fn test_single_source_shortest_distance_generic() -> Fallible<()> {
-    //        for data in get_vector_fsts_for_tests() {
-    //            let fst = data.fst;
-    //            let d_ref = data.all_distances;
-    //
-    //            for state in fst.states_iter() {
-    //                let d = single_source_shortest_distance(&fst, state)?;
-    //                assert_eq!(
-    //                    d, d_ref[state],
-    //                    "Test failing for single source shortest distance on wFST {:?} at state {:?}",
-    //                    data.name, state
-    //                );
-    //            }
-    //
-    //            let d = single_source_shortest_distance(&fst, fst.num_states())?;
-    //            assert_eq!(
-    //                d,
-    //                vec![IntegerWeight::zero(); fst.num_states()],
-    //                "Test failing for single source shortest distance on wFST {:?} at state {:?}",
-    //                data.name,
-    //                fst.num_states()
-    //            );
-    //        }
-    //        Ok(())
-    //    }
-    //
-    //    #[test]
-    //    fn test_shortest_distance_generic() -> Fallible<()> {
-    //        for data in get_vector_fsts_for_tests() {
-    //            let fst = data.fst;
-    //            let d_ref = data.all_distances;
-    //            let d = shortest_distance(&fst, false)?;
-    //
-    //            if let Some(start_state) = fst.start() {
-    //                assert_eq!(
-    //                    d, d_ref[start_state],
-    //                    "Test failing for all shortest distance on wFST : {:?}",
-    //                    data.name
-    //                );
-    //            } else {
-    //                assert_eq!(
-    //                    d,
-    //                    vec![IntegerWeight::zero(); fst.num_states()],
-    //                    "Test failing for all shortest distance on wFST : {:?}",
-    //                    data.name
-    //                );
-    //            }
-    //        }
-    //        Ok(())
-    //    }
+pub mod revamp {
+    use failure::Fallible;
+
+    use crate::fst_traits::Fst;
+    use crate::algorithms::arc_filters::AnyArcFilter;
+    use crate::algorithms::queues::AutoQueue;
+
+    pub fn shortest_distance<F: Fst>(fst: &F, reverse: bool) -> Fallible<Vec<F::W>>{
+
+        if !reverse {
+            let arc_filer = AnyArcFilter{};
+//            let queue = AutoQueue::
+            unimplemented!()
+        } else {
+            unimplemented!()
+        }
+
+        unimplemented!()
+    }
 }

--- a/rustfst/src/algorithms/shortest_distance.rs
+++ b/rustfst/src/algorithms/shortest_distance.rs
@@ -1,100 +1,194 @@
-use std::collections::VecDeque;
+use std::marker::PhantomData;
 
 use failure::Fallible;
-use unsafe_unwrap::UnsafeUnwrap;
 
-use crate::algorithms::reverse as reverse_f;
+use crate::algorithms::arc_filters::{AnyArcFilter, ArcFilter};
+use crate::algorithms::Queue;
+use crate::algorithms::queues::AutoQueue;
+use crate::algorithms::shortest_path::hack_convert_reverse_reverse;
 use crate::fst_impls::VectorFst;
-use crate::fst_traits::{CoreFst, ExpandedFst};
+use crate::fst_traits::{ExpandedFst, MutableFst};
 use crate::semirings::{Semiring, SemiringProperties};
 use crate::StateId;
 
-/// This operation computes the shortest distance from the state `state_id` to every state.
-/// The shortest distance from `p` to `q` is the ⊕-sum of the weights
-/// of all the paths between `p` and `q`.
-///
-/// # Example
-/// ```
-/// # use rustfst::semirings::{Semiring, IntegerWeight};
-/// # use rustfst::fst_impls::VectorFst;
-/// # use rustfst::fst_traits::MutableFst;
-/// # use rustfst::algorithms::single_source_shortest_distance;
-/// # use rustfst::Arc;
-/// let mut fst = VectorFst::<IntegerWeight>::new();
-/// let s0 = fst.add_state();
-/// let s1 = fst.add_state();
-/// let s2 = fst.add_state();
-///
-/// fst.set_start(s0).unwrap();
-/// fst.add_arc(s0, Arc::new(32, 23, 18, s1));
-/// fst.add_arc(s0, Arc::new(32, 23, 21, s2));
-/// fst.add_arc(s1, Arc::new(32, 23, 55, s2));
-///
-/// let dists = single_source_shortest_distance(&fst, s1).unwrap();
-///
-/// assert_eq!(dists, vec![
-///     IntegerWeight::zero(),
-///     IntegerWeight::one(),
-///     IntegerWeight::new(55),
-/// ]);
-///
-/// ```
-pub fn single_source_shortest_distance<F: ExpandedFst>(
-    fst: &F,
-    state_id: StateId,
-) -> Fallible<Vec<<F as CoreFst>::W>> {
-    let mut d = vec![];
-    let mut r = vec![];
+pub struct ShortestDistanceConfig<W: Semiring, Q: Queue, A: ArcFilter<W>> {
+    pub arc_filter: A,
+    pub state_queue: Q,
+    pub source: Option<StateId>,
+    pub first_path: bool,
+    // TODO: Shouldn't need that
+    weight: PhantomData<W>,
+}
 
-    // Check whether the wFST contains the state
-    if state_id < fst.num_states() {
-        while d.len() <= state_id {
-            d.push(F::W::zero());
-            r.push(F::W::zero());
+impl<W: Semiring, Q: Queue, A: ArcFilter<W>> ShortestDistanceConfig<W, Q, A> {
+    pub fn new(arc_filter: A, state_queue: Q, source: Option<StateId>, first_path: bool) -> Self {
+        Self {
+            arc_filter,
+            state_queue,
+            source,
+            first_path,
+            weight: PhantomData,
         }
-        d[state_id] = F::W::one();
-        r[state_id] = F::W::one();
+    }
 
-        let mut queue = VecDeque::new();
-        queue.push_back(state_id);
+    pub fn new_with_default(arc_filter: A, state_queue: Q) -> Self {
+        Self::new(arc_filter, state_queue, None, false)
+    }
+}
 
-        while !queue.is_empty() {
-            let state_cour = unsafe { queue.pop_front().unsafe_unwrap() };
-            while d.len() <= state_cour {
-                d.push(F::W::zero());
-                r.push(F::W::zero());
+pub struct ShortestDistanceState<'a, W: Semiring, Q: Queue, A: ArcFilter<W>, F: ExpandedFst<W = W>>
+{
+    fst: &'a F,
+    state_queue: Q,
+    arc_filter: A,
+    first_path: bool,
+    enqueued: Vec<bool>,
+    distance: Vec<W>,
+    adder: Vec<W>,
+    radder: Vec<W>,
+    sources: Vec<Option<StateId>>,
+    retain: bool,
+    source_id: usize,
+}
+
+impl<'a, W: Semiring, Q: Queue, A: ArcFilter<W>, F: ExpandedFst<W = W>>
+    ShortestDistanceState<'a, W, Q, A, F>
+{
+    pub fn new(fst: &'a F, state_queue: Q, arc_filter: A, first_path: bool, retain: bool) -> Self {
+        Self {
+            fst,
+            state_queue,
+            arc_filter,
+            first_path,
+            distance: Vec::with_capacity(fst.num_states()),
+            enqueued: Vec::with_capacity(fst.num_states()),
+            adder: Vec::with_capacity(fst.num_states()),
+            radder: Vec::with_capacity(fst.num_states()),
+            sources: Vec::with_capacity(fst.num_states()),
+            source_id: 0,
+            retain,
+        }
+    }
+    pub fn new_from_config(
+        fst: &'a F,
+        opts: ShortestDistanceConfig<W, Q, A>,
+        retain: bool,
+    ) -> Self {
+        Self::new(
+            fst,
+            opts.state_queue,
+            opts.arc_filter,
+            opts.first_path,
+            retain,
+        )
+    }
+
+    fn ensure_distance_index_is_valid(&mut self, index: usize) {
+        while self.distance.len() <= index {
+            self.distance.push(W::zero());
+            self.enqueued.push(false);
+            self.adder.push(W::zero());
+            self.radder.push(W::zero());
+        }
+    }
+
+    fn ensure_sources_index_is_valid(&mut self, index: usize) {
+        while self.sources.len() <= index {
+            self.sources.push(None);
+        }
+    }
+
+    pub fn shortest_distance(&mut self, source: Option<StateId>) -> Fallible<Vec<W>> {
+        let start_state = self
+            .fst
+            .start()
+            .ok_or_else(|| format_err!("Fst doesn't have s start state"))?;
+        let weight_properties = W::properties();
+        if !weight_properties.contains(SemiringProperties::RIGHT_SEMIRING) {
+            bail!("ShortestDistance: Weight needs to be right distributive")
+        }
+        if self.first_path && !weight_properties.contains(SemiringProperties::PATH) {
+            bail!("ShortestDistance: The first_path option is disallowed when Weight does not have the path property")
+        }
+        self.state_queue.clear();
+        if !self.retain {
+            self.distance.clear();
+            self.adder.clear();
+            self.radder.clear();
+            self.enqueued.clear();
+        }
+        let source = source.unwrap_or(start_state);
+        self.ensure_distance_index_is_valid(source);
+        if self.retain {
+            self.ensure_sources_index_is_valid(source);
+            self.sources[source] = Some(self.source_id);
+        }
+        self.distance[source] = W::one();
+        self.adder[source] = W::one();
+        self.radder[source] = W::one();
+        self.enqueued[source] = true;
+        self.state_queue.enqueue(source);
+        while !self.state_queue.is_empty() {
+            let state = self.state_queue.head().unwrap();
+            self.state_queue.dequeue();
+            self.ensure_distance_index_is_valid(state);
+            if self.first_path && self.fst.is_final(state)? {
+                break;
             }
-            let r2 = &r[state_cour].clone();
-            r[state_cour] = F::W::zero();
-
-            for arc in unsafe { fst.arcs_iter_unchecked(state_cour) } {
+            self.enqueued[state] = false;
+            let r = self.radder[state].clone();
+            self.radder[state] = W::zero();
+            for arc in self.fst.arcs_iter(state)? {
                 let nextstate = arc.nextstate;
-                while d.len() <= nextstate {
-                    d.push(F::W::zero());
-                    r.push(F::W::zero());
+                if !self.arc_filter.keep(arc) {
+                    continue;
                 }
-                if d[nextstate] != d[nextstate].plus(&r2.times(&arc.weight)?)? {
-                    d[nextstate] = d[nextstate].plus(&r2.times(&arc.weight)?)?;
-                    r[nextstate] = r[nextstate].plus(&r2.times(&arc.weight)?)?;
-                    if !queue.contains(&nextstate) {
-                        queue.push_back(nextstate);
+                self.ensure_distance_index_is_valid(nextstate);
+                if self.retain {
+                    self.ensure_sources_index_is_valid(nextstate);
+                    if self.sources[nextstate] != Some(self.source_id) {
+                        self.distance[nextstate] = W::zero();
+                        self.adder[nextstate] = W::zero();
+                        self.radder[nextstate] = W::zero();
+                        self.enqueued[nextstate] = false;
+                        self.sources[nextstate] = Some(self.source_id);
+                    }
+                }
+                let nd = self.distance.get_mut(nextstate).unwrap();
+                let na = self.adder.get_mut(nextstate).unwrap();
+                let nr = self.radder.get_mut(nextstate).unwrap();
+                let weight = r.times(&arc.weight)?;
+                if *nd != nd.plus(&weight)? {
+                    na.plus_assign(&weight)?;
+                    *nd = na.clone();
+                    nr.plus_assign(&weight)?;
+                    if !self.enqueued[state] {
+                        self.state_queue.enqueue(nextstate);
+                        self.enqueued[nextstate] = true;
+                    } else {
+                        self.state_queue.update(nextstate);
                     }
                 }
             }
         }
+        self.source_id += 1;
+        // TODO: This clone could be avoided
+        Ok(self.distance.clone())
     }
-
-    Ok(d)
 }
 
-pub fn _shortest_distance<F: ExpandedFst>(fst: &F) -> Fallible<Vec<<F as CoreFst>::W>> {
-    if !F::W::properties().contains(SemiringProperties::RIGHT_SEMIRING) {
-        bail!("ShortestDistance: Weight needs to be right distributive");
-    }
-    if let Some(start_state) = fst.start() {
-        return single_source_shortest_distance(fst, start_state);
-    }
-    Ok(vec![])
+pub fn shortest_distance_with_config<
+    W: Semiring,
+    Q: Queue,
+    A: ArcFilter<W>,
+    F: MutableFst<W = W>,
+>(
+    fst: &F,
+    opts: ShortestDistanceConfig<W, Q, A>,
+) -> Fallible<Vec<W>> {
+    let source = opts.source;
+    let mut sd_state = ShortestDistanceState::new_from_config(fst, opts, false);
+    sd_state.shortest_distance(source)
 }
 
 /// This operation computes the shortest distance from the initial state to every state.
@@ -130,271 +224,58 @@ pub fn _shortest_distance<F: ExpandedFst>(fst: &F) -> Fallible<Vec<<F as CoreFst
 /// # Ok(())
 /// # }
 /// ```
-pub fn shortest_distance<F: ExpandedFst>(fst: &F, reverse: bool) -> Fallible<Vec<<F as CoreFst>::W>>
+pub fn shortest_distance<F: MutableFst>(fst: &F, reverse: bool) -> Fallible<Vec<F::W>>
 where
-    <<F as CoreFst>::W as Semiring>::ReverseWeight: 'static,
+    F::W: 'static,
 {
     if !reverse {
-        _shortest_distance(fst)
+        let arc_filter = AnyArcFilter {};
+        let queue = AutoQueue::new(fst, None, &arc_filter)?;
+        let config = ShortestDistanceConfig::new_with_default(arc_filter, queue);
+        shortest_distance_with_config(fst, config)
     } else {
-        let rfst: VectorFst<_> = reverse_f(fst)?;
-        let rdistance = _shortest_distance(&rfst)?;
-        let mut distance = vec![];
-        while distance.len() < (rdistance.len() - 1) {
-            // TODO: Need to find a better to say that W::ReverseWeight::ReverseWeight == W
-            let rw = rdistance[distance.len() + 1].reverse()?;
-            distance.push(
-                unsafe {
-                    std::mem::transmute::<
-                    &<<<F as CoreFst>::W as Semiring>::ReverseWeight as Semiring>::ReverseWeight,
-                    &<F as CoreFst>::W,
-                >(&rw)
-                }
-                .clone(),
-            );
+        let arc_filter = AnyArcFilter {};
+        let rfst: VectorFst<_> = crate::algorithms::reverse(fst)?;
+        let state_queue = AutoQueue::new(&rfst, None, &arc_filter)?;
+        let ropts = ShortestDistanceConfig::new_with_default(arc_filter, state_queue);
+        let rdistance = shortest_distance_with_config(&rfst, ropts)?;
+        let mut distance = Vec::with_capacity(rdistance.len() - 1); //reversing added one state
+        while distance.len() < rdistance.len() - 1 {
+            distance.push(hack_convert_reverse_reverse(
+                rdistance[distance.len() + 1].reverse()?,
+            ));
         }
         Ok(distance)
     }
 }
 
-pub mod revamp {
-    use failure::Fallible;
+#[allow(unused)]
+/// Return the sum of the weight of all successful paths in an FST, i.e., the
+/// shortest-distance from the initial state to the final states..
+fn shortest_distance_3<F: MutableFst>(fst: &F) -> Fallible<F::W>
+where
+    F::W: 'static,
+{
+    let weight_properties = F::W::properties();
 
-    use crate::algorithms::arc_filters::{AnyArcFilter, ArcFilter};
-    use crate::algorithms::queues::AutoQueue;
-    use crate::algorithms::shortest_path::hack_convert_reverse_reverse;
-    use crate::algorithms::Queue;
-    use crate::fst_impls::VectorFst;
-    use crate::fst_traits::{ExpandedFst, Fst, MutableFst};
-    use crate::semirings::{Semiring, SemiringProperties};
-    use crate::StateId;
-    use failure::_core::marker::PhantomData;
-    use nom::combinator::opt;
-
-    pub struct ShortestDistanceConfig<W: Semiring, Q: Queue, A: ArcFilter<W>> {
-        arc_filter: A,
-        state_queue: Q,
-        source: Option<StateId>,
-        first_path: bool,
-        // TODO: Shouldn't need that
-        weight: PhantomData<W>,
-    }
-
-    impl<W: Semiring, Q: Queue, A: ArcFilter<W>> ShortestDistanceConfig<W, Q, A> {
-        pub fn new(
-            arc_filter: A,
-            state_queue: Q,
-            source: Option<StateId>,
-            first_path: bool,
-        ) -> Self {
-            Self {
-                arc_filter,
-                state_queue,
-                source,
-                first_path,
-                weight: PhantomData,
-            }
+    if weight_properties.contains(SemiringProperties::RIGHT_SEMIRING) {
+        let distance = shortest_distance(fst, false)?;
+        let mut sum = F::W::zero();
+        let zero = F::W::zero();
+        for state in 0..distance.len() {
+            sum.plus_assign(distance[state].times(fst.final_weight(state)?.unwrap_or(&zero))?)?;
         }
-
-        pub fn new_with_default(arc_filter: A, state_queue: Q) -> Self {
-            Self::new(arc_filter, state_queue, None, false)
-        }
-    }
-
-    pub struct ShortestDistanceState<
-        'a,
-        W: Semiring,
-        Q: Queue,
-        A: ArcFilter<W>,
-        F: ExpandedFst<W = W>,
-    > {
-        fst: &'a F,
-        state_queue: Q,
-        arc_filter: A,
-        first_path: bool,
-        enqueued: Vec<bool>,
-        distance: Vec<W>,
-        adder: Vec<W>,
-        radder: Vec<W>,
-        sources: Vec<Option<StateId>>,
-        retain: bool,
-        source_id: usize,
-    }
-
-    impl<'a, W: Semiring, Q: Queue, A: ArcFilter<W>, F: ExpandedFst<W = W>>
-        ShortestDistanceState<'a, W, Q, A, F>
-    {
-        pub fn new(fst: &'a F, opts: ShortestDistanceConfig<W, Q, A>, retain: bool) -> Self {
-            Self {
-                fst,
-                state_queue: opts.state_queue,
-                arc_filter: opts.arc_filter,
-                first_path: opts.first_path,
-                distance: Vec::with_capacity(fst.num_states()),
-                enqueued: Vec::with_capacity(fst.num_states()),
-                adder: Vec::with_capacity(fst.num_states()),
-                radder: Vec::with_capacity(fst.num_states()),
-                sources: Vec::with_capacity(fst.num_states()),
-                source_id: 0,
-                retain,
-            }
-        }
-
-        fn ensure_distance_index_is_valid(&mut self, index: usize) {
-            while self.distance.len() <= index {
-                self.distance.push(W::zero());
-                self.enqueued.push(false);
-                self.adder.push(W::zero());
-                self.radder.push(W::zero());
-            }
-        }
-
-        fn ensure_sources_index_is_valid(&mut self, index: usize) {
-            while self.sources.len() <= index {
-                self.sources.push(None);
-            }
-        }
-
-        pub fn shortest_distance(&mut self, source: Option<StateId>) -> Fallible<Vec<W>> {
-            let start_state = self
-                .fst
-                .start()
-                .ok_or_else(|| format_err!("Fst doesn't have s start state"))?;
-            let weight_properties = W::properties();
-            if !weight_properties.contains(SemiringProperties::RIGHT_SEMIRING) {
-                bail!("ShortestDistance: Weight needs to be right distributive")
-            }
-            if self.first_path && !weight_properties.contains(SemiringProperties::PATH) {
-                bail!("ShortestDistance: The first_path option is disallowed when Weight does not have the path property")
-            }
-            self.state_queue.clear();
-            if !self.retain {
-                self.distance.clear();
-                self.adder.clear();
-                self.radder.clear();
-                self.enqueued.clear();
-            }
-            let source = source.unwrap_or(start_state);
-            self.ensure_distance_index_is_valid(source);
-            if self.retain {
-                self.ensure_sources_index_is_valid(source);
-                self.sources[source] = Some(self.source_id);
-            }
-            self.distance[source] = W::one();
-            self.adder[source] = W::one();
-            self.radder[source] = W::one();
-            self.enqueued[source] = true;
-            self.state_queue.enqueue(source);
-            while !self.state_queue.is_empty() {
-                let state = self.state_queue.head().unwrap();
-                self.state_queue.dequeue();
-                self.ensure_distance_index_is_valid(state);
-                if self.first_path && self.fst.is_final(state)? {
-                    break;
-                }
-                self.enqueued[state] = false;
-                let r = self.radder[state].clone();
-                self.radder[state] = W::zero();
-                for arc in self.fst.arcs_iter(state)? {
-                    let nextstate = arc.nextstate;
-                    if !self.arc_filter.keep(arc) {
-                        continue;
-                    }
-                    self.ensure_distance_index_is_valid(nextstate);
-                    if self.retain {
-                        self.ensure_sources_index_is_valid(nextstate);
-                        if self.sources[nextstate] != Some(self.source_id) {
-                            self.distance[nextstate] = W::zero();
-                            self.adder[nextstate] = W::zero();
-                            self.radder[nextstate] = W::zero();
-                            self.enqueued[nextstate] = false;
-                            self.sources[nextstate] = Some(self.source_id);
-                        }
-                    }
-                    let nd = self.distance.get_mut(nextstate).unwrap();
-                    let na = self.adder.get_mut(nextstate).unwrap();
-                    let nr = self.radder.get_mut(nextstate).unwrap();
-                    let weight = r.times(&arc.weight)?;
-                    if *nd != nd.plus(&weight)? {
-                        na.plus_assign(&weight)?;
-                        *nd = na.clone();
-                        nr.plus_assign(&weight)?;
-                        if !self.enqueued[state] {
-                            self.state_queue.enqueue(nextstate);
-                            self.enqueued[nextstate] = true;
-                        } else {
-                            self.state_queue.update(nextstate);
-                        }
-                    }
-                }
-            }
-            self.source_id += 1;
-            // TODO: This clone could be avoided
-            Ok(self.distance.clone())
-        }
-    }
-
-    pub fn shortest_distance_with_config<W: Semiring, Q: Queue, A: ArcFilter<W>, F: MutableFst<W = W>>(
-        fst: &F,
-        opts: ShortestDistanceConfig<W, Q, A>,
-    ) -> Fallible<Vec<W>> {
-        let source = opts.source;
-        let mut sd_state = ShortestDistanceState::new(fst, opts, false);
-        sd_state.shortest_distance(source)
-    }
-
-    pub fn shortest_distance<F: MutableFst>(fst: &F, reverse: bool) -> Fallible<Vec<F::W>>
-    where
-        F::W: 'static,
-    {
-        if !reverse {
-            let arc_filter = AnyArcFilter {};
-            let queue = AutoQueue::new(fst, None, &arc_filter)?;
-            let config = ShortestDistanceConfig::new_with_default(arc_filter, queue);
-            shortest_distance_with_config(fst, config)
-        } else {
-            let arc_filter = AnyArcFilter {};
-            let rfst: VectorFst<_> = crate::algorithms::reverse(fst)?;
-            let state_queue = AutoQueue::new(&rfst, None, &arc_filter)?;
-            let ropts = ShortestDistanceConfig::new_with_default(arc_filter, state_queue);
-            let rdistance = shortest_distance_with_config(&rfst, ropts)?;
-            let mut distance = Vec::with_capacity(rdistance.len() - 1); //reversing added one state
-            while distance.len() < rdistance.len() - 1 {
-                distance.push(hack_convert_reverse_reverse(
-                    rdistance[distance.len() + 1].reverse()?,
-                ));
-            }
-            Ok(distance)
-        }
-    }
-
-    /// Return the sum of the weight of all successful paths in an FST, i.e., the
-    /// shortest-distance from the initial state to the final states..
-    pub fn shortest_distance_3<F: MutableFst>(fst: &F) -> Fallible<F::W>
-    where
-        F::W: 'static,
-    {
-        let weight_properties = F::W::properties();
-
-        if weight_properties.contains(SemiringProperties::RIGHT_SEMIRING) {
-            let distance = shortest_distance(fst, false)?;
-            let mut sum = F::W::zero();
-            let zero = F::W::zero();
-            for state in 0..distance.len() {
-                sum.plus_assign(distance[state].times(fst.final_weight(state)?.unwrap_or(&zero))?)?;
-            }
-            Ok(sum)
-        } else {
-            let distance = shortest_distance(fst, true)?;
-            if let Some(state) = fst.start() {
-                if state < distance.len() {
-                    Ok(distance[state].clone())
-                } else {
-                    Ok(F::W::zero())
-                }
+        Ok(sum)
+    } else {
+        let distance = shortest_distance(fst, true)?;
+        if let Some(state) = fst.start() {
+            if state < distance.len() {
+                Ok(distance[state].clone())
             } else {
                 Ok(F::W::zero())
             }
+        } else {
+            Ok(F::W::zero())
         }
     }
 }

--- a/rustfst/src/algorithms/shortest_distance.rs
+++ b/rustfst/src/algorithms/shortest_distance.rs
@@ -3,9 +3,9 @@ use std::marker::PhantomData;
 use failure::Fallible;
 
 use crate::algorithms::arc_filters::{AnyArcFilter, ArcFilter};
-use crate::algorithms::Queue;
 use crate::algorithms::queues::AutoQueue;
 use crate::algorithms::shortest_path::hack_convert_reverse_reverse;
+use crate::algorithms::Queue;
 use crate::fst_impls::VectorFst;
 use crate::fst_traits::{ExpandedFst, MutableFst};
 use crate::semirings::{Semiring, SemiringProperties};
@@ -99,10 +99,10 @@ impl<'a, W: Semiring, Q: Queue, A: ArcFilter<W>, F: ExpandedFst<W = W>>
     }
 
     pub fn shortest_distance(&mut self, source: Option<StateId>) -> Fallible<Vec<W>> {
-        let start_state = self
-            .fst
-            .start()
-            .ok_or_else(|| format_err!("Fst doesn't have s start state"))?;
+        let start_state = match self.fst.start() {
+            Some(start_state) => start_state,
+            None => return Ok(vec![]),
+        };
         let weight_properties = W::properties();
         if !weight_properties.contains(SemiringProperties::RIGHT_SEMIRING) {
             bail!("ShortestDistance: Weight needs to be right distributive")

--- a/rustfst/src/algorithms/shortest_path.rs
+++ b/rustfst/src/algorithms/shortest_path.rs
@@ -14,6 +14,7 @@ use crate::fst_traits::{ArcIterator, CoreFst, ExpandedFst, MutableFst};
 use crate::semirings::{Semiring, SemiringProperties, WeaklyDivisibleSemiring, WeightQuantize};
 use crate::Arc;
 use crate::StateId;
+use crate::algorithms::arc_filters::AnyArcFilter;
 
 /// Creates an FST containing the n-shortest paths in the input FST. The n-shortest paths are the
 /// n-lowest weight paths w.r.t. the natural semiring order.
@@ -116,7 +117,7 @@ where
         return Ok(());
     }
     let mut enqueued = vec![];
-    let mut queue = AutoQueue::new(ifst, None)?;
+    let mut queue = AutoQueue::new(ifst, None, &AnyArcFilter{})?;
     let source = unsafe { start.unsafe_unwrap() };
     let mut f_distance = F::W::zero();
     distance.clear();

--- a/rustfst/src/algorithms/shortest_path.rs
+++ b/rustfst/src/algorithms/shortest_path.rs
@@ -7,6 +7,7 @@ use failure::Fallible;
 
 use unsafe_unwrap::UnsafeUnwrap;
 
+use crate::algorithms::arc_filters::AnyArcFilter;
 use crate::algorithms::queues::AutoQueue;
 use crate::algorithms::{connect, determinize_with_distance, reverse, shortest_distance, Queue};
 use crate::fst_impls::VectorFst;
@@ -14,7 +15,6 @@ use crate::fst_traits::{ArcIterator, CoreFst, ExpandedFst, MutableFst};
 use crate::semirings::{Semiring, SemiringProperties, WeaklyDivisibleSemiring, WeightQuantize};
 use crate::Arc;
 use crate::StateId;
-use crate::algorithms::arc_filters::AnyArcFilter;
 
 /// Creates an FST containing the n-shortest paths in the input FST. The n-shortest paths are the
 /// n-lowest weight paths w.r.t. the natural semiring order.
@@ -117,7 +117,7 @@ where
         return Ok(());
     }
     let mut enqueued = vec![];
-    let mut queue = AutoQueue::new(ifst, None, &AnyArcFilter{})?;
+    let mut queue = AutoQueue::new(ifst, None, &AnyArcFilter {})?;
     let source = unsafe { start.unsafe_unwrap() };
     let mut f_distance = F::W::zero();
     distance.clear();

--- a/rustfst/src/algorithms/top_sort.rs
+++ b/rustfst/src/algorithms/top_sort.rs
@@ -1,11 +1,11 @@
 use failure::Fallible;
 
+use crate::algorithms::arc_filters::AnyArcFilter;
 use crate::algorithms::dfs_visit::{dfs_visit, Visitor};
 use crate::algorithms::state_sort;
 use crate::fst_traits::{ExpandedFst, Fst, MutableFst};
 use crate::Arc;
 use crate::StateId;
-use crate::algorithms::arc_filters::AnyArcFilter;
 
 pub struct TopOrderVisitor {
     pub order: Vec<StateId>,
@@ -76,7 +76,7 @@ where
     F: MutableFst + ExpandedFst,
 {
     let mut visitor = TopOrderVisitor::new();
-    dfs_visit(fst, &mut visitor, AnyArcFilter{}, false);
+    dfs_visit(fst, &mut visitor, &AnyArcFilter {}, false);
     if visitor.acyclic {
         state_sort(fst, &visitor.order)?;
     }

--- a/rustfst/src/algorithms/top_sort.rs
+++ b/rustfst/src/algorithms/top_sort.rs
@@ -5,6 +5,7 @@ use crate::algorithms::state_sort;
 use crate::fst_traits::{ExpandedFst, Fst, MutableFst};
 use crate::Arc;
 use crate::StateId;
+use crate::algorithms::arc_filters::AnyArcFilter;
 
 pub struct TopOrderVisitor {
     pub order: Vec<StateId>,
@@ -75,7 +76,7 @@ where
     F: MutableFst + ExpandedFst,
 {
     let mut visitor = TopOrderVisitor::new();
-    dfs_visit(fst, &mut visitor, false);
+    dfs_visit(fst, &mut visitor, AnyArcFilter{}, false);
     if visitor.acyclic {
         state_sort(fst, &visitor.order)?;
     }

--- a/rustfst/src/fst_properties/compute_fst_properties.rs
+++ b/rustfst/src/fst_properties/compute_fst_properties.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 use failure::Fallible;
 use unsafe_unwrap::UnsafeUnwrap;
 
+use crate::algorithms::arc_filters::AnyArcFilter;
 use crate::algorithms::dfs_visit::dfs_visit;
 use crate::algorithms::visitors::SccVisitor;
 use crate::fst_properties::FstProperties;
@@ -16,7 +17,7 @@ pub fn compute_fst_properties<F: Fst + ExpandedFst>(fst: &F) -> Fallible<FstProp
     let mut comp_props = FstProperties::empty();
 
     let mut visitor = SccVisitor::new(fst, true, true);
-    dfs_visit(fst, &mut visitor, false);
+    dfs_visit(fst, &mut visitor, &AnyArcFilter {}, false);
     let sccs = unsafe { &visitor.scc.unsafe_unwrap() };
 
     comp_props |= FstProperties::ACCESSIBLE;

--- a/rustfst/src/fst_traits/expanded_fst.rs
+++ b/rustfst/src/fst_traits/expanded_fst.rs
@@ -6,7 +6,7 @@ use crate::fst_traits::Fst;
 
 /// Trait defining the necessary methods that should implement an ExpandedFST e.g
 /// a FST where all the states are already computed and not computed on the fly.
-pub trait ExpandedFst: Fst {
+pub trait ExpandedFst: Fst + Clone + PartialEq {
     /// Returns the number of states that contains the FST. They are all counted even if some states
     /// are not on a successful path (doesn't perform triming).
     ///

--- a/rustfst/src/fst_traits/fst.rs
+++ b/rustfst/src/fst_traits/fst.rs
@@ -111,9 +111,7 @@ pub trait CoreFst {
 }
 
 /// Trait defining the minimum interface necessary for a wFST.
-pub trait Fst:
-    CoreFst + for<'a> ArcIterator<'a> + for<'b> StateIterator<'b> + Debug
-{
+pub trait Fst: CoreFst + for<'a> ArcIterator<'a> + for<'b> StateIterator<'b> + Debug {
     // TODO: Move niepsilons and noepsilons to required methods.
     /// Returns the number of arcs with epsilon input labels leaving a state.
     ///

--- a/rustfst/src/fst_traits/fst.rs
+++ b/rustfst/src/fst_traits/fst.rs
@@ -112,7 +112,7 @@ pub trait CoreFst {
 
 /// Trait defining the minimum interface necessary for a wFST.
 pub trait Fst:
-    CoreFst + PartialEq + Clone + for<'a> ArcIterator<'a> + for<'b> StateIterator<'b> + Debug
+    CoreFst + for<'a> ArcIterator<'a> + for<'b> StateIterator<'b> + Debug
 {
     // TODO: Move niepsilons and noepsilons to required methods.
     /// Returns the number of arcs with epsilon input labels leaving a state.

--- a/rustfst/src/fst_traits/iterators.rs
+++ b/rustfst/src/fst_traits/iterators.rs
@@ -6,7 +6,7 @@ use failure::Fallible;
 /// Trait to iterate over the states of a wFST.
 pub trait StateIterator<'a> {
     /// Iterator used to iterate over the `state_id` of the states of an FST.
-    type Iter: Iterator<Item = StateId> + Clone;
+    type Iter: Iterator<Item = StateId>;
 
     /// Creates an iterator over the `state_id` of the states of an FST.
     ///

--- a/rustfst/src/lib.rs
+++ b/rustfst/src/lib.rs
@@ -74,7 +74,7 @@
 //!     project(&mut fst, ProjectType::ProjectInput);
 //!
 //!     // - Remove epsilon transitions.
-//!     fst = rm_epsilon(&fst)?;
+//!     rm_epsilon(&mut fst)?;
 //!
 //!     // - Compute an equivalent FST but deterministic.
 //!     fst = determinize(&fst, DeterminizeType::DeterminizeFunctional)?;

--- a/rustfst/src/tests_openfst/algorithms/closure.rs
+++ b/rustfst/src/tests_openfst/algorithms/closure.rs
@@ -9,12 +9,12 @@ use crate::tests_openfst::algorithms::dynamic_fst::compare_fst_static_dynamic;
 use crate::tests_openfst::FstTestData;
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct ClosureOperationResult {
+pub struct SimpleStaticDynamicOperationResult {
     result_static: String,
     result_dynamic: String,
 }
 
-pub struct ClosureTestData<F>
+pub struct SimpleStaticDynamicTestData<F>
 where
     F: SerializableFst,
     F::W: SerializableSemiring,
@@ -23,13 +23,13 @@ where
     pub result_dynamic: F,
 }
 
-impl ClosureOperationResult {
-    pub fn parse<F>(&self) -> ClosureTestData<F>
+impl SimpleStaticDynamicOperationResult {
+    pub fn parse<F>(&self) -> SimpleStaticDynamicTestData<F>
     where
         F: SerializableFst,
         F::W: SerializableSemiring,
     {
-        ClosureTestData {
+        SimpleStaticDynamicTestData {
             result_static: F::from_text_string(self.result_static.as_str()).unwrap(),
             result_dynamic: F::from_text_string(self.result_dynamic.as_str()).unwrap(),
         }

--- a/rustfst/src/tests_openfst/algorithms/rm_epsilon.rs
+++ b/rustfst/src/tests_openfst/algorithms/rm_epsilon.rs
@@ -3,21 +3,20 @@ use std::fmt::Display;
 use failure::Fallible;
 
 use crate::algorithms::{isomorphic, rm_epsilon};
-use crate::fst_impls::VectorFst;
 use crate::fst_properties::FstProperties;
 use crate::fst_traits::{ExpandedFst, MutableFst, SerializableFst};
 use crate::semirings::SerializableSemiring;
-use crate::semirings::StarSemiring;
 use crate::semirings::WeaklyDivisibleSemiring;
 use crate::tests_openfst::FstTestData;
 
 pub fn test_rmepsilon<F>(test_data: &FstTestData<F>) -> Fallible<()>
 where
     F: SerializableFst + MutableFst + ExpandedFst + Display,
-    F::W: 'static + SerializableSemiring + WeaklyDivisibleSemiring + StarSemiring,
+    F::W: 'static + SerializableSemiring + WeaklyDivisibleSemiring,
 {
     // Remove epsilon
-    let fst_rmepsilon: VectorFst<_> = rm_epsilon(&test_data.raw).unwrap();
+    let mut fst_rmepsilon = test_data.raw.clone();
+    rm_epsilon(&mut fst_rmepsilon)?;
     assert!(fst_rmepsilon
         .properties()?
         .contains(FstProperties::NO_EPSILONS));

--- a/rustfst/src/tests_openfst/algorithms/rm_epsilon.rs
+++ b/rustfst/src/tests_openfst/algorithms/rm_epsilon.rs
@@ -2,11 +2,13 @@ use std::fmt::Display;
 
 use failure::Fallible;
 
-use crate::algorithms::{isomorphic, rm_epsilon};
+use crate::algorithms::{rm_epsilon, RmEpsilonFst};
+use crate::fst_impls::VectorFst;
 use crate::fst_properties::FstProperties;
 use crate::fst_traits::{ExpandedFst, MutableFst, SerializableFst};
 use crate::semirings::SerializableSemiring;
 use crate::semirings::WeaklyDivisibleSemiring;
+use crate::tests_openfst::algorithms::dynamic_fst::compare_fst_static_dynamic;
 use crate::tests_openfst::FstTestData;
 
 pub fn test_rmepsilon<F>(test_data: &FstTestData<F>) -> Fallible<()>
@@ -20,10 +22,27 @@ where
     assert!(fst_rmepsilon
         .properties()?
         .contains(FstProperties::NO_EPSILONS));
-    assert!(
-        isomorphic(&fst_rmepsilon, &test_data.rmepsilon)?,
+    assert_eq!(
+        fst_rmepsilon,
+        test_data.rmepsilon.result_static,
         "{}",
-        error_message_fst!(test_data.rmepsilon, fst_rmepsilon, "RmEpsilon")
+        error_message_fst!(
+            test_data.rmepsilon.result_static,
+            fst_rmepsilon,
+            "RmEpsilon"
+        )
     );
+    Ok(())
+}
+
+pub fn test_rmepsilon_dynamic<W>(test_data: &FstTestData<VectorFst<W>>) -> Fallible<()>
+where
+    W: SerializableSemiring + 'static,
+    W::ReverseWeight: 'static,
+{
+    let rmepsilon_dynamic_fst_openfst = &test_data.rmepsilon.result_dynamic;
+    let rmepsilon_dynamic_fst = RmEpsilonFst::new(test_data.raw.clone());
+    compare_fst_static_dynamic(rmepsilon_dynamic_fst_openfst, &rmepsilon_dynamic_fst)?;
+
     Ok(())
 }

--- a/rustfst/src/tests_openfst/algorithms/weight_pushing.rs
+++ b/rustfst/src/tests_openfst/algorithms/weight_pushing.rs
@@ -11,7 +11,7 @@ use crate::tests_openfst::FstTestData;
 pub fn test_weight_pushing_initial<F>(test_data: &FstTestData<F>) -> Fallible<()>
 where
     F: SerializableFst + MutableFst + Display,
-    F::W: SerializableSemiring + WeaklyDivisibleSemiring,
+    F::W: SerializableSemiring + WeaklyDivisibleSemiring + 'static,
     <<F as CoreFst>::W as Semiring>::ReverseWeight: 'static,
 {
     // Weight pushing initial
@@ -37,7 +37,7 @@ where
 pub fn test_weight_pushing_final<F>(test_data: &FstTestData<F>) -> Fallible<()>
 where
     F: SerializableFst + MutableFst + Display,
-    F::W: SerializableSemiring + WeaklyDivisibleSemiring,
+    F::W: SerializableSemiring + WeaklyDivisibleSemiring + 'static,
     <<F as CoreFst>::W as Semiring>::ReverseWeight: 'static,
 {
     // Weight pushing final

--- a/rustfst/src/tests_openfst/mod.rs
+++ b/rustfst/src/tests_openfst/mod.rs
@@ -338,33 +338,6 @@ macro_rules! do_run {
     };
 }
 
-// TODO: rmepsilon implementation requires the StarSemiring implementation which seems avoidable.
-macro_rules! do_run_rmepsilon {
-    ($f: ident, $fst_name: expr) => {
-        let absolute_path_folder = get_path_folder($fst_name)?;
-        let mut path_metadata = absolute_path_folder.clone();
-        path_metadata.push("metadata.json");
-
-        let string = read_to_string(&path_metadata)
-            .map_err(|_| format_err!("Can't open {:?}", &path_metadata))?;
-        let parsed_test_data: ParsedFstTestData = serde_json::from_str(&string).unwrap();
-
-        match parsed_test_data.weight_type.as_str() {
-            "tropical" | "standard" => {
-                let test_data: FstTestData<VectorFst<TropicalWeight>> =
-                    FstTestData::new(&parsed_test_data, absolute_path_folder.as_path());
-                $f(&test_data)?;
-            }
-            "log" => {
-                let test_data: FstTestData<VectorFst<LogWeight>> =
-                    FstTestData::new(&parsed_test_data, absolute_path_folder.as_path());
-                $f(&test_data)?;
-            }
-            _ => bail!("Weight type unknown : {:?}", parsed_test_data.weight_type),
-        };
-    };
-}
-
 macro_rules! test_fst {
     ($namespace: tt, $fst_name: expr) => {
         mod $namespace {
@@ -684,10 +657,7 @@ macro_rules! test_fst {
 
             #[test]
             fn test_rmepsilon_openfst() -> Fallible<()> {
-                if $fst_name != "fst_011" {
-                    do_run_rmepsilon!(test_rmepsilon, $fst_name);
-                }
-
+                do_run!(test_rmepsilon, $fst_name);
                 Ok(())
             }
         }

--- a/rustfst/src/tests_openfst/mod.rs
+++ b/rustfst/src/tests_openfst/mod.rs
@@ -50,7 +50,7 @@ use self::algorithms::{
     push::{test_push, PushOperationResult, PushTestData},
     replace::{test_replace, test_replace_dynamic, ReplaceOperationResult, ReplaceTestData},
     reverse::test_reverse,
-    rm_epsilon::test_rmepsilon,
+    rm_epsilon::{test_rmepsilon, test_rmepsilon_dynamic},
     shortest_distance::{
         test_shortest_distance, ShorestDistanceOperationResult, ShortestDistanceTestData,
     },
@@ -68,7 +68,7 @@ use self::misc::test_del_all_states;
 use crate::fst_traits::SerializableFst;
 use crate::tests_openfst::algorithms::closure::{
     test_closure_plus, test_closure_plus_dynamic, test_closure_star, test_closure_star_dynamic,
-    ClosureOperationResult, ClosureTestData,
+    SimpleStaticDynamicOperationResult, SimpleStaticDynamicTestData,
 };
 use crate::tests_openfst::algorithms::concat::{
     test_concat, test_concat_dynamic, ConcatOperationResult, ConcatTestData,
@@ -102,7 +102,7 @@ impl FstOperationResult {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ParsedFstTestData {
-    rmepsilon: FstOperationResult,
+    rmepsilon: SimpleStaticDynamicOperationResult,
     name: String,
     invert: FstOperationResult,
     weight_type: String,
@@ -143,8 +143,8 @@ pub struct ParsedFstTestData {
     replace: Vec<ReplaceOperationResult>,
     union: Vec<UnionOperationResult>,
     concat: Vec<ConcatOperationResult>,
-    closure_plus: ClosureOperationResult,
-    closure_star: ClosureOperationResult,
+    closure_plus: SimpleStaticDynamicOperationResult,
+    closure_star: SimpleStaticDynamicOperationResult,
     raw_vector_with_symt_bin_path: String,
 }
 
@@ -152,7 +152,7 @@ pub struct FstTestData<F: SerializableFst>
 where
     F::W: SerializableSemiring,
 {
-    pub rmepsilon: F,
+    pub rmepsilon: SimpleStaticDynamicTestData<F>,
     #[allow(unused)]
     pub name: String,
     pub invert: F,
@@ -193,8 +193,8 @@ where
     pub replace: Vec<ReplaceTestData<F>>,
     pub union: Vec<UnionTestData<F>>,
     pub concat: Vec<ConcatTestData<F>>,
-    pub closure_plus: ClosureTestData<F>,
-    pub closure_star: ClosureTestData<F>,
+    pub closure_plus: SimpleStaticDynamicTestData<F>,
+    pub closure_star: SimpleStaticDynamicTestData<F>,
     pub raw_vector_with_symt_bin_path: PathBuf,
 }
 
@@ -658,6 +658,12 @@ macro_rules! test_fst {
             #[test]
             fn test_rmepsilon_openfst() -> Fallible<()> {
                 do_run!(test_rmepsilon, $fst_name);
+                Ok(())
+            }
+
+            #[test]
+            fn test_rmepsilon_dynamic_openfst() -> Fallible<()> {
+                do_run!(test_rmepsilon_dynamic, $fst_name);
                 Ok(())
             }
         }


### PR DESCRIPTION
Fix : #63 
Fix : #73 
- `RmEpsilon` now mutates its input.
- `dfs_visit` now accepts an `ArcFilter` to be able to skip some arcs.
- `AutoQueue` and `TopOrderQueue` now take an `ArcFilter` in input.
- Remove `Fst` trait bound on `Clone` and `PartialEq`. However this is mandatory to be an `ExpandedFst`.
- `rmepsilon` no longer requires the `Semiring` to be a `StarSemiring`.
- Revamped RmEpsilon and ShortestDistance implementations in order to be closer to OpenFst's one.
- Added dynamic version of `RmEpsilon`, namely `RmEpsilonFst`.