### PR TITLE
Fst Send Sync traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement `SerializableSemiring` for `ProbabilityWeight`
 - Add support for `SymbolTable` serialization while serializing a FST in binary format.
 - Implement Composition operation. Added support to LookAhead filter.
+- Implement Fst traits for `sync::Arc<F>`
 
 ### Changed
 - `fst_convert` now consumes its input. Use `fst_convert_from_ref` to pass a borrow.
@@ -25,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove `MutableFst` trait bound from input of `shortest_path`.
 - `ArcMap` now takes an immutable mapper as parameter.
 - Use anyhow instead of failure for errors.
+- `SymbolTable` shared with `std::sync::Arc` instead of Rc
 
 ### Fixed
 - Fix olabel display while drawing a FST if no symbol table is provided

--- a/rustfst/src/algorithms/closure.rs
+++ b/rustfst/src/algorithms/closure.rs
@@ -7,7 +7,7 @@ use crate::fst_traits::{
 use crate::semirings::Semiring;
 use crate::{SymbolTable, EPS_LABEL};
 use anyhow::Result;
-use std::rc::Rc;
+use std::sync;
 
 /// Defines the different types of closure : Star or Plus.
 #[derive(Clone, Debug, Copy, PartialEq)]
@@ -184,27 +184,27 @@ impl<F: Fst + 'static> Fst for ClosureFst<F>
 where
     F::W: 'static,
 {
-    fn input_symbols(&self) -> Option<Rc<SymbolTable>> {
+    fn input_symbols(&self) -> Option<sync::Arc<SymbolTable>> {
         self.0.input_symbols()
     }
 
-    fn output_symbols(&self) -> Option<Rc<SymbolTable>> {
+    fn output_symbols(&self) -> Option<sync::Arc<SymbolTable>> {
         self.0.output_symbols()
     }
 
-    fn set_input_symbols(&mut self, symt: Rc<SymbolTable>) {
+    fn set_input_symbols(&mut self, symt: sync::Arc<SymbolTable>) {
         self.0.set_input_symbols(symt)
     }
 
-    fn set_output_symbols(&mut self, symt: Rc<SymbolTable>) {
+    fn set_output_symbols(&mut self, symt: sync::Arc<SymbolTable>) {
         self.0.set_output_symbols(symt)
     }
 
-    fn unset_input_symbols(&mut self) -> Option<Rc<SymbolTable>> {
+    fn unset_input_symbols(&mut self) -> Option<sync::Arc<SymbolTable>> {
         self.0.unset_input_symbols()
     }
 
-    fn unset_output_symbols(&mut self) -> Option<Rc<SymbolTable>> {
+    fn unset_output_symbols(&mut self) -> Option<sync::Arc<SymbolTable>> {
         self.0.unset_output_symbols()
     }
 }

--- a/rustfst/src/algorithms/compose/add_on.rs
+++ b/rustfst/src/algorithms/compose/add_on.rs
@@ -1,5 +1,5 @@
 use std::fmt::Debug;
-use std::rc::Rc;
+use std::sync;
 
 use anyhow::Result;
 
@@ -97,27 +97,27 @@ impl<F: Fst, T: Debug> Fst for FstAddOn<F, T>
 where
     F::W: 'static,
 {
-    fn input_symbols(&self) -> Option<Rc<SymbolTable>> {
+    fn input_symbols(&self) -> Option<sync::Arc<SymbolTable>> {
         self.fst.input_symbols()
     }
 
-    fn output_symbols(&self) -> Option<Rc<SymbolTable>> {
+    fn output_symbols(&self) -> Option<sync::Arc<SymbolTable>> {
         self.fst.output_symbols()
     }
 
-    fn set_input_symbols(&mut self, symt: Rc<SymbolTable>) {
+    fn set_input_symbols(&mut self, symt: sync::Arc<SymbolTable>) {
         self.fst.set_input_symbols(symt)
     }
 
-    fn set_output_symbols(&mut self, symt: Rc<SymbolTable>) {
+    fn set_output_symbols(&mut self, symt: sync::Arc<SymbolTable>) {
         self.fst.set_output_symbols(symt)
     }
 
-    fn unset_input_symbols(&mut self) -> Option<Rc<SymbolTable>> {
+    fn unset_input_symbols(&mut self) -> Option<sync::Arc<SymbolTable>> {
         self.fst.unset_input_symbols()
     }
 
-    fn unset_output_symbols(&mut self) -> Option<Rc<SymbolTable>> {
+    fn unset_output_symbols(&mut self) -> Option<sync::Arc<SymbolTable>> {
         self.fst.unset_output_symbols()
     }
 }

--- a/rustfst/src/algorithms/compose/matcher_fst.rs
+++ b/rustfst/src/algorithms/compose/matcher_fst.rs
@@ -2,6 +2,7 @@ use std::cell::RefCell;
 use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::rc::Rc;
+use std::sync;
 
 use anyhow::Result;
 
@@ -120,27 +121,27 @@ impl<F: Fst, M: Debug, T: Debug> Fst for MatcherFst<F, M, T>
 where
     F::W: 'static,
 {
-    fn input_symbols(&self) -> Option<Rc<SymbolTable>> {
+    fn input_symbols(&self) -> Option<sync::Arc<SymbolTable>> {
         self.fst_add_on.input_symbols()
     }
 
-    fn output_symbols(&self) -> Option<Rc<SymbolTable>> {
+    fn output_symbols(&self) -> Option<sync::Arc<SymbolTable>> {
         self.fst_add_on.output_symbols()
     }
 
-    fn set_input_symbols(&mut self, symt: Rc<SymbolTable>) {
+    fn set_input_symbols(&mut self, symt: sync::Arc<SymbolTable>) {
         self.fst_add_on.set_input_symbols(symt)
     }
 
-    fn set_output_symbols(&mut self, symt: Rc<SymbolTable>) {
+    fn set_output_symbols(&mut self, symt: sync::Arc<SymbolTable>) {
         self.fst_add_on.set_output_symbols(symt)
     }
 
-    fn unset_input_symbols(&mut self) -> Option<Rc<SymbolTable>> {
+    fn unset_input_symbols(&mut self) -> Option<sync::Arc<SymbolTable>> {
         self.fst_add_on.unset_input_symbols()
     }
 
-    fn unset_output_symbols(&mut self) -> Option<Rc<SymbolTable>> {
+    fn unset_output_symbols(&mut self) -> Option<sync::Arc<SymbolTable>> {
         self.fst_add_on.unset_output_symbols()
     }
 }

--- a/rustfst/src/algorithms/concat.rs
+++ b/rustfst/src/algorithms/concat.rs
@@ -7,7 +7,7 @@ use crate::fst_traits::{
 };
 use crate::semirings::Semiring;
 use crate::{SymbolTable, EPS_LABEL};
-use std::rc::Rc;
+use std::sync;
 
 /// Performs the concatenation of two wFSTs. If `A` transduces string `x` to `y` with weight `a`
 /// and `B` transduces string `w` to `v` with weight `b`, then their concatenation
@@ -195,27 +195,27 @@ impl<F: Fst + 'static> Fst for ConcatFst<F>
 where
     F::W: 'static,
 {
-    fn input_symbols(&self) -> Option<Rc<SymbolTable>> {
+    fn input_symbols(&self) -> Option<sync::Arc<SymbolTable>> {
         self.0.input_symbols()
     }
 
-    fn output_symbols(&self) -> Option<Rc<SymbolTable>> {
+    fn output_symbols(&self) -> Option<sync::Arc<SymbolTable>> {
         self.0.output_symbols()
     }
 
-    fn set_input_symbols(&mut self, symt: Rc<SymbolTable>) {
+    fn set_input_symbols(&mut self, symt: sync::Arc<SymbolTable>) {
         self.0.set_input_symbols(symt)
     }
 
-    fn set_output_symbols(&mut self, symt: Rc<SymbolTable>) {
+    fn set_output_symbols(&mut self, symt: sync::Arc<SymbolTable>) {
         self.0.set_output_symbols(symt)
     }
 
-    fn unset_input_symbols(&mut self) -> Option<Rc<SymbolTable>> {
+    fn unset_input_symbols(&mut self) -> Option<sync::Arc<SymbolTable>> {
         self.0.unset_input_symbols()
     }
 
-    fn unset_output_symbols(&mut self) -> Option<Rc<SymbolTable>> {
+    fn unset_output_symbols(&mut self) -> Option<sync::Arc<SymbolTable>> {
         self.0.unset_output_symbols()
     }
 }

--- a/rustfst/src/algorithms/union.rs
+++ b/rustfst/src/algorithms/union.rs
@@ -1,4 +1,4 @@
-use std::rc::Rc;
+use std::sync;
 
 use anyhow::Result;
 use unsafe_unwrap::UnsafeUnwrap;
@@ -214,27 +214,27 @@ impl<F: Fst + 'static> Fst for UnionFst<F>
 where
     F::W: 'static,
 {
-    fn input_symbols(&self) -> Option<Rc<SymbolTable>> {
+    fn input_symbols(&self) -> Option<sync::Arc<SymbolTable>> {
         self.0.input_symbols()
     }
 
-    fn output_symbols(&self) -> Option<Rc<SymbolTable>> {
+    fn output_symbols(&self) -> Option<sync::Arc<SymbolTable>> {
         self.0.output_symbols()
     }
 
-    fn set_input_symbols(&mut self, symt: Rc<SymbolTable>) {
+    fn set_input_symbols(&mut self, symt: sync::Arc<SymbolTable>) {
         self.0.set_input_symbols(symt)
     }
 
-    fn set_output_symbols(&mut self, symt: Rc<SymbolTable>) {
+    fn set_output_symbols(&mut self, symt: sync::Arc<SymbolTable>) {
         self.0.set_output_symbols(symt)
     }
 
-    fn unset_input_symbols(&mut self) -> Option<Rc<SymbolTable>> {
+    fn unset_input_symbols(&mut self) -> Option<sync::Arc<SymbolTable>> {
         self.0.unset_input_symbols()
     }
 
-    fn unset_output_symbols(&mut self) -> Option<Rc<SymbolTable>> {
+    fn unset_output_symbols(&mut self) -> Option<sync::Arc<SymbolTable>> {
         self.0.unset_output_symbols()
     }
 }

--- a/rustfst/src/fst_impls/const_fst/data_structure.rs
+++ b/rustfst/src/fst_impls/const_fst/data_structure.rs
@@ -1,5 +1,5 @@
 use crate::{Arc, StateId, SymbolTable};
-use std::rc::Rc;
+use std::sync;
 
 /// Immutable FST whose states and arcs each implemented by single arrays,
 #[derive(Debug, PartialEq, Clone)]
@@ -7,8 +7,8 @@ pub struct ConstFst<W> {
     pub(crate) states: Vec<ConstState<W>>,
     pub(crate) arcs: Vec<Arc<W>>,
     pub(crate) start: Option<StateId>,
-    pub(crate) isymt: Option<Rc<SymbolTable>>,
-    pub(crate) osymt: Option<Rc<SymbolTable>>,
+    pub(crate) isymt: Option<sync::Arc<SymbolTable>>,
+    pub(crate) osymt: Option<sync::Arc<SymbolTable>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Default)]

--- a/rustfst/src/fst_impls/const_fst/fst.rs
+++ b/rustfst/src/fst_impls/const_fst/fst.rs
@@ -4,30 +4,30 @@ use crate::semirings::Semiring;
 
 use crate::SymbolTable;
 use anyhow::{format_err, Result};
-use std::rc::Rc;
+use std::sync;
 
 impl<W: Semiring + 'static> Fst for ConstFst<W> {
-    fn input_symbols(&self) -> Option<Rc<SymbolTable>> {
+    fn input_symbols(&self) -> Option<sync::Arc<SymbolTable>> {
         self.isymt.clone()
     }
 
-    fn output_symbols(&self) -> Option<Rc<SymbolTable>> {
+    fn output_symbols(&self) -> Option<sync::Arc<SymbolTable>> {
         self.osymt.clone()
     }
 
-    fn set_input_symbols(&mut self, symt: Rc<SymbolTable>) {
-        self.isymt = Some(Rc::clone(&symt))
+    fn set_input_symbols(&mut self, symt: sync::Arc<SymbolTable>) {
+        self.isymt = Some(sync::Arc::clone(&symt))
     }
 
-    fn set_output_symbols(&mut self, symt: Rc<SymbolTable>) {
-        self.osymt = Some(Rc::clone(&symt));
+    fn set_output_symbols(&mut self, symt: sync::Arc<SymbolTable>) {
+        self.osymt = Some(sync::Arc::clone(&symt));
     }
 
-    fn unset_input_symbols(&mut self) -> Option<Rc<SymbolTable>> {
+    fn unset_input_symbols(&mut self) -> Option<sync::Arc<SymbolTable>> {
         self.isymt.take()
     }
 
-    fn unset_output_symbols(&mut self) -> Option<Rc<SymbolTable>> {
+    fn unset_output_symbols(&mut self) -> Option<sync::Arc<SymbolTable>> {
         self.osymt.take()
     }
 }

--- a/rustfst/src/fst_impls/rc.rs
+++ b/rustfst/src/fst_impls/rc.rs
@@ -114,3 +114,111 @@ impl<F: FstIntoIterator> FstIntoIterator for Rc<F> {
         unimplemented!()
     }
 }
+
+
+
+impl<F: Fst> Fst for sync::Arc<F>
+where
+    F::W: 'static,
+{
+    fn input_symbols(&self) -> Option<sync::Arc<SymbolTable>> {
+        self.deref().input_symbols()
+    }
+
+    fn output_symbols(&self) -> Option<sync::Arc<SymbolTable>> {
+        self.deref().output_symbols()
+    }
+
+    fn set_input_symbols(&mut self, _symt: sync::Arc<SymbolTable>) {
+        unimplemented!()
+    }
+
+    fn set_output_symbols(&mut self, _symt: sync::Arc<SymbolTable>) {
+        unimplemented!()
+    }
+
+    fn unset_input_symbols(&mut self) -> Option<sync::Arc<SymbolTable>> {
+        unimplemented!()
+    }
+
+    fn unset_output_symbols(&mut self) -> Option<sync::Arc<SymbolTable>> {
+        unimplemented!()
+    }
+}
+
+impl<F: ExpandedFst> ExpandedFst for sync::Arc<F>
+where
+    F::W: 'static,
+{
+    fn num_states(&self) -> usize {
+        self.deref().num_states()
+    }
+}
+
+impl<F: CoreFst> CoreFst for sync::Arc<F> {
+    type W = F::W;
+
+    fn start(&self) -> Option<usize> {
+        self.deref().start()
+    }
+
+    fn final_weight(&self, state_id: usize) -> Result<Option<&Self::W>> {
+        self.deref().final_weight(state_id)
+    }
+
+    unsafe fn final_weight_unchecked(&self, state_id: usize) -> Option<&Self::W> {
+        self.deref().final_weight_unchecked(state_id)
+    }
+
+    fn num_arcs(&self, s: usize) -> Result<usize> {
+        self.deref().num_arcs(s)
+    }
+
+    unsafe fn num_arcs_unchecked(&self, s: usize) -> usize {
+        self.deref().num_arcs_unchecked(s)
+    }
+}
+
+impl<'a, F: FstIterator<'a>> FstIterator<'a> for sync::Arc<F>
+where
+    F::W: 'a,
+{
+    type ArcsIter = F::ArcsIter;
+    type FstIter = F::FstIter;
+
+    fn fst_iter(&'a self) -> Self::FstIter {
+        self.deref().fst_iter()
+    }
+}
+
+impl<'a, F: ArcIterator<'a>> ArcIterator<'a> for sync::Arc<F>
+where
+    F::W: 'a,
+{
+    type Iter = F::Iter;
+
+    fn arcs_iter(&'a self, state_id: usize) -> Result<Self::Iter> {
+        self.deref().arcs_iter(state_id)
+    }
+
+    unsafe fn arcs_iter_unchecked(&'a self, state_id: usize) -> Self::Iter {
+        self.deref().arcs_iter_unchecked(state_id)
+    }
+}
+
+impl<'a, F: StateIterator<'a>> StateIterator<'a> for sync::Arc<F> {
+    type Iter = F::Iter;
+
+    fn states_iter(&'a self) -> Self::Iter {
+        self.deref().states_iter()
+    }
+}
+
+impl<F: FstIntoIterator> FstIntoIterator for sync::Arc<F> {
+    type ArcsIter = F::ArcsIter;
+    type FstIter = F::FstIter;
+
+    fn fst_into_iter(self) -> Self::FstIter {
+        unimplemented!()
+    }
+}

--- a/rustfst/src/fst_impls/rc.rs
+++ b/rustfst/src/fst_impls/rc.rs
@@ -1,5 +1,6 @@
 use std::ops::Deref;
 use std::rc::Rc;
+use std::sync;
 
 use anyhow::Result;
 
@@ -12,27 +13,27 @@ impl<F: Fst> Fst for Rc<F>
 where
     F::W: 'static,
 {
-    fn input_symbols(&self) -> Option<Rc<SymbolTable>> {
+    fn input_symbols(&self) -> Option<sync::Arc<SymbolTable>> {
         self.deref().input_symbols()
     }
 
-    fn output_symbols(&self) -> Option<Rc<SymbolTable>> {
+    fn output_symbols(&self) -> Option<sync::Arc<SymbolTable>> {
         self.deref().output_symbols()
     }
 
-    fn set_input_symbols(&mut self, _symt: Rc<SymbolTable>) {
+    fn set_input_symbols(&mut self, _symt: sync::Arc<SymbolTable>) {
         unimplemented!()
     }
 
-    fn set_output_symbols(&mut self, _symt: Rc<SymbolTable>) {
+    fn set_output_symbols(&mut self, _symt: sync::Arc<SymbolTable>) {
         unimplemented!()
     }
 
-    fn unset_input_symbols(&mut self) -> Option<Rc<SymbolTable>> {
+    fn unset_input_symbols(&mut self) -> Option<sync::Arc<SymbolTable>> {
         unimplemented!()
     }
 
-    fn unset_output_symbols(&mut self) -> Option<Rc<SymbolTable>> {
+    fn unset_output_symbols(&mut self) -> Option<sync::Arc<SymbolTable>> {
         unimplemented!()
     }
 }

--- a/rustfst/src/fst_impls/vector_fst/data_structure.rs
+++ b/rustfst/src/fst_impls/vector_fst/data_structure.rs
@@ -4,7 +4,7 @@ use crate::arc::Arc;
 use crate::semirings::Semiring;
 use crate::symbol_table::SymbolTable;
 use crate::StateId;
-use std::rc::Rc;
+use std::sync;
 
 /// Simple concrete, mutable FST whose states and arcs are stored in standard vectors.
 ///
@@ -14,8 +14,8 @@ use std::rc::Rc;
 pub struct VectorFst<W> {
     pub(crate) states: Vec<VectorFstState<W>>,
     pub(crate) start_state: Option<StateId>,
-    pub(crate) isymt: Option<Rc<SymbolTable>>,
-    pub(crate) osymt: Option<Rc<SymbolTable>>,
+    pub(crate) isymt: Option<sync::Arc<SymbolTable>>,
+    pub(crate) osymt: Option<sync::Arc<SymbolTable>>,
 }
 
 // In my opinion, it is not a good idea to store values like num_arcs, num_input_epsilons

--- a/rustfst/src/fst_impls/vector_fst/fst.rs
+++ b/rustfst/src/fst_impls/vector_fst/fst.rs
@@ -1,4 +1,4 @@
-use std::rc::Rc;
+use std::sync;
 
 use anyhow::Result;
 
@@ -8,28 +8,28 @@ use crate::semirings::Semiring;
 use crate::{StateId, SymbolTable};
 
 impl<W: 'static + Semiring> Fst for VectorFst<W> {
-    fn input_symbols(&self) -> Option<Rc<SymbolTable>> {
-        // Rc is incremented, SymbolTable is not duplicated
+    fn input_symbols(&self) -> Option<sync::Arc<SymbolTable>> {
+        // sync::Arc is incremented, SymbolTable is not duplicated
         self.isymt.clone()
     }
 
-    fn output_symbols(&self) -> Option<Rc<SymbolTable>> {
+    fn output_symbols(&self) -> Option<sync::Arc<SymbolTable>> {
         self.osymt.clone()
     }
 
-    fn set_input_symbols(&mut self, symt: Rc<SymbolTable>) {
-        self.isymt = Some(Rc::clone(&symt))
+    fn set_input_symbols(&mut self, symt: sync::Arc<SymbolTable>) {
+        self.isymt = Some(sync::Arc::clone(&symt))
     }
 
-    fn set_output_symbols(&mut self, symt: Rc<SymbolTable>) {
-        self.osymt = Some(Rc::clone(&symt));
+    fn set_output_symbols(&mut self, symt: sync::Arc<SymbolTable>) {
+        self.osymt = Some(sync::Arc::clone(&symt));
     }
 
-    fn unset_input_symbols(&mut self) -> Option<Rc<SymbolTable>> {
+    fn unset_input_symbols(&mut self) -> Option<sync::Arc<SymbolTable>> {
         self.isymt.take()
     }
 
-    fn unset_output_symbols(&mut self) -> Option<Rc<SymbolTable>> {
+    fn unset_output_symbols(&mut self) -> Option<sync::Arc<SymbolTable>> {
         self.osymt.take()
     }
 }

--- a/rustfst/src/fst_impls/vector_fst/test.rs
+++ b/rustfst/src/fst_impls/vector_fst/test.rs
@@ -12,7 +12,7 @@ mod tests {
     };
     use crate::semirings::{ProbabilityWeight, Semiring, TropicalWeight};
     use crate::SymbolTable;
-    use std::rc::Rc;
+    use std::sync;
 
     #[test]
     fn test_small_fst() -> Result<()> {
@@ -319,7 +319,7 @@ mod tests {
             symt.add_symbol("b"); // 2
             symt.add_symbol("c"); // 3
 
-            fst.set_input_symbols(Rc::new(symt));
+            fst.set_input_symbols(sync::Arc::new(symt));
         }
         {
             let symt = fst.input_symbols();
@@ -331,7 +331,7 @@ mod tests {
         // Test output symbol table
         {
             let symt = SymbolTable::new();
-            fst.set_output_symbols(Rc::new(symt));
+            fst.set_output_symbols(sync::Arc::new(symt));
         }
         {
             let symt = fst.output_symbols();

--- a/rustfst/src/fst_traits/fst.rs
+++ b/rustfst/src/fst_traits/fst.rs
@@ -1,5 +1,5 @@
 use std::fmt::Debug;
-use std::rc::Rc;
+use std::sync;
 
 use anyhow::Result;
 
@@ -186,24 +186,24 @@ pub trait Fst:
 
     /// Retrieves the input `SymbolTable` associated to the Fst.
     /// If no SymbolTable has been previously attached then `None` is returned.
-    fn input_symbols(&self) -> Option<Rc<SymbolTable>>;
+    fn input_symbols(&self) -> Option<sync::Arc<SymbolTable>>;
 
     /// Retrieves the output `SymbolTable` associated to the Fst.
     /// If no SymbolTable has been previously attached then `None` is returned.
-    fn output_symbols(&self) -> Option<Rc<SymbolTable>>;
+    fn output_symbols(&self) -> Option<sync::Arc<SymbolTable>>;
 
     /// Attaches an output `SymbolTable` to the Fst.
     /// The `SymbolTable` is not duplicated with the use of Rc.
-    fn set_input_symbols(&mut self, symt: Rc<SymbolTable>);
+    fn set_input_symbols(&mut self, symt: sync::Arc<SymbolTable>);
 
     /// Attaches an output `SymbolTable` to the Fst.
     /// The `SymbolTable` is not duplicated with the use of Rc.
-    fn set_output_symbols(&mut self, symt: Rc<SymbolTable>);
+    fn set_output_symbols(&mut self, symt: sync::Arc<SymbolTable>);
 
     /// Removes the input symbol table from the Fst and retrieves it.
-    fn unset_input_symbols(&mut self) -> Option<Rc<SymbolTable>>;
+    fn unset_input_symbols(&mut self) -> Option<sync::Arc<SymbolTable>>;
     /// Removes the output symbol table from the Fst and retrieves it.
-    fn unset_output_symbols(&mut self) -> Option<Rc<SymbolTable>>;
+    fn unset_output_symbols(&mut self) -> Option<sync::Arc<SymbolTable>>;
 
     fn set_symts_from_fst<OF: Fst>(&mut self, other_fst: &OF) {
         if let Some(symt) = other_fst.input_symbols() {

--- a/rustfst/src/tests_openfst/fst_impls/const_fst.rs
+++ b/rustfst/src/tests_openfst/fst_impls/const_fst.rs
@@ -1,4 +1,4 @@
-use std::rc::Rc;
+use std::sync;
 
 use anyhow::Result;
 
@@ -22,8 +22,8 @@ where
         osymt.add_symbol("b");
         osymt.add_symbol("c");
 
-        raw_fst.set_input_symbols(Rc::new(isymt));
-        raw_fst.set_output_symbols(Rc::new(osymt));
+        raw_fst.set_input_symbols(sync::Arc::new(isymt));
+        raw_fst.set_output_symbols(sync::Arc::new(osymt));
     }
 
     let const_fst: ConstFst<_> = raw_fst.clone().into();

--- a/rustfst/src/tests_openfst/io/mod.rs
+++ b/rustfst/src/tests_openfst/io/mod.rs
@@ -7,9 +7,9 @@ pub mod vector_fst_text_serialization;
 
 use crate::fst_traits::Fst;
 use crate::symbol_table::SymbolTable;
-use std::rc::Rc;
+use std::sync;
 
-fn generate_symbol_table<F: Fst>(prefix: &str, fst: &F) -> (Rc<SymbolTable>, Rc<SymbolTable>) {
+fn generate_symbol_table<F: Fst>(prefix: &str, fst: &F) -> (sync::Arc<SymbolTable>, sync::Arc<SymbolTable>) {
     let mut input_symt = SymbolTable::new();
     let mut output_symt = SymbolTable::new();
     let mut highest_ilabel = 0;
@@ -28,5 +28,5 @@ fn generate_symbol_table<F: Fst>(prefix: &str, fst: &F) -> (Rc<SymbolTable>, Rc<
     let output_symbols =
         (0..(highest_olabel + 1)).map(|it| format!("{}_input_symbol_{}", prefix, it));
     output_symt.add_symbols(output_symbols);
-    (Rc::new(input_symt), Rc::new(output_symt))
+    (sync::Arc::new(input_symt), sync::Arc::new(output_symt))
 }


### PR DESCRIPTION
- use for SymbolTable `sync::Arc` instead for Rc. Therefore ConstFst and VectorFst are now Send and Sync. 
- Implement Fst traits on `sync::Arc<F>`