### PR TITLE
Symbol table serialization when serializing a FST (Binary) 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `take_final_weight` and `take_final_weight_unchecked` to MutableFst API.
 - Add `add_super_final_state` algorithm.
 - Add the `ReverseBack` trait that must be implemented for Semiring::ReverseWeight. Allows to avoid using transmute when we have `weight.reverse().reverse()` calls.
+- Implement `SerializableSemiring` for `ProbabilityWeight`
+- Add support for `SymbolTable` serialization while serializing a FST in binary format.
+
 
 ### Changed
 - `fst_convert` now consumes its input. Use `fst_convert_from_ref` to pass a borrow.

--- a/rustfst/src/fst_impls/const_fst/serializable_fst.rs
+++ b/rustfst/src/fst_impls/const_fst/serializable_fst.rs
@@ -44,13 +44,21 @@ impl<W: 'static + SerializableSemiring> SerializableFst for ConstFst<W> {
     fn write<P: AsRef<Path>>(&self, path_bin_fst: P) -> Fallible<()> {
         let mut file = BufWriter::new(File::create(path_bin_fst)?);
 
+        let mut flags = FstFlags::empty();
+        if self.input_symbols().is_some(){
+            flags |= FstFlags::HAS_ISYMBOLS;
+        }
+        if self.output_symbols().is_some(){
+            flags |= FstFlags::HAS_OSYMBOLS;
+        }
+
         let hdr = FstHeader {
             magic_number: FST_MAGIC_NUMBER,
             fst_type: OpenFstString::new(Self::fst_type()),
             arc_type: OpenFstString::new(Arc::<W>::arc_type()),
             version: CONST_FILE_VERSION,
-            // TODO: Flags are used to check whether or not a symboltable has to be loaded
-            flags: FstFlags::empty(),
+            // TODO: Set flags if the content is aligned
+            flags,
             // TODO: Once the properties are stored, need to read them. kExpanded
             properties: 1u64,
             start: self.start.map(|v| v as i64).unwrap_or(-1),

--- a/rustfst/src/fst_impls/const_fst/serializable_fst.rs
+++ b/rustfst/src/fst_impls/const_fst/serializable_fst.rs
@@ -45,10 +45,10 @@ impl<W: 'static + SerializableSemiring> SerializableFst for ConstFst<W> {
         let mut file = BufWriter::new(File::create(path_bin_fst)?);
 
         let mut flags = FstFlags::empty();
-        if self.input_symbols().is_some(){
+        if self.input_symbols().is_some() {
             flags |= FstFlags::HAS_ISYMBOLS;
         }
-        if self.output_symbols().is_some(){
+        if self.output_symbols().is_some() {
             flags |= FstFlags::HAS_OSYMBOLS;
         }
 

--- a/rustfst/src/fst_impls/vector_fst/serializable_fst.rs
+++ b/rustfst/src/fst_impls/vector_fst/serializable_fst.rs
@@ -47,10 +47,10 @@ impl<W: 'static + SerializableSemiring> SerializableFst for VectorFst<W> {
             .sum();
 
         let mut flags = FstFlags::empty();
-        if self.input_symbols().is_some(){
+        if self.input_symbols().is_some() {
             flags |= FstFlags::HAS_ISYMBOLS;
         }
-        if self.output_symbols().is_some(){
+        if self.output_symbols().is_some() {
             flags |= FstFlags::HAS_OSYMBOLS;
         }
 

--- a/rustfst/src/fst_impls/vector_fst/serializable_fst.rs
+++ b/rustfst/src/fst_impls/vector_fst/serializable_fst.rs
@@ -46,13 +46,21 @@ impl<W: 'static + SerializableSemiring> SerializableFst for VectorFst<W> {
             .map(|s: usize| unsafe { self.num_arcs_unchecked(s) })
             .sum();
 
+        let mut flags = FstFlags::empty();
+        if self.input_symbols().is_some(){
+            flags |= FstFlags::HAS_ISYMBOLS;
+        }
+        if self.output_symbols().is_some(){
+            flags |= FstFlags::HAS_OSYMBOLS;
+        }
+
         let hdr = FstHeader {
             magic_number: FST_MAGIC_NUMBER,
             fst_type: OpenFstString::new(Self::fst_type()),
             arc_type: OpenFstString::new(Arc::<W>::arc_type()),
             version: 2i32,
             // TODO: Set flags if the content is aligned
-            flags: FstFlags::empty(),
+            flags,
             // TODO: Once the properties are stored, need to read them
             properties: 3u64,
             start: self.start_state.map(|v| v as i64).unwrap_or(-1),

--- a/rustfst/src/parsers/bin_fst/fst_header.rs
+++ b/rustfst/src/parsers/bin_fst/fst_header.rs
@@ -11,7 +11,7 @@ use bitflags::bitflags;
 use crate::parsers::bin_fst::utils_serialization::{
     write_bin_i32, write_bin_i64, write_bin_u32, write_bin_u64,
 };
-use crate::parsers::bin_symt::nom_parser::{ parse_symbol_table_bin, write_bin_symt };
+use crate::parsers::bin_symt::nom_parser::{parse_symbol_table_bin, write_bin_symt};
 use crate::SymbolTable;
 use std::rc::Rc;
 

--- a/rustfst/src/parsers/bin_fst/fst_header.rs
+++ b/rustfst/src/parsers/bin_fst/fst_header.rs
@@ -11,7 +11,7 @@ use bitflags::bitflags;
 use crate::parsers::bin_fst::utils_serialization::{
     write_bin_i32, write_bin_i64, write_bin_u32, write_bin_u64,
 };
-use crate::parsers::bin_symt::nom_parser::parse_symbol_table_bin;
+use crate::parsers::bin_symt::nom_parser::{ parse_symbol_table_bin, write_bin_symt };
 use crate::SymbolTable;
 use std::rc::Rc;
 
@@ -53,6 +53,14 @@ fn optionally_parse_symt(i: &[u8], parse_symt: bool) -> IResult<&[u8], Option<Sy
         Ok((i, Some(symt)))
     } else {
         Ok((i, None))
+    }
+}
+
+fn optionally_write_symt<W: Write>(file: &mut W, symt: &Option<Rc<SymbolTable>>) -> Fallible<()> {
+    if let Some(symt) = symt {
+        write_bin_symt(file, symt)
+    } else {
+        Ok(())
     }
 }
 
@@ -119,6 +127,8 @@ impl FstHeader {
         write_bin_i64(file, self.num_states)?;
         //num_arcs: i64,
         write_bin_i64(file, self.num_arcs)?;
+        optionally_write_symt(file, &self.isymt)?;
+        optionally_write_symt(file, &self.osymt)?;
         Ok(())
     }
 }

--- a/rustfst/src/semirings/probability_weight.rs
+++ b/rustfst/src/semirings/probability_weight.rs
@@ -131,6 +131,12 @@ impl_quantize_f32!(ProbabilityWeight);
 
 partial_eq_and_hash_f32!(ProbabilityWeight);
 
+test_semiring_serializable!(
+    tests_probability_weight_serializable,
+    ProbabilityWeight,
+    ProbabilityWeight::one() ProbabilityWeight::zero() ProbabilityWeight::new(0.3) ProbabilityWeight::new(0.5) ProbabilityWeight::new(0.0) ProbabilityWeight::new(1.0)
+);
+
 impl Into<ProbabilityWeight> for f32 {
     fn into(self) -> ProbabilityWeight {
         ProbabilityWeight::new(self)

--- a/rustfst/src/tests_openfst/io/const_fst_bin_serializer.rs
+++ b/rustfst/src/tests_openfst/io/const_fst_bin_serializer.rs
@@ -2,10 +2,10 @@ use failure::Fallible;
 use tempfile::tempdir;
 
 use crate::fst_impls::{ConstFst, VectorFst};
-use crate::fst_traits::{ Fst, SerializableFst };
+use crate::fst_traits::{Fst, SerializableFst};
 use crate::semirings::SerializableSemiring;
-use crate::tests_openfst::FstTestData;
 use crate::tests_openfst::io::generate_symbol_table;
+use crate::tests_openfst::FstTestData;
 
 pub fn test_const_fst_bin_serializer<W>(test_data: &FstTestData<VectorFst<W>>) -> Fallible<()>
 where
@@ -29,7 +29,9 @@ where
     Ok(())
 }
 
-pub fn test_const_fst_bin_serializer_with_symt<W>(test_data: &FstTestData<VectorFst<W>>) -> Fallible<()>
+pub fn test_const_fst_bin_serializer_with_symt<W>(
+    test_data: &FstTestData<VectorFst<W>>,
+) -> Fallible<()>
 where
     W: SerializableSemiring + 'static,
 {
@@ -49,7 +51,11 @@ where
         raw_const_with_symt,
         deserialized_fst,
         "{}",
-        error_message_fst!(raw_const_with_symt, deserialized_fst, "Serializer ConstFst Bin with Generated Symbol Table")
+        error_message_fst!(
+            raw_const_with_symt,
+            deserialized_fst,
+            "Serializer ConstFst Bin with Generated Symbol Table"
+        )
     );
     Ok(())
 }

--- a/rustfst/src/tests_openfst/io/const_fst_bin_serializer.rs
+++ b/rustfst/src/tests_openfst/io/const_fst_bin_serializer.rs
@@ -2,9 +2,10 @@ use failure::Fallible;
 use tempfile::tempdir;
 
 use crate::fst_impls::{ConstFst, VectorFst};
-use crate::fst_traits::SerializableFst;
+use crate::fst_traits::{ Fst, SerializableFst };
 use crate::semirings::SerializableSemiring;
 use crate::tests_openfst::FstTestData;
+use crate::tests_openfst::io::generate_symbol_table;
 
 pub fn test_const_fst_bin_serializer<W>(test_data: &FstTestData<VectorFst<W>>) -> Fallible<()>
 where
@@ -24,6 +25,31 @@ where
         deserialized_fst,
         "{}",
         error_message_fst!(raw_const, deserialized_fst, "Serializer ConstFst Bin")
+    );
+    Ok(())
+}
+
+pub fn test_const_fst_bin_serializer_with_symt<W>(test_data: &FstTestData<VectorFst<W>>) -> Fallible<()>
+where
+    W: SerializableSemiring + 'static,
+{
+    let dir = tempdir()?;
+
+    let mut raw_const_with_symt: ConstFst<_> = test_data.raw.clone().into();
+    let (input_symt, output_symt) = generate_symbol_table("test", &raw_const_with_symt);
+    raw_const_with_symt.set_input_symbols(input_symt);
+    raw_const_with_symt.set_output_symbols(output_symt);
+
+    let path_fst_serialized = dir.path().join("raw_const.fst");
+    raw_const_with_symt.write(&path_fst_serialized)?;
+
+    let deserialized_fst = ConstFst::<W>::read(&path_fst_serialized)?;
+
+    assert_eq!(
+        raw_const_with_symt,
+        deserialized_fst,
+        "{}",
+        error_message_fst!(raw_const_with_symt, deserialized_fst, "Serializer ConstFst Bin with Generated Symbol Table")
     );
     Ok(())
 }

--- a/rustfst/src/tests_openfst/io/const_fst_text_serialization.rs
+++ b/rustfst/src/tests_openfst/io/const_fst_text_serialization.rs
@@ -3,10 +3,10 @@ use tempfile::tempdir;
 
 use crate::algorithms::fst_convert_from_ref;
 use crate::fst_impls::{ConstFst, VectorFst};
-use crate::fst_traits::{Fst, SerializableFst };
+use crate::fst_traits::{Fst, SerializableFst};
 use crate::semirings::SerializableSemiring;
-use crate::tests_openfst::FstTestData;
 use crate::tests_openfst::io::generate_symbol_table;
+use crate::tests_openfst::FstTestData;
 
 pub fn test_const_fst_text_serialization<W>(test_data: &FstTestData<VectorFst<W>>) -> Fallible<()>
 where
@@ -45,7 +45,9 @@ where
     Ok(())
 }
 
-pub fn test_const_fst_text_serialization_with_symt<W>(test_data: &FstTestData<VectorFst<W>>) -> Fallible<()>
+pub fn test_const_fst_text_serialization_with_symt<W>(
+    test_data: &FstTestData<VectorFst<W>>,
+) -> Fallible<()>
 where
     W: SerializableSemiring + 'static,
 {
@@ -62,7 +64,7 @@ where
     let deserialized_fst = ConstFst::<W>::read_text(&path_fst_serialized)?;
 
     // Text serialization doesn't include the symbol table.
-    let mut raw_const_without_symt =  raw_const_with_symt;
+    let mut raw_const_without_symt = raw_const_with_symt;
     raw_const_without_symt.unset_input_symbols();
     raw_const_without_symt.unset_output_symbols();
 
@@ -70,8 +72,11 @@ where
         raw_const_without_symt,
         deserialized_fst,
         "{}",
-        error_message_fst!(raw_const_without_symt, deserialized_fst, "Serializer ConstFst Text with Generated Symbol Table")
+        error_message_fst!(
+            raw_const_without_symt,
+            deserialized_fst,
+            "Serializer ConstFst Text with Generated Symbol Table"
+        )
     );
     Ok(())
 }
-

--- a/rustfst/src/tests_openfst/io/mod.rs
+++ b/rustfst/src/tests_openfst/io/mod.rs
@@ -5,11 +5,9 @@ pub mod vector_fst_bin_deserializer;
 pub mod vector_fst_bin_serializer;
 pub mod vector_fst_text_serialization;
 
-
+use crate::fst_traits::Fst;
 use crate::symbol_table::SymbolTable;
 use std::rc::Rc;
-use crate::fst_traits::Fst;
-
 
 fn generate_symbol_table<F: Fst>(prefix: &str, fst: &F) -> (Rc<SymbolTable>, Rc<SymbolTable>) {
     let mut input_symt = SymbolTable::new();
@@ -23,12 +21,12 @@ fn generate_symbol_table<F: Fst>(prefix: &str, fst: &F) -> (Rc<SymbolTable>, Rc<
         }
     }
 
-    let input_symbols = (0..(highest_ilabel + 1))
-            .map(|it| format!("{}_input_symbol_{}", prefix, it));
+    let input_symbols =
+        (0..(highest_ilabel + 1)).map(|it| format!("{}_input_symbol_{}", prefix, it));
     input_symt.add_symbols(input_symbols);
 
-     let output_symbols = (0..(highest_olabel + 1))
-            .map(|it| format!("{}_input_symbol_{}", prefix, it));
+    let output_symbols =
+        (0..(highest_olabel + 1)).map(|it| format!("{}_input_symbol_{}", prefix, it));
     output_symt.add_symbols(output_symbols);
     (Rc::new(input_symt), Rc::new(output_symt))
 }

--- a/rustfst/src/tests_openfst/io/mod.rs
+++ b/rustfst/src/tests_openfst/io/mod.rs
@@ -4,3 +4,31 @@ pub mod const_fst_text_serialization;
 pub mod vector_fst_bin_deserializer;
 pub mod vector_fst_bin_serializer;
 pub mod vector_fst_text_serialization;
+
+
+use crate::symbol_table::SymbolTable;
+use std::rc::Rc;
+use crate::fst_traits::Fst;
+
+
+fn generate_symbol_table<F: Fst>(prefix: &str, fst: &F) -> (Rc<SymbolTable>, Rc<SymbolTable>) {
+    let mut input_symt = SymbolTable::new();
+    let mut output_symt = SymbolTable::new();
+    let mut highest_ilabel = 0;
+    let mut highest_olabel = 0;
+    for state in fst.fst_iter() {
+        for arc_out in state.arcs {
+            highest_ilabel = highest_ilabel.max(arc_out.ilabel);
+            highest_olabel = highest_olabel.max(arc_out.olabel);
+        }
+    }
+
+    let input_symbols = (0..(highest_ilabel + 1))
+            .map(|it| format!("{}_input_symbol_{}", prefix, it));
+    input_symt.add_symbols(input_symbols);
+
+     let output_symbols = (0..(highest_olabel + 1))
+            .map(|it| format!("{}_input_symbol_{}", prefix, it));
+    output_symt.add_symbols(output_symbols);
+    (Rc::new(input_symt), Rc::new(output_symt))
+}

--- a/rustfst/src/tests_openfst/io/vector_fst_bin_serializer.rs
+++ b/rustfst/src/tests_openfst/io/vector_fst_bin_serializer.rs
@@ -2,9 +2,11 @@ use failure::Fallible;
 use tempfile::tempdir;
 
 use crate::fst_impls::VectorFst;
-use crate::fst_traits::SerializableFst;
+use crate::fst_traits::{Fst, SerializableFst };
 use crate::semirings::SerializableSemiring;
 use crate::tests_openfst::FstTestData;
+use crate::tests_openfst::io::generate_symbol_table;
+
 
 pub fn test_vector_fst_bin_serializer<W>(test_data: &FstTestData<VectorFst<W>>) -> Fallible<()>
 where
@@ -22,6 +24,31 @@ where
         deserialized_fst,
         "{}",
         error_message_fst!(test_data.raw, deserialized_fst, "Serializer VectorFst Bin")
+    );
+    Ok(())
+}
+
+pub fn test_vector_fst_bin_serializer_with_symt<W>(test_data: &FstTestData<VectorFst<W>>) -> Fallible<()>
+where
+    W: SerializableSemiring + 'static,
+{
+    let dir = tempdir()?;
+
+    let path_fst_serialized = dir.path().join("raw.fst");
+    let mut raw_with_symt = test_data.raw.clone();
+    let (input_symt, output_symt) = generate_symbol_table("test", &raw_with_symt);
+    raw_with_symt.set_input_symbols(input_symt);
+    raw_with_symt.set_output_symbols(output_symt);
+
+    raw_with_symt.write(&path_fst_serialized)?;
+
+    let deserialized_fst = VectorFst::<W>::read(&path_fst_serialized)?;
+
+    assert_eq!(
+        raw_with_symt,
+        deserialized_fst,
+        "{}",
+        error_message_fst!(raw_with_symt, deserialized_fst, "Serializer VectorFst Bin with Generated Symbol Table")
     );
     Ok(())
 }

--- a/rustfst/src/tests_openfst/io/vector_fst_bin_serializer.rs
+++ b/rustfst/src/tests_openfst/io/vector_fst_bin_serializer.rs
@@ -2,11 +2,10 @@ use failure::Fallible;
 use tempfile::tempdir;
 
 use crate::fst_impls::VectorFst;
-use crate::fst_traits::{Fst, SerializableFst };
+use crate::fst_traits::{Fst, SerializableFst};
 use crate::semirings::SerializableSemiring;
-use crate::tests_openfst::FstTestData;
 use crate::tests_openfst::io::generate_symbol_table;
-
+use crate::tests_openfst::FstTestData;
 
 pub fn test_vector_fst_bin_serializer<W>(test_data: &FstTestData<VectorFst<W>>) -> Fallible<()>
 where
@@ -28,7 +27,9 @@ where
     Ok(())
 }
 
-pub fn test_vector_fst_bin_serializer_with_symt<W>(test_data: &FstTestData<VectorFst<W>>) -> Fallible<()>
+pub fn test_vector_fst_bin_serializer_with_symt<W>(
+    test_data: &FstTestData<VectorFst<W>>,
+) -> Fallible<()>
 where
     W: SerializableSemiring + 'static,
 {
@@ -48,7 +49,11 @@ where
         raw_with_symt,
         deserialized_fst,
         "{}",
-        error_message_fst!(raw_with_symt, deserialized_fst, "Serializer VectorFst Bin with Generated Symbol Table")
+        error_message_fst!(
+            raw_with_symt,
+            deserialized_fst,
+            "Serializer VectorFst Bin with Generated Symbol Table"
+        )
     );
     Ok(())
 }

--- a/rustfst/src/tests_openfst/io/vector_fst_text_serialization.rs
+++ b/rustfst/src/tests_openfst/io/vector_fst_text_serialization.rs
@@ -2,9 +2,10 @@ use failure::Fallible;
 use tempfile::tempdir;
 
 use crate::fst_impls::VectorFst;
-use crate::fst_traits::SerializableFst;
+use crate::fst_traits::{ Fst, SerializableFst };
 use crate::semirings::SerializableSemiring;
 use crate::tests_openfst::FstTestData;
+use crate::tests_openfst::io::generate_symbol_table;
 
 pub fn test_vector_fst_text_serialization<W>(test_data: &FstTestData<VectorFst<W>>) -> Fallible<()>
 where
@@ -22,6 +23,37 @@ where
         deserialized_fst,
         "{}",
         error_message_fst!(test_data.raw, deserialized_fst, "Serializer VectorFst Text")
+    );
+    Ok(())
+}
+
+
+pub fn test_vector_fst_text_serialization_with_symt<W>(test_data: &FstTestData<VectorFst<W>>) -> Fallible<()>
+where
+    W: SerializableSemiring + 'static,
+{
+    let dir = tempdir()?;
+
+    let path_fst_serialized = dir.path().join("raw.fst");
+    let mut raw_with_symt = test_data.raw.clone();
+    let (input_symt, output_symt) = generate_symbol_table("test", &raw_with_symt);
+    raw_with_symt.set_input_symbols(input_symt);
+    raw_with_symt.set_output_symbols(output_symt);
+
+    raw_with_symt.write_text(&path_fst_serialized)?;
+
+    let deserialized_fst = VectorFst::<W>::read_text(&path_fst_serialized)?;
+
+    // Text serialization doesn't include the symbol table.
+    let mut raw_without_symt =  raw_with_symt;
+    raw_without_symt.unset_input_symbols();
+    raw_without_symt.unset_output_symbols();
+
+    assert_eq!(
+        raw_without_symt,
+        deserialized_fst,
+        "{}",
+        error_message_fst!(raw_without_symt, deserialized_fst, "Serializer VectorFst Text with Generated Symbol Table")
     );
     Ok(())
 }

--- a/rustfst/src/tests_openfst/io/vector_fst_text_serialization.rs
+++ b/rustfst/src/tests_openfst/io/vector_fst_text_serialization.rs
@@ -2,10 +2,10 @@ use failure::Fallible;
 use tempfile::tempdir;
 
 use crate::fst_impls::VectorFst;
-use crate::fst_traits::{ Fst, SerializableFst };
+use crate::fst_traits::{Fst, SerializableFst};
 use crate::semirings::SerializableSemiring;
-use crate::tests_openfst::FstTestData;
 use crate::tests_openfst::io::generate_symbol_table;
+use crate::tests_openfst::FstTestData;
 
 pub fn test_vector_fst_text_serialization<W>(test_data: &FstTestData<VectorFst<W>>) -> Fallible<()>
 where
@@ -27,8 +27,9 @@ where
     Ok(())
 }
 
-
-pub fn test_vector_fst_text_serialization_with_symt<W>(test_data: &FstTestData<VectorFst<W>>) -> Fallible<()>
+pub fn test_vector_fst_text_serialization_with_symt<W>(
+    test_data: &FstTestData<VectorFst<W>>,
+) -> Fallible<()>
 where
     W: SerializableSemiring + 'static,
 {
@@ -45,7 +46,7 @@ where
     let deserialized_fst = VectorFst::<W>::read_text(&path_fst_serialized)?;
 
     // Text serialization doesn't include the symbol table.
-    let mut raw_without_symt =  raw_with_symt;
+    let mut raw_without_symt = raw_with_symt;
     raw_without_symt.unset_input_symbols();
     raw_without_symt.unset_output_symbols();
 
@@ -53,7 +54,11 @@ where
         raw_without_symt,
         deserialized_fst,
         "{}",
-        error_message_fst!(raw_without_symt, deserialized_fst, "Serializer VectorFst Text with Generated Symbol Table")
+        error_message_fst!(
+            raw_without_symt,
+            deserialized_fst,
+            "Serializer VectorFst Text with Generated Symbol Table"
+        )
     );
     Ok(())
 }

--- a/rustfst/src/tests_openfst/mod.rs
+++ b/rustfst/src/tests_openfst/mod.rs
@@ -31,10 +31,10 @@ use crate::tests_openfst::io::const_fst_bin_deserializer::{
     test_const_fst_aligned_bin_deserializer, test_const_fst_bin_deserializer,
 };
 use crate::tests_openfst::io::const_fst_bin_serializer::{
-    test_const_fst_bin_serializer, test_const_fst_bin_serializer_with_symt
+    test_const_fst_bin_serializer, test_const_fst_bin_serializer_with_symt,
 };
 use crate::tests_openfst::io::const_fst_text_serialization::{
-    test_const_fst_text_serialization, test_const_fst_text_serialization_with_symt
+    test_const_fst_text_serialization, test_const_fst_text_serialization_with_symt,
 };
 
 use self::algorithms::{
@@ -69,9 +69,6 @@ use self::fst_impls::const_fst::test_const_fst_convert_convert;
 use self::fst_impls::test_fst_into_iterator::{
     test_fst_into_iterator_const, test_fst_into_iterator_vector,
 };
-use crate::tests_openfst::io::vector_fst_bin_deserializer::test_vector_fst_bin_deserializer;
-use crate::tests_openfst::io::vector_fst_bin_serializer::{ test_vector_fst_bin_serializer, test_vector_fst_bin_serializer_with_symt };
-use crate::tests_openfst::io::vector_fst_text_serialization::{ test_vector_fst_text_serialization, test_vector_fst_text_serialization_with_symt };
 use self::misc::test_del_all_states;
 use crate::fst_traits::SerializableFst;
 use crate::tests_openfst::algorithms::closure::{
@@ -82,7 +79,14 @@ use crate::tests_openfst::algorithms::concat::{
     test_concat, test_concat_dynamic, ConcatOperationResult, ConcatTestData,
 };
 use crate::tests_openfst::algorithms::union::{test_union, test_union_dynamic};
+use crate::tests_openfst::io::vector_fst_bin_deserializer::test_vector_fst_bin_deserializer;
 use crate::tests_openfst::io::vector_fst_bin_deserializer::test_vector_fst_bin_with_symt_deserializer;
+use crate::tests_openfst::io::vector_fst_bin_serializer::{
+    test_vector_fst_bin_serializer, test_vector_fst_bin_serializer_with_symt,
+};
+use crate::tests_openfst::io::vector_fst_text_serialization::{
+    test_vector_fst_text_serialization, test_vector_fst_text_serialization_with_symt,
+};
 
 #[macro_use]
 mod macros;
@@ -681,7 +685,7 @@ macro_rules! test_fst {
                 Ok(())
             }
 
-             #[test]
+            #[test]
             fn test_const_fst_text_serialization_with_symt_openfst() -> Fallible<()> {
                 do_run!(test_const_fst_text_serialization_with_symt, $fst_name);
                 Ok(())

--- a/rustfst/src/tests_openfst/mod.rs
+++ b/rustfst/src/tests_openfst/mod.rs
@@ -30,8 +30,12 @@ use crate::tests_openfst::algorithms::gallic_encode_decode::GallicTestData;
 use crate::tests_openfst::io::const_fst_bin_deserializer::{
     test_const_fst_aligned_bin_deserializer, test_const_fst_bin_deserializer,
 };
-use crate::tests_openfst::io::const_fst_bin_serializer::test_const_fst_bin_serializer;
-use crate::tests_openfst::io::const_fst_text_serialization::test_const_fst_text_serialization;
+use crate::tests_openfst::io::const_fst_bin_serializer::{
+    test_const_fst_bin_serializer, test_const_fst_bin_serializer_with_symt
+};
+use crate::tests_openfst::io::const_fst_text_serialization::{
+    test_const_fst_text_serialization, test_const_fst_text_serialization_with_symt
+};
 
 use self::algorithms::{
     arc_map::{
@@ -65,9 +69,9 @@ use self::fst_impls::const_fst::test_const_fst_convert_convert;
 use self::fst_impls::test_fst_into_iterator::{
     test_fst_into_iterator_const, test_fst_into_iterator_vector,
 };
-use self::io::vector_fst_bin_deserializer::test_vector_fst_bin_deserializer;
-use self::io::vector_fst_bin_serializer::test_vector_fst_bin_serializer;
-use self::io::vector_fst_text_serialization::test_vector_fst_text_serialization;
+use crate::tests_openfst::io::vector_fst_bin_deserializer::test_vector_fst_bin_deserializer;
+use crate::tests_openfst::io::vector_fst_bin_serializer::{ test_vector_fst_bin_serializer, test_vector_fst_bin_serializer_with_symt };
+use crate::tests_openfst::io::vector_fst_text_serialization::{ test_vector_fst_text_serialization, test_vector_fst_text_serialization_with_symt };
 use self::misc::test_del_all_states;
 use crate::fst_traits::SerializableFst;
 use crate::tests_openfst::algorithms::closure::{
@@ -606,8 +610,20 @@ macro_rules! test_fst {
             }
 
             #[test]
+            fn test_vector_fst_text_serialization_with_symt_openfst() -> Fallible<()> {
+                do_run!(test_vector_fst_text_serialization_with_symt, $fst_name);
+                Ok(())
+            }
+
+            #[test]
             fn test_vector_fst_bin_serializer_openfst() -> Fallible<()> {
                 do_run!(test_vector_fst_bin_serializer, $fst_name);
+                Ok(())
+            }
+
+            #[test]
+            fn test_vector_fst_bin_serializer_with_symt_openfst() -> Fallible<()> {
+                do_run!(test_vector_fst_bin_serializer_with_symt, $fst_name);
                 Ok(())
             }
 
@@ -654,8 +670,20 @@ macro_rules! test_fst {
             }
 
             #[test]
+            fn test_const_fst_bin_serializer_with_symt_openfst() -> Fallible<()> {
+                do_run!(test_const_fst_bin_serializer_with_symt, $fst_name);
+                Ok(())
+            }
+
+            #[test]
             fn test_const_fst_text_serialization_openfst() -> Fallible<()> {
                 do_run!(test_const_fst_text_serialization, $fst_name);
+                Ok(())
+            }
+
+             #[test]
+            fn test_const_fst_text_serialization_with_symt_openfst() -> Fallible<()> {
+                do_run!(test_const_fst_text_serialization_with_symt, $fst_name);
                 Ok(())
             }
 


### PR DESCRIPTION
- [x] Symbol table serialization in FstHeader serialization
- [x] Support for `ConstFst`
- [x] Support for `VectorFst`
- [x] Tests for `ConstFst` and `VectorFst`
- [x] Implement the `SerializableSemiring` for `ProbabilityWeight` 