### PR TITLE
Move doc-comment to dev dependencies

### DIFF
--- a/rustfst/Cargo.toml
+++ b/rustfst/Cargo.toml
@@ -29,7 +29,6 @@ ordered-float = '1'
 typenum = '1.10.0'
 stable_bst = '0.2.0'
 unsafe_unwrap = '0.1.0'
-doc-comment = "0.3.1"
 
 [dev-dependencies]
 counter = '0.4'
@@ -41,3 +40,4 @@ tempfile = '3.0'
 path_abs = '0.5'
 pretty_assertions = "0.6.1"
 proptest = "0.9.4"
+doc-comment = "0.3.1"


### PR DESCRIPTION
Found with cargo udeps (https://github.com/est31/cargo-udeps)