### PR TITLE
Reverse back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `FstIteratorMut` as a trait bound of `MutableFst`
 - Add `take_final_weight` and `take_final_weight_unchecked` to MutableFst API.
 - Add `add_super_final_state` algorithm.
+- Add the `ReverseBack` trait that must be implemented for Semiring::ReverseWeight. Allows to avoid using transmute when we have `weight.reverse().reverse()` calls.
 
 ### Changed
 - `fst_convert` now consumes its input. Use `fst_convert_from_ref` to pass a borrow.

--- a/rustfst/src/algorithms/push.rs
+++ b/rustfst/src/algorithms/push.rs
@@ -11,8 +11,8 @@ use crate::algorithms::{
     FactorWeightType, ReweightType,
 };
 use crate::fst_impls::VectorFst;
-use crate::fst_traits::{AllocableFst, CoreFst, ExpandedFst, Fst, MutableFst};
-use crate::semirings::{DivideType, Semiring, TropicalWeight};
+use crate::fst_traits::{AllocableFst, CoreFst, ExpandedFst, MutableFst};
+use crate::semirings::{DivideType, Semiring};
 use crate::semirings::{
     GallicWeightLeft, GallicWeightRight, StringWeightLeft, StringWeightRight,
     WeaklyDivisibleSemiring, WeightQuantize,

--- a/rustfst/src/algorithms/push.rs
+++ b/rustfst/src/algorithms/push.rs
@@ -11,8 +11,8 @@ use crate::algorithms::{
     FactorWeightType, ReweightType,
 };
 use crate::fst_impls::VectorFst;
-use crate::fst_traits::{AllocableFst, CoreFst, ExpandedFst, MutableFst};
-use crate::semirings::{DivideType, Semiring};
+use crate::fst_traits::{AllocableFst, CoreFst, ExpandedFst, Fst, MutableFst};
+use crate::semirings::{DivideType, Semiring, TropicalWeight};
 use crate::semirings::{
     GallicWeightLeft, GallicWeightRight, StringWeightLeft, StringWeightRight,
     WeaklyDivisibleSemiring, WeightQuantize,

--- a/rustfst/src/algorithms/queues/auto_queue.rs
+++ b/rustfst/src/algorithms/queues/auto_queue.rs
@@ -1,15 +1,15 @@
 use failure::Fallible;
 
-use crate::algorithms::{Queue, QueueType};
 use crate::algorithms::arc_filters::ArcFilter;
 use crate::algorithms::dfs_visit::dfs_visit;
 use crate::algorithms::visitors::SccVisitor;
+use crate::algorithms::{Queue, QueueType};
 use crate::fst_properties::FstProperties;
 use crate::fst_traits::ExpandedFst;
 use crate::semirings::{Semiring, SemiringProperties};
 
 use super::{
-    FifoQueue, LifoQueue, natural_less, NaturalShortestFirstQueue, SccQueue, StateOrderQueue,
+    natural_less, FifoQueue, LifoQueue, NaturalShortestFirstQueue, SccQueue, StateOrderQueue,
     TopOrderQueue, TrivialQueue,
 };
 

--- a/rustfst/src/algorithms/queues/top_order_queue.rs
+++ b/rustfst/src/algorithms/queues/top_order_queue.rs
@@ -1,7 +1,7 @@
-use crate::algorithms::{Queue, QueueType};
 use crate::algorithms::arc_filters::ArcFilter;
 use crate::algorithms::dfs_visit::dfs_visit;
 use crate::algorithms::top_sort::TopOrderVisitor;
+use crate::algorithms::{Queue, QueueType};
 use crate::fst_traits::ExpandedFst;
 use crate::StateId;
 

--- a/rustfst/src/algorithms/reverse.rs
+++ b/rustfst/src/algorithms/reverse.rs
@@ -3,6 +3,7 @@ use failure::Fallible;
 use crate::arc::Arc;
 use crate::fst_traits::{AllocableFst, ExpandedFst, MutableFst};
 use crate::semirings::Semiring;
+use crate::EPS_LABEL;
 
 /// Reverses an FST. The reversed result is written to an output mutable FST.
 /// If A transduces string x to y with weight a, then the reverse of A
@@ -36,9 +37,7 @@ where
     let istart = ifst.start();
     let ostart = ofst.add_state();
 
-    for _ in 0..ifst.num_states() {
-        ofst.add_state();
-    }
+    ofst.add_states(ifst.num_states());
 
     let mut c_arcs = vec![0; ifst.num_states() + 1];
     for is in 0..ifst.num_states() {
@@ -56,7 +55,7 @@ where
         }
         let weight = unsafe { ifst.final_weight_unchecked(is) };
         if let Some(w) = weight {
-            states_arcs[0].push(Arc::new(0, 0, w.reverse()?, os));
+            states_arcs[0].push(Arc::new(EPS_LABEL, EPS_LABEL, w.reverse()?, os));
         }
 
         for iarc in unsafe { ifst.arcs_iter_unchecked(is) } {

--- a/rustfst/src/algorithms/shortest_distance.rs
+++ b/rustfst/src/algorithms/shortest_distance.rs
@@ -4,11 +4,10 @@ use failure::Fallible;
 
 use crate::algorithms::arc_filters::{AnyArcFilter, ArcFilter};
 use crate::algorithms::queues::AutoQueue;
-use crate::algorithms::shortest_path::hack_convert_reverse_reverse;
 use crate::algorithms::Queue;
 use crate::fst_impls::VectorFst;
 use crate::fst_traits::{ExpandedFst, MutableFst};
-use crate::semirings::{Semiring, SemiringProperties};
+use crate::semirings::{Semiring, SemiringProperties, IntoSemiring};
 use crate::StateId;
 use std::borrow::Borrow;
 
@@ -280,9 +279,9 @@ where
         let rdistance = shortest_distance_with_config(&rfst, ropts)?;
         let mut distance = Vec::with_capacity(rdistance.len() - 1); //reversing added one state
         while distance.len() < rdistance.len() - 1 {
-            distance.push(hack_convert_reverse_reverse(
-                rdistance[distance.len() + 1].reverse()?,
-            ));
+            distance.push(
+                rdistance[distance.len() + 1].reverse_back()?,
+            );
         }
         Ok(distance)
     }

--- a/rustfst/src/algorithms/shortest_distance.rs
+++ b/rustfst/src/algorithms/shortest_distance.rs
@@ -7,7 +7,7 @@ use crate::algorithms::queues::AutoQueue;
 use crate::algorithms::Queue;
 use crate::fst_impls::VectorFst;
 use crate::fst_traits::{ExpandedFst, MutableFst};
-use crate::semirings::{IntoSemiring, Semiring, SemiringProperties};
+use crate::semirings::{ReverseBack, Semiring, SemiringProperties};
 use crate::StateId;
 use std::borrow::Borrow;
 

--- a/rustfst/src/algorithms/shortest_distance.rs
+++ b/rustfst/src/algorithms/shortest_distance.rs
@@ -7,7 +7,7 @@ use crate::algorithms::queues::AutoQueue;
 use crate::algorithms::Queue;
 use crate::fst_impls::VectorFst;
 use crate::fst_traits::{ExpandedFst, MutableFst};
-use crate::semirings::{Semiring, SemiringProperties, IntoSemiring};
+use crate::semirings::{IntoSemiring, Semiring, SemiringProperties};
 use crate::StateId;
 use std::borrow::Borrow;
 
@@ -279,9 +279,7 @@ where
         let rdistance = shortest_distance_with_config(&rfst, ropts)?;
         let mut distance = Vec::with_capacity(rdistance.len() - 1); //reversing added one state
         while distance.len() < rdistance.len() - 1 {
-            distance.push(
-                rdistance[distance.len() + 1].reverse_back()?,
-            );
+            distance.push(rdistance[distance.len() + 1].reverse_back()?);
         }
         Ok(distance)
     }

--- a/rustfst/src/algorithms/shortest_path.rs
+++ b/rustfst/src/algorithms/shortest_path.rs
@@ -13,7 +13,7 @@ use crate::algorithms::{connect, determinize_with_distance, reverse, shortest_di
 use crate::fst_impls::VectorFst;
 use crate::fst_traits::{ArcIterator, CoreFst, ExpandedFst, MutableFst};
 use crate::semirings::{
-    IntoSemiring, Semiring, SemiringProperties, WeaklyDivisibleSemiring, WeightQuantize,
+    ReverseBack, Semiring, SemiringProperties, WeaklyDivisibleSemiring, WeightQuantize,
 };
 use crate::Arc;
 use crate::StateId;

--- a/rustfst/src/algorithms/shortest_path.rs
+++ b/rustfst/src/algorithms/shortest_path.rs
@@ -12,7 +12,9 @@ use crate::algorithms::queues::AutoQueue;
 use crate::algorithms::{connect, determinize_with_distance, reverse, shortest_distance, Queue};
 use crate::fst_impls::VectorFst;
 use crate::fst_traits::{ArcIterator, CoreFst, ExpandedFst, MutableFst};
-use crate::semirings::{Semiring, SemiringProperties, WeaklyDivisibleSemiring, WeightQuantize, IntoSemiring};
+use crate::semirings::{
+    IntoSemiring, Semiring, SemiringProperties, WeaklyDivisibleSemiring, WeightQuantize,
+};
 use crate::Arc;
 use crate::StateId;
 
@@ -99,7 +101,7 @@ fn single_shortest_path<F>(
 ) -> Fallible<()>
 where
     F: ExpandedFst,
-    <F as CoreFst>::W: 'static,
+    F::W: 'static,
 {
     parent.clear();
     *f_parent = None;
@@ -257,7 +259,7 @@ impl<'a, 'b, W: Semiring> ShortestPathCompare<'a, 'b, W> {
 
 fn n_shortest_path<W, FI, FO>(ifst: &FI, distance: &[W], nshortest: usize) -> Fallible<FO>
 where
-    W: Semiring + 'static,
+    W: Semiring,
     FI: ExpandedFst<W = W::ReverseWeight> + MutableFst<W = W::ReverseWeight>,
     FO: MutableFst<W = W> + ExpandedFst<W = W>,
 {

--- a/rustfst/src/semirings/boolean_weight.rs
+++ b/rustfst/src/semirings/boolean_weight.rs
@@ -1,8 +1,6 @@
 use failure::Fallible;
 
-use crate::semirings::{
-    CompleteSemiring, IntoSemiring, Semiring, SemiringProperties, StarSemiring,
-};
+use crate::semirings::{CompleteSemiring, ReverseBack, Semiring, SemiringProperties, StarSemiring};
 use std::borrow::Borrow;
 /// Boolean semiring: (&, |, false, true).
 #[derive(Clone, Debug, PartialEq, PartialOrd, Default, Eq, Copy, Hash)]
@@ -59,9 +57,9 @@ impl Semiring for BooleanWeight {
     }
 }
 
-impl IntoSemiring<BooleanWeight> for BooleanWeight {
+impl ReverseBack<BooleanWeight> for BooleanWeight {
     fn reverse_back(&self) -> Fallible<BooleanWeight> {
-        unimplemented!()
+        Ok(self.clone())
     }
 }
 

--- a/rustfst/src/semirings/boolean_weight.rs
+++ b/rustfst/src/semirings/boolean_weight.rs
@@ -1,6 +1,6 @@
 use failure::Fallible;
 
-use crate::semirings::{CompleteSemiring, Semiring, SemiringProperties, StarSemiring};
+use crate::semirings::{CompleteSemiring, Semiring, SemiringProperties, StarSemiring, IntoSemiring};
 use std::borrow::Borrow;
 /// Boolean semiring: (&, |, false, true).
 #[derive(Clone, Debug, PartialEq, PartialOrd, Default, Eq, Copy, Hash)]
@@ -54,6 +54,12 @@ impl Semiring for BooleanWeight {
             | SemiringProperties::COMMUTATIVE
             | SemiringProperties::IDEMPOTENT
             | SemiringProperties::PATH
+    }
+}
+
+impl IntoSemiring<BooleanWeight> for BooleanWeight {
+    fn reverse_back(&self) -> Fallible<BooleanWeight> {
+        unimplemented!()
     }
 }
 

--- a/rustfst/src/semirings/boolean_weight.rs
+++ b/rustfst/src/semirings/boolean_weight.rs
@@ -1,6 +1,8 @@
 use failure::Fallible;
 
-use crate::semirings::{CompleteSemiring, Semiring, SemiringProperties, StarSemiring, IntoSemiring};
+use crate::semirings::{
+    CompleteSemiring, IntoSemiring, Semiring, SemiringProperties, StarSemiring,
+};
 use std::borrow::Borrow;
 /// Boolean semiring: (&, |, false, true).
 #[derive(Clone, Debug, PartialEq, PartialOrd, Default, Eq, Copy, Hash)]

--- a/rustfst/src/semirings/gallic_weight.rs
+++ b/rustfst/src/semirings/gallic_weight.rs
@@ -6,7 +6,7 @@ use std::marker::PhantomData;
 use failure::Fallible;
 use nom::IResult;
 
-use crate::semirings::ProductWeight;
+use crate::semirings::{ProductWeight, IntoSemiring};
 use crate::semirings::Semiring;
 #[cfg(test)]
 use crate::semirings::TropicalWeight;
@@ -68,6 +68,12 @@ macro_rules! gallic_weight {
         {
             fn as_ref(&self) -> &Self {
                 &self
+            }
+        }
+
+        impl<W: Semiring> IntoSemiring<$semiring> for <$semiring as Semiring>::ReverseWeight {
+            fn reverse_back(&self) -> Fallible<$semiring> {
+                unimplemented!()
             }
         }
 
@@ -376,6 +382,12 @@ impl<W: Semiring> Semiring for GallicWeight<W> {
 
     fn properties() -> SemiringProperties {
         UnionWeight::<GallicWeightRestrict<W>, GallicUnionWeightOption<GallicWeightRestrict<W>>>::properties()
+    }
+}
+
+impl<W: Semiring> IntoSemiring<GallicWeight<W>> for <GallicWeight<W> as Semiring>::ReverseWeight {
+    fn reverse_back(&self) -> Fallible<GallicWeight<W>> {
+        unimplemented!()
     }
 }
 

--- a/rustfst/src/semirings/gallic_weight.rs
+++ b/rustfst/src/semirings/gallic_weight.rs
@@ -13,7 +13,7 @@ use crate::semirings::{
     DivideType, SemiringProperties, SerializableSemiring, StringWeightLeft, StringWeightRestrict,
     StringWeightRight, UnionWeight, UnionWeightOption, WeaklyDivisibleSemiring, WeightQuantize,
 };
-use crate::semirings::{IntoSemiring, ProductWeight};
+use crate::semirings::{ProductWeight, ReverseBack};
 use crate::Label;
 
 /// Product of StringWeightLeft and an arbitrary weight.
@@ -71,9 +71,9 @@ macro_rules! gallic_weight {
             }
         }
 
-        impl<W: Semiring> IntoSemiring<$semiring> for <$semiring as Semiring>::ReverseWeight {
+        impl<W: Semiring> ReverseBack<$semiring> for <$semiring as Semiring>::ReverseWeight {
             fn reverse_back(&self) -> Fallible<$semiring> {
-                unimplemented!()
+                Ok(<$semiring>::new(self.0.reverse_back()?))
             }
         }
 
@@ -385,9 +385,9 @@ impl<W: Semiring> Semiring for GallicWeight<W> {
     }
 }
 
-impl<W: Semiring> IntoSemiring<GallicWeight<W>> for <GallicWeight<W> as Semiring>::ReverseWeight {
+impl<W: Semiring> ReverseBack<GallicWeight<W>> for <GallicWeight<W> as Semiring>::ReverseWeight {
     fn reverse_back(&self) -> Fallible<GallicWeight<W>> {
-        unimplemented!()
+        Ok(GallicWeight(self.0.reverse_back()?))
     }
 }
 

--- a/rustfst/src/semirings/gallic_weight.rs
+++ b/rustfst/src/semirings/gallic_weight.rs
@@ -6,7 +6,6 @@ use std::marker::PhantomData;
 use failure::Fallible;
 use nom::IResult;
 
-use crate::semirings::{ProductWeight, IntoSemiring};
 use crate::semirings::Semiring;
 #[cfg(test)]
 use crate::semirings::TropicalWeight;
@@ -14,6 +13,7 @@ use crate::semirings::{
     DivideType, SemiringProperties, SerializableSemiring, StringWeightLeft, StringWeightRestrict,
     StringWeightRight, UnionWeight, UnionWeightOption, WeaklyDivisibleSemiring, WeightQuantize,
 };
+use crate::semirings::{IntoSemiring, ProductWeight};
 use crate::Label;
 
 /// Product of StringWeightLeft and an arbitrary weight.

--- a/rustfst/src/semirings/integer_weight.rs
+++ b/rustfst/src/semirings/integer_weight.rs
@@ -3,7 +3,7 @@ use std::i32;
 
 use failure::Fallible;
 
-use crate::semirings::{CompleteSemiring, Semiring, SemiringProperties, StarSemiring};
+use crate::semirings::{CompleteSemiring, Semiring, SemiringProperties, StarSemiring, IntoSemiring};
 
 /// Probability semiring: (x, +, 0.0, 1.0).
 #[derive(Clone, Debug, PartialEq, PartialOrd, Default, Hash, Eq, Copy)]
@@ -56,6 +56,12 @@ impl Semiring for IntegerWeight {
         SemiringProperties::LEFT_SEMIRING
             | SemiringProperties::RIGHT_SEMIRING
             | SemiringProperties::COMMUTATIVE
+    }
+}
+
+impl IntoSemiring<IntegerWeight> for IntegerWeight {
+    fn reverse_back(&self) -> Fallible<IntegerWeight> {
+        unimplemented!()
     }
 }
 

--- a/rustfst/src/semirings/integer_weight.rs
+++ b/rustfst/src/semirings/integer_weight.rs
@@ -3,7 +3,9 @@ use std::i32;
 
 use failure::Fallible;
 
-use crate::semirings::{CompleteSemiring, Semiring, SemiringProperties, StarSemiring, IntoSemiring};
+use crate::semirings::{
+    CompleteSemiring, IntoSemiring, Semiring, SemiringProperties, StarSemiring,
+};
 
 /// Probability semiring: (x, +, 0.0, 1.0).
 #[derive(Clone, Debug, PartialEq, PartialOrd, Default, Hash, Eq, Copy)]

--- a/rustfst/src/semirings/integer_weight.rs
+++ b/rustfst/src/semirings/integer_weight.rs
@@ -3,9 +3,7 @@ use std::i32;
 
 use failure::Fallible;
 
-use crate::semirings::{
-    CompleteSemiring, IntoSemiring, Semiring, SemiringProperties, StarSemiring,
-};
+use crate::semirings::{CompleteSemiring, ReverseBack, Semiring, SemiringProperties, StarSemiring};
 
 /// Probability semiring: (x, +, 0.0, 1.0).
 #[derive(Clone, Debug, PartialEq, PartialOrd, Default, Hash, Eq, Copy)]
@@ -61,9 +59,9 @@ impl Semiring for IntegerWeight {
     }
 }
 
-impl IntoSemiring<IntegerWeight> for IntegerWeight {
+impl ReverseBack<IntegerWeight> for IntegerWeight {
     fn reverse_back(&self) -> Fallible<IntegerWeight> {
-        unimplemented!()
+        Ok(self.clone())
     }
 }
 

--- a/rustfst/src/semirings/log_weight.rs
+++ b/rustfst/src/semirings/log_weight.rs
@@ -7,7 +7,10 @@ use failure::Fallible;
 use ordered_float::OrderedFloat;
 
 use crate::parsers::bin_fst::utils_serialization::write_bin_f32;
-use crate::semirings::{CompleteSemiring, DivideType, Semiring, SemiringProperties, SerializableSemiring, StarSemiring, WeaklyDivisibleSemiring, WeightQuantize, IntoSemiring};
+use crate::semirings::{
+    CompleteSemiring, DivideType, IntoSemiring, Semiring, SemiringProperties, SerializableSemiring,
+    StarSemiring, WeaklyDivisibleSemiring, WeightQuantize,
+};
 use crate::KDELTA;
 use nom::number::complete::{float, le_f32};
 use nom::IResult;

--- a/rustfst/src/semirings/log_weight.rs
+++ b/rustfst/src/semirings/log_weight.rs
@@ -7,10 +7,7 @@ use failure::Fallible;
 use ordered_float::OrderedFloat;
 
 use crate::parsers::bin_fst::utils_serialization::write_bin_f32;
-use crate::semirings::{
-    CompleteSemiring, DivideType, Semiring, SemiringProperties, SerializableSemiring, StarSemiring,
-    WeaklyDivisibleSemiring, WeightQuantize,
-};
+use crate::semirings::{CompleteSemiring, DivideType, Semiring, SemiringProperties, SerializableSemiring, StarSemiring, WeaklyDivisibleSemiring, WeightQuantize, IntoSemiring};
 use crate::KDELTA;
 use nom::number::complete::{float, le_f32};
 use nom::IResult;
@@ -94,6 +91,12 @@ impl Semiring for LogWeight {
         SemiringProperties::LEFT_SEMIRING
             | SemiringProperties::RIGHT_SEMIRING
             | SemiringProperties::COMMUTATIVE
+    }
+}
+
+impl IntoSemiring<LogWeight> for LogWeight {
+    fn reverse_back(&self) -> Fallible<LogWeight> {
+        unimplemented!()
     }
 }
 

--- a/rustfst/src/semirings/log_weight.rs
+++ b/rustfst/src/semirings/log_weight.rs
@@ -8,7 +8,7 @@ use ordered_float::OrderedFloat;
 
 use crate::parsers::bin_fst::utils_serialization::write_bin_f32;
 use crate::semirings::{
-    CompleteSemiring, DivideType, IntoSemiring, Semiring, SemiringProperties, SerializableSemiring,
+    CompleteSemiring, DivideType, ReverseBack, Semiring, SemiringProperties, SerializableSemiring,
     StarSemiring, WeaklyDivisibleSemiring, WeightQuantize,
 };
 use crate::KDELTA;
@@ -97,9 +97,9 @@ impl Semiring for LogWeight {
     }
 }
 
-impl IntoSemiring<LogWeight> for LogWeight {
+impl ReverseBack<LogWeight> for LogWeight {
     fn reverse_back(&self) -> Fallible<LogWeight> {
-        unimplemented!()
+        Ok(self.clone())
     }
 }
 

--- a/rustfst/src/semirings/mod.rs
+++ b/rustfst/src/semirings/mod.rs
@@ -25,7 +25,7 @@ pub use self::log_weight::LogWeight;
 pub use self::probability_weight::ProbabilityWeight;
 pub use self::product_weight::ProductWeight;
 pub use self::semiring::{
-    CompleteSemiring, DivideType, IntoSemiring, Semiring, SemiringProperties, SerializableSemiring,
+    CompleteSemiring, DivideType, ReverseBack, Semiring, SemiringProperties, SerializableSemiring,
     StarSemiring, WeaklyDivisibleSemiring, WeightQuantize,
 };
 pub(crate) use self::string_variant::StringWeightVariant;

--- a/rustfst/src/semirings/mod.rs
+++ b/rustfst/src/semirings/mod.rs
@@ -26,7 +26,7 @@ pub use self::probability_weight::ProbabilityWeight;
 pub use self::product_weight::ProductWeight;
 pub use self::semiring::{
     CompleteSemiring, DivideType, Semiring, SemiringProperties, SerializableSemiring, StarSemiring,
-    WeaklyDivisibleSemiring, WeightQuantize,
+    WeaklyDivisibleSemiring, WeightQuantize, IntoSemiring
 };
 pub(crate) use self::string_variant::StringWeightVariant;
 pub use self::string_weight::{

--- a/rustfst/src/semirings/mod.rs
+++ b/rustfst/src/semirings/mod.rs
@@ -25,8 +25,8 @@ pub use self::log_weight::LogWeight;
 pub use self::probability_weight::ProbabilityWeight;
 pub use self::product_weight::ProductWeight;
 pub use self::semiring::{
-    CompleteSemiring, DivideType, Semiring, SemiringProperties, SerializableSemiring, StarSemiring,
-    WeaklyDivisibleSemiring, WeightQuantize, IntoSemiring
+    CompleteSemiring, DivideType, IntoSemiring, Semiring, SemiringProperties, SerializableSemiring,
+    StarSemiring, WeaklyDivisibleSemiring, WeightQuantize,
 };
 pub(crate) use self::string_variant::StringWeightVariant;
 pub use self::string_weight::{

--- a/rustfst/src/semirings/probability_weight.rs
+++ b/rustfst/src/semirings/probability_weight.rs
@@ -6,7 +6,7 @@ use failure::Fallible;
 use ordered_float::OrderedFloat;
 
 use crate::semirings::{
-    CompleteSemiring, DivideType, IntoSemiring, Semiring, SemiringProperties, StarSemiring,
+    CompleteSemiring, DivideType, ReverseBack, Semiring, SemiringProperties, StarSemiring,
     WeaklyDivisibleSemiring, WeightQuantize,
 };
 use crate::KDELTA;
@@ -71,7 +71,7 @@ impl Semiring for ProbabilityWeight {
     }
 }
 
-impl IntoSemiring<ProbabilityWeight> for ProbabilityWeight {
+impl ReverseBack<ProbabilityWeight> for ProbabilityWeight {
     fn reverse_back(&self) -> Fallible<ProbabilityWeight> {
         unimplemented!()
     }

--- a/rustfst/src/semirings/probability_weight.rs
+++ b/rustfst/src/semirings/probability_weight.rs
@@ -5,10 +5,7 @@ use std::hash::{Hash, Hasher};
 use failure::Fallible;
 use ordered_float::OrderedFloat;
 
-use crate::semirings::{
-    CompleteSemiring, DivideType, Semiring, SemiringProperties, StarSemiring,
-    WeaklyDivisibleSemiring, WeightQuantize,
-};
+use crate::semirings::{CompleteSemiring, DivideType, Semiring, SemiringProperties, StarSemiring, WeaklyDivisibleSemiring, WeightQuantize, IntoSemiring};
 use crate::KDELTA;
 
 /// Probability semiring: (x, +, 0.0, 1.0).
@@ -68,6 +65,12 @@ impl Semiring for ProbabilityWeight {
         SemiringProperties::LEFT_SEMIRING
             | SemiringProperties::RIGHT_SEMIRING
             | SemiringProperties::COMMUTATIVE
+    }
+}
+
+impl IntoSemiring<ProbabilityWeight> for ProbabilityWeight {
+    fn reverse_back(&self) -> Fallible<ProbabilityWeight> {
+        unimplemented!()
     }
 }
 

--- a/rustfst/src/semirings/probability_weight.rs
+++ b/rustfst/src/semirings/probability_weight.rs
@@ -5,7 +5,10 @@ use std::hash::{Hash, Hasher};
 use failure::Fallible;
 use ordered_float::OrderedFloat;
 
-use crate::semirings::{CompleteSemiring, DivideType, Semiring, SemiringProperties, StarSemiring, WeaklyDivisibleSemiring, WeightQuantize, IntoSemiring};
+use crate::semirings::{
+    CompleteSemiring, DivideType, IntoSemiring, Semiring, SemiringProperties, StarSemiring,
+    WeaklyDivisibleSemiring, WeightQuantize,
+};
 use crate::KDELTA;
 
 /// Probability semiring: (x, +, 0.0, 1.0).

--- a/rustfst/src/semirings/product_weight.rs
+++ b/rustfst/src/semirings/product_weight.rs
@@ -7,7 +7,7 @@ use failure::Fallible;
 use nom::IResult;
 
 use crate::semirings::{
-    DivideType, IntoSemiring, Semiring, SemiringProperties, SerializableSemiring,
+    DivideType, ReverseBack, Semiring, SemiringProperties, SerializableSemiring,
     WeaklyDivisibleSemiring, WeightQuantize,
 };
 #[cfg(test)]
@@ -96,11 +96,11 @@ where
     }
 }
 
-impl<W1: Semiring, W2: Semiring> IntoSemiring<ProductWeight<W1, W2>>
+impl<W1: Semiring, W2: Semiring> ReverseBack<ProductWeight<W1, W2>>
     for <ProductWeight<W1, W2> as Semiring>::ReverseWeight
 {
     fn reverse_back(&self) -> Fallible<ProductWeight<W1, W2>> {
-        unimplemented!()
+        Ok((self.value1().reverse_back()?, self.value2().reverse_back()?).into())
     }
 }
 

--- a/rustfst/src/semirings/product_weight.rs
+++ b/rustfst/src/semirings/product_weight.rs
@@ -6,7 +6,10 @@ use std::io::Write;
 use failure::Fallible;
 use nom::IResult;
 
-use crate::semirings::{DivideType, Semiring, SemiringProperties, SerializableSemiring, WeaklyDivisibleSemiring, WeightQuantize, IntoSemiring};
+use crate::semirings::{
+    DivideType, IntoSemiring, Semiring, SemiringProperties, SerializableSemiring,
+    WeaklyDivisibleSemiring, WeightQuantize,
+};
 #[cfg(test)]
 use crate::semirings::{LogWeight, TropicalWeight};
 
@@ -93,7 +96,9 @@ where
     }
 }
 
-impl<W1: Semiring, W2: Semiring> IntoSemiring<ProductWeight<W1, W2>> for <ProductWeight<W1, W2> as Semiring>::ReverseWeight {
+impl<W1: Semiring, W2: Semiring> IntoSemiring<ProductWeight<W1, W2>>
+    for <ProductWeight<W1, W2> as Semiring>::ReverseWeight
+{
     fn reverse_back(&self) -> Fallible<ProductWeight<W1, W2>> {
         unimplemented!()
     }

--- a/rustfst/src/semirings/product_weight.rs
+++ b/rustfst/src/semirings/product_weight.rs
@@ -6,10 +6,7 @@ use std::io::Write;
 use failure::Fallible;
 use nom::IResult;
 
-use crate::semirings::{
-    DivideType, Semiring, SemiringProperties, SerializableSemiring, WeaklyDivisibleSemiring,
-    WeightQuantize,
-};
+use crate::semirings::{DivideType, Semiring, SemiringProperties, SerializableSemiring, WeaklyDivisibleSemiring, WeightQuantize, IntoSemiring};
 #[cfg(test)]
 use crate::semirings::{LogWeight, TropicalWeight};
 
@@ -93,6 +90,12 @@ where
                 | SemiringProperties::RIGHT_SEMIRING
                 | SemiringProperties::COMMUTATIVE
                 | SemiringProperties::IDEMPOTENT)
+    }
+}
+
+impl<W1: Semiring, W2: Semiring> IntoSemiring<ProductWeight<W1, W2>> for <ProductWeight<W1, W2> as Semiring>::ReverseWeight {
+    fn reverse_back(&self) -> Fallible<ProductWeight<W1, W2>> {
+        unimplemented!()
     }
 }
 

--- a/rustfst/src/semirings/semiring.rs
+++ b/rustfst/src/semirings/semiring.rs
@@ -34,7 +34,7 @@ bitflags! {
 /// For more information : https://cs.nyu.edu/~mohri/pub/hwa.pdf
 pub trait Semiring: Clone + PartialEq + PartialOrd + Debug + Hash + Eq {
     type Type: Clone;
-    type ReverseWeight: Semiring + IntoSemiring<Self>;
+    type ReverseWeight: Semiring + ReverseBack<Self>;
 
     fn zero() -> Self;
     fn one() -> Self;
@@ -70,15 +70,9 @@ pub trait Semiring: Clone + PartialEq + PartialOrd + Debug + Hash + Eq {
     fn properties() -> SemiringProperties;
 }
 
-pub trait IntoSemiring<W> {
+pub trait ReverseBack<W> {
     fn reverse_back(&self) -> Fallible<W>;
 }
-
-//impl<W: Semiring> IntoSemiring<W> for W {
-//    fn reverse(&self) -> Fallible<W> {
-//        unimplemented!()
-//    }
-//}
 
 /// Determines direction of division.
 #[derive(Copy, Clone, PartialOrd, PartialEq)]

--- a/rustfst/src/semirings/semiring.rs
+++ b/rustfst/src/semirings/semiring.rs
@@ -34,7 +34,7 @@ bitflags! {
 /// For more information : https://cs.nyu.edu/~mohri/pub/hwa.pdf
 pub trait Semiring: Clone + PartialEq + PartialOrd + Debug + Hash + Eq {
     type Type: Clone;
-    type ReverseWeight: Semiring;
+    type ReverseWeight: Semiring + IntoSemiring<Self>;
 
     fn zero() -> Self;
     fn one() -> Self;
@@ -67,9 +67,18 @@ pub trait Semiring: Clone + PartialEq + PartialOrd + Debug + Hash + Eq {
         *self == Self::zero()
     }
     fn reverse(&self) -> Fallible<Self::ReverseWeight>;
-
     fn properties() -> SemiringProperties;
 }
+
+pub trait IntoSemiring<W> {
+    fn reverse_back(&self) -> Fallible<W>;
+}
+
+//impl<W: Semiring> IntoSemiring<W> for W {
+//    fn reverse(&self) -> Fallible<W> {
+//        unimplemented!()
+//    }
+//}
 
 /// Determines direction of division.
 #[derive(Copy, Clone, PartialOrd, PartialEq)]

--- a/rustfst/src/semirings/string_weight.rs
+++ b/rustfst/src/semirings/string_weight.rs
@@ -13,8 +13,8 @@ use crate::parsers::bin_fst::utils_serialization::write_bin_i32;
 use crate::parsers::nom_utils::num;
 use crate::semirings::string_variant::StringWeightVariant;
 use crate::semirings::{
-    DivideType, Semiring, SemiringProperties, SerializableSemiring, WeaklyDivisibleSemiring,
-    WeightQuantize, IntoSemiring
+    DivideType, IntoSemiring, Semiring, SemiringProperties, SerializableSemiring,
+    WeaklyDivisibleSemiring, WeightQuantize,
 };
 use crate::Label;
 

--- a/rustfst/src/semirings/string_weight.rs
+++ b/rustfst/src/semirings/string_weight.rs
@@ -14,7 +14,7 @@ use crate::parsers::nom_utils::num;
 use crate::semirings::string_variant::StringWeightVariant;
 use crate::semirings::{
     DivideType, Semiring, SemiringProperties, SerializableSemiring, WeaklyDivisibleSemiring,
-    WeightQuantize,
+    WeightQuantize, IntoSemiring
 };
 use crate::Label;
 
@@ -52,6 +52,12 @@ macro_rules! string_semiring {
         impl AsRef<Self> for $semiring {
             fn as_ref(&self) -> &$semiring {
                 &self
+            }
+        }
+
+        impl IntoSemiring<$semiring> for <$semiring as Semiring>::ReverseWeight {
+            fn reverse_back(&self) -> Fallible<$semiring> {
+                unimplemented!()
             }
         }
 

--- a/rustfst/src/semirings/string_weight.rs
+++ b/rustfst/src/semirings/string_weight.rs
@@ -13,7 +13,7 @@ use crate::parsers::bin_fst::utils_serialization::write_bin_i32;
 use crate::parsers::nom_utils::num;
 use crate::semirings::string_variant::StringWeightVariant;
 use crate::semirings::{
-    DivideType, IntoSemiring, Semiring, SemiringProperties, SerializableSemiring,
+    DivideType, ReverseBack, Semiring, SemiringProperties, SerializableSemiring,
     WeaklyDivisibleSemiring, WeightQuantize,
 };
 use crate::Label;
@@ -55,9 +55,9 @@ macro_rules! string_semiring {
             }
         }
 
-        impl IntoSemiring<$semiring> for <$semiring as Semiring>::ReverseWeight {
+        impl ReverseBack<$semiring> for <$semiring as Semiring>::ReverseWeight {
             fn reverse_back(&self) -> Fallible<$semiring> {
-                unimplemented!()
+                self.reverse()
             }
         }
 

--- a/rustfst/src/semirings/tropical_weight.rs
+++ b/rustfst/src/semirings/tropical_weight.rs
@@ -10,7 +10,10 @@ use ordered_float::OrderedFloat;
 
 use crate::parsers::bin_fst::utils_serialization::write_bin_f32;
 use crate::semirings::semiring::SerializableSemiring;
-use crate::semirings::{CompleteSemiring, DivideType, Semiring, SemiringProperties, StarSemiring, WeaklyDivisibleSemiring, WeightQuantize, IntoSemiring};
+use crate::semirings::{
+    CompleteSemiring, DivideType, IntoSemiring, Semiring, SemiringProperties, StarSemiring,
+    WeaklyDivisibleSemiring, WeightQuantize,
+};
 use crate::KDELTA;
 
 /// Tropical semiring: (min, +, inf, 0).

--- a/rustfst/src/semirings/tropical_weight.rs
+++ b/rustfst/src/semirings/tropical_weight.rs
@@ -10,10 +10,7 @@ use ordered_float::OrderedFloat;
 
 use crate::parsers::bin_fst::utils_serialization::write_bin_f32;
 use crate::semirings::semiring::SerializableSemiring;
-use crate::semirings::{
-    CompleteSemiring, DivideType, Semiring, SemiringProperties, StarSemiring,
-    WeaklyDivisibleSemiring, WeightQuantize,
-};
+use crate::semirings::{CompleteSemiring, DivideType, Semiring, SemiringProperties, StarSemiring, WeaklyDivisibleSemiring, WeightQuantize, IntoSemiring};
 use crate::KDELTA;
 
 /// Tropical semiring: (min, +, inf, 0).
@@ -85,6 +82,12 @@ impl Semiring for TropicalWeight {
             | SemiringProperties::COMMUTATIVE
             | SemiringProperties::PATH
             | SemiringProperties::IDEMPOTENT
+    }
+}
+
+impl IntoSemiring<TropicalWeight> for TropicalWeight {
+    fn reverse_back(&self) -> Fallible<TropicalWeight> {
+        unimplemented!()
     }
 }
 

--- a/rustfst/src/semirings/tropical_weight.rs
+++ b/rustfst/src/semirings/tropical_weight.rs
@@ -11,7 +11,7 @@ use ordered_float::OrderedFloat;
 use crate::parsers::bin_fst::utils_serialization::write_bin_f32;
 use crate::semirings::semiring::SerializableSemiring;
 use crate::semirings::{
-    CompleteSemiring, DivideType, IntoSemiring, Semiring, SemiringProperties, StarSemiring,
+    CompleteSemiring, DivideType, ReverseBack, Semiring, SemiringProperties, StarSemiring,
     WeaklyDivisibleSemiring, WeightQuantize,
 };
 use crate::KDELTA;
@@ -88,9 +88,9 @@ impl Semiring for TropicalWeight {
     }
 }
 
-impl IntoSemiring<TropicalWeight> for TropicalWeight {
+impl ReverseBack<TropicalWeight> for TropicalWeight {
     fn reverse_back(&self) -> Fallible<TropicalWeight> {
-        unimplemented!()
+        Ok(self.clone())
     }
 }
 

--- a/rustfst/src/semirings/union_weight.rs
+++ b/rustfst/src/semirings/union_weight.rs
@@ -15,7 +15,7 @@ use nom::IResult;
 
 use crate::parsers::bin_fst::utils_serialization::write_bin_i32;
 use crate::semirings::{
-    DivideType, IntoSemiring, Semiring, SemiringProperties, SerializableSemiring,
+    DivideType, ReverseBack, Semiring, SemiringProperties, SerializableSemiring,
     WeaklyDivisibleSemiring, WeightQuantize,
 };
 
@@ -305,10 +305,12 @@ where
     }
 }
 
-impl<W: Semiring, O: UnionWeightOption<W>> IntoSemiring<UnionWeight<W, O>>
+impl<W: Semiring, O: UnionWeightOption<W>> ReverseBack<UnionWeight<W, O>>
     for <UnionWeight<W, O> as Semiring>::ReverseWeight
 {
     fn reverse_back(&self) -> Fallible<UnionWeight<W, O>> {
-        unimplemented!()
+        let res = self.reverse()?;
+        // TODO: Find a way to avoid this transmute. For the moment, it is necessary because of the compare function.
+        unsafe { Ok(std::mem::transmute(res)) }
     }
 }

--- a/rustfst/src/semirings/union_weight.rs
+++ b/rustfst/src/semirings/union_weight.rs
@@ -14,10 +14,7 @@ use nom::number::complete::le_i32;
 use nom::IResult;
 
 use crate::parsers::bin_fst::utils_serialization::write_bin_i32;
-use crate::semirings::{
-    DivideType, Semiring, SemiringProperties, SerializableSemiring, WeaklyDivisibleSemiring,
-    WeightQuantize,
-};
+use crate::semirings::{DivideType, Semiring, SemiringProperties, SerializableSemiring, WeaklyDivisibleSemiring, WeightQuantize, IntoSemiring};
 
 pub trait UnionWeightOption<W: Semiring>: Debug + Hash + Clone + PartialOrd + Eq {
     type ReverseOptions: UnionWeightOption<W::ReverseWeight>;
@@ -302,5 +299,11 @@ where
     fn parse_text(i: &str) -> IResult<&str, Self> {
         let (i, res) = alt((Self::parse_text_empty_set, Self::parse_text_non_empty_set))(i)?;
         Ok((i, res))
+    }
+}
+
+impl<W: Semiring, O: UnionWeightOption<W>> IntoSemiring<UnionWeight<W, O>> for <UnionWeight<W,O> as Semiring>::ReverseWeight {
+    fn reverse_back(&self) -> Fallible<UnionWeight<W, O>> {
+        unimplemented!()
     }
 }

--- a/rustfst/src/semirings/union_weight.rs
+++ b/rustfst/src/semirings/union_weight.rs
@@ -14,7 +14,10 @@ use nom::number::complete::le_i32;
 use nom::IResult;
 
 use crate::parsers::bin_fst::utils_serialization::write_bin_i32;
-use crate::semirings::{DivideType, Semiring, SemiringProperties, SerializableSemiring, WeaklyDivisibleSemiring, WeightQuantize, IntoSemiring};
+use crate::semirings::{
+    DivideType, IntoSemiring, Semiring, SemiringProperties, SerializableSemiring,
+    WeaklyDivisibleSemiring, WeightQuantize,
+};
 
 pub trait UnionWeightOption<W: Semiring>: Debug + Hash + Clone + PartialOrd + Eq {
     type ReverseOptions: UnionWeightOption<W::ReverseWeight>;
@@ -302,7 +305,9 @@ where
     }
 }
 
-impl<W: Semiring, O: UnionWeightOption<W>> IntoSemiring<UnionWeight<W, O>> for <UnionWeight<W,O> as Semiring>::ReverseWeight {
+impl<W: Semiring, O: UnionWeightOption<W>> IntoSemiring<UnionWeight<W, O>>
+    for <UnionWeight<W, O> as Semiring>::ReverseWeight
+{
     fn reverse_back(&self) -> Fallible<UnionWeight<W, O>> {
         unimplemented!()
     }

--- a/rustfst/src/tests_openfst/test_weights.rs
+++ b/rustfst/src/tests_openfst/test_weights.rs
@@ -5,8 +5,8 @@ use serde_derive::{Deserialize, Serialize};
 
 use crate::semirings::{
     GallicWeight, GallicWeightLeft, GallicWeightMin, GallicWeightRestrict, GallicWeightRight,
-    LogWeight, ProductWeight, SerializableSemiring, StringWeightLeft, StringWeightRestrict,
-    StringWeightRight, TropicalWeight,
+    LogWeight, ProductWeight, ReverseBack, SerializableSemiring, StringWeightLeft,
+    StringWeightRestrict, StringWeightRight, TropicalWeight,
 };
 use crate::Arc;
 
@@ -69,6 +69,11 @@ fn do_run_test_openfst_weight<W: SerializableSemiring>(
     );
     assert_eq!(W::weight_type(), test_data.weight_type);
     assert_eq!(Arc::<W>::arc_type(), test_data.arc_type);
+
+    assert_eq!(
+        test_data.weight_1.reverse()?.reverse_back()?,
+        test_data.weight_1
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Add the `ReverseBack` trait that must be implemented for `Semiring::ReverseWeight`. Allows to avoid using transmute when we have `weight.reverse().reverse()` calls.