### PR TITLE
Add Clone to dynamic FST structs

### DIFF
--- a/rustfst/src/algorithms/compose/compose_filters/alt_sequence_compose_filter.rs
+++ b/rustfst/src/algorithms/compose/compose_filters/alt_sequence_compose_filter.rs
@@ -14,7 +14,7 @@ use crate::fst_traits::{CoreFst, Fst};
 use crate::semirings::Semiring;
 use crate::{Arc, StateId, EPS_LABEL, NO_LABEL, NO_STATE_ID};
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct AltSequenceComposeFilter<W: Semiring, M1: Matcher<W>, M2: Matcher<W>> {
     fst1: PhantomData<M1::F>,
     fst2: Rc<M2::F>,

--- a/rustfst/src/algorithms/compose/lookahead_filters/lookahead_compose_filter.rs
+++ b/rustfst/src/algorithms/compose/lookahead_filters/lookahead_compose_filter.rs
@@ -18,7 +18,7 @@ use crate::algorithms::compose::matchers::{MatchType, Matcher};
 use crate::semirings::Semiring;
 use crate::{Arc, EPS_LABEL};
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct LookAheadComposeFilter<
     W: Semiring,
     CF: LookAheadComposeFilterTrait<W>,

--- a/rustfst/src/algorithms/compose/lookahead_filters/lookahead_selector.rs
+++ b/rustfst/src/algorithms/compose/lookahead_filters/lookahead_selector.rs
@@ -5,19 +5,19 @@ use std::rc::Rc;
 use crate::algorithms::compose::matchers::{MatchType, Matcher};
 use crate::semirings::Semiring;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SMatchInput {}
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SMatchOutput {}
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SMatchBoth {}
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SMatchNone {}
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SMatchUnknown {}
 
 pub trait MatchTypeTrait: Debug {
@@ -54,7 +54,7 @@ impl MatchTypeTrait for SMatchUnknown {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct LookAheadSelector<F, M> {
     pub fst: Rc<F>,
     pub matcher: Rc<RefCell<M>>,
@@ -80,7 +80,7 @@ fn selector_match_output<W: Semiring, M1: Matcher<W>, M2: Matcher<W>>(
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum Selector<W: Semiring, M1: Matcher<W>, M2: Matcher<W>> {
     MatchInput(LookAheadSelector<M1::F, M2>),
     MatchOutput(LookAheadSelector<M2::F, M1>),

--- a/rustfst/src/algorithms/compose/matchers/multi_eps_matcher.rs
+++ b/rustfst/src/algorithms/compose/matchers/multi_eps_matcher.rs
@@ -21,7 +21,7 @@ bitflags! {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct MultiEpsMatcher<W, M> {
     matcher: Rc<RefCell<M>>,
     flags: MultiEpsMatcherFlags,
@@ -245,7 +245,7 @@ impl<W: Semiring, M: Matcher<W>> Matcher<W> for MultiEpsMatcher<W, M> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct CompactSet<K> {
     set: BTreeSet<K>,
     min_key: K,


### PR DESCRIPTION
This was enough to get my opaque dynamic FST struct to implement `Clone`, although maybe I missed some structs that ought to be cloneable but I don't happen to be using.