### PR TITLE
Arc sym tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed Arc as Tr (for transition)
 - Renamed DynamicFst as LazyFst
 - Semiring impls are required to be 'static
+- SymbolTable are now wrapped in std::sync::Arc (instead of Rc)
+- renamed unset_input_symbols and unset_output_symbols to take_*_symbols
+- static FST struct are now Send and Sync
 
 ### Fixed
 - Fix olabel display while drawing a FST if no symbol table is provided

--- a/rustfst/src/algorithms/closure.rs
+++ b/rustfst/src/algorithms/closure.rs
@@ -7,7 +7,7 @@ use crate::semirings::Semiring;
 use crate::tr::Tr;
 use crate::{SymbolTable, EPS_LABEL};
 use anyhow::Result;
-use std::rc::Rc;
+use std::sync::Arc;
 
 /// Defines the different types of closure : Star or Plus.
 #[derive(Clone, Debug, Copy, PartialEq)]
@@ -95,10 +95,10 @@ where
     pub fn new(fst: F, closure_type: ClosureType) -> Result<Self> {
         let mut rfst = F::new();
         if let Some(isymt) = fst.input_symbols() {
-            rfst.set_input_symbols(isymt);
+            rfst.set_input_symbols(Arc::clone(isymt));
         }
         if let Some(osymt) = fst.output_symbols() {
-            rfst.set_output_symbols(osymt);
+            rfst.set_output_symbols(Arc::clone(osymt));
         }
         match closure_type {
             ClosureType::ClosureStar => {
@@ -184,28 +184,28 @@ impl<F: Fst + 'static> Fst for ClosureFst<F>
 where
     F::W: 'static,
 {
-    fn input_symbols(&self) -> Option<Rc<SymbolTable>> {
+    fn input_symbols(&self) -> Option<&Arc<SymbolTable>> {
         self.0.input_symbols()
     }
 
-    fn output_symbols(&self) -> Option<Rc<SymbolTable>> {
+    fn output_symbols(&self) -> Option<&Arc<SymbolTable>> {
         self.0.output_symbols()
     }
 
-    fn set_input_symbols(&mut self, symt: Rc<SymbolTable>) {
+    fn set_input_symbols(&mut self, symt: Arc<SymbolTable>) {
         self.0.set_input_symbols(symt)
     }
 
-    fn set_output_symbols(&mut self, symt: Rc<SymbolTable>) {
+    fn set_output_symbols(&mut self, symt: Arc<SymbolTable>) {
         self.0.set_output_symbols(symt)
     }
 
-    fn unset_input_symbols(&mut self) -> Option<Rc<SymbolTable>> {
-        self.0.unset_input_symbols()
+    fn take_input_symbols(&mut self) -> Option<Arc<SymbolTable>> {
+        self.0.take_input_symbols()
     }
 
-    fn unset_output_symbols(&mut self) -> Option<Rc<SymbolTable>> {
-        self.0.unset_output_symbols()
+    fn take_output_symbols(&mut self) -> Option<Arc<SymbolTable>> {
+        self.0.take_output_symbols()
     }
 }
 

--- a/rustfst/src/algorithms/compose/add_on.rs
+++ b/rustfst/src/algorithms/compose/add_on.rs
@@ -1,5 +1,5 @@
 use std::fmt::Debug;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use anyhow::Result;
 
@@ -97,28 +97,28 @@ impl<F: Fst, T: Debug> Fst for FstAddOn<F, T>
 where
     F::W: 'static,
 {
-    fn input_symbols(&self) -> Option<Rc<SymbolTable>> {
+    fn input_symbols(&self) -> Option<&Arc<SymbolTable>> {
         self.fst.input_symbols()
     }
 
-    fn output_symbols(&self) -> Option<Rc<SymbolTable>> {
+    fn output_symbols(&self) -> Option<&Arc<SymbolTable>> {
         self.fst.output_symbols()
     }
 
-    fn set_input_symbols(&mut self, symt: Rc<SymbolTable>) {
+    fn set_input_symbols(&mut self, symt: Arc<SymbolTable>) {
         self.fst.set_input_symbols(symt)
     }
 
-    fn set_output_symbols(&mut self, symt: Rc<SymbolTable>) {
+    fn set_output_symbols(&mut self, symt: Arc<SymbolTable>) {
         self.fst.set_output_symbols(symt)
     }
 
-    fn unset_input_symbols(&mut self) -> Option<Rc<SymbolTable>> {
-        self.fst.unset_input_symbols()
+    fn take_input_symbols(&mut self) -> Option<Arc<SymbolTable>> {
+        self.fst.take_input_symbols()
     }
 
-    fn unset_output_symbols(&mut self) -> Option<Rc<SymbolTable>> {
-        self.fst.unset_output_symbols()
+    fn take_output_symbols(&mut self) -> Option<Arc<SymbolTable>> {
+        self.fst.take_output_symbols()
     }
 }
 

--- a/rustfst/src/algorithms/compose/compose_filters/alt_sequence_compose_filter.rs
+++ b/rustfst/src/algorithms/compose/compose_filters/alt_sequence_compose_filter.rs
@@ -1,6 +1,6 @@
 use std::cell::RefCell;
 use std::marker::PhantomData;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use anyhow::Result;
 
@@ -17,9 +17,9 @@ use crate::{StateId, Tr, EPS_LABEL, NO_LABEL, NO_STATE_ID};
 #[derive(Clone, Debug)]
 pub struct AltSequenceComposeFilter<W: Semiring, M1: Matcher<W>, M2: Matcher<W>> {
     fst1: PhantomData<M1::F>,
-    fst2: Rc<M2::F>,
-    matcher1: Rc<RefCell<M1>>,
-    matcher2: Rc<RefCell<M2>>,
+    fst2: Arc<M2::F>,
+    matcher1: Arc<RefCell<M1>>,
+    matcher2: Arc<RefCell<M2>>,
     /// Current fst1 state
     s1: StateId,
     /// Current fst2 state
@@ -39,21 +39,21 @@ impl<W: Semiring + 'static, M1: Matcher<W>, M2: Matcher<W>> ComposeFilter<W>
     type M2 = M2;
     type FS = IntegerFilterState;
 
-    fn new<IM1: Into<Option<Rc<RefCell<Self::M1>>>>, IM2: Into<Option<Rc<RefCell<Self::M2>>>>>(
-        fst1: Rc<<Self::M1 as Matcher<W>>::F>,
-        fst2: Rc<<Self::M2 as Matcher<W>>::F>,
+    fn new<IM1: Into<Option<Arc<RefCell<Self::M1>>>>, IM2: Into<Option<Arc<RefCell<Self::M2>>>>>(
+        fst1: Arc<<Self::M1 as Matcher<W>>::F>,
+        fst2: Arc<<Self::M2 as Matcher<W>>::F>,
         m1: IM1,
         m2: IM2,
     ) -> Result<Self> {
         Ok(Self {
-            fst2: Rc::clone(&fst2),
+            fst2: Arc::clone(&fst2),
             matcher1: m1.into().unwrap_or_else(|| {
-                Rc::new(RefCell::new(
+                Arc::new(RefCell::new(
                     Self::M1::new(fst1, MatchType::MatchOutput).unwrap(),
                 ))
             }),
             matcher2: m2.into().unwrap_or_else(|| {
-                Rc::new(RefCell::new(
+                Arc::new(RefCell::new(
                     Self::M2::new(fst2, MatchType::MatchInput).unwrap(),
                 ))
             }),
@@ -114,12 +114,12 @@ impl<W: Semiring + 'static, M1: Matcher<W>, M2: Matcher<W>> ComposeFilter<W>
         Ok(())
     }
 
-    fn matcher1(&self) -> Rc<RefCell<Self::M1>> {
-        Rc::clone(&self.matcher1)
+    fn matcher1(&self) -> Arc<RefCell<Self::M1>> {
+        Arc::clone(&self.matcher1)
     }
 
-    fn matcher2(&self) -> Rc<RefCell<Self::M2>> {
-        Rc::clone(&self.matcher2)
+    fn matcher2(&self) -> Arc<RefCell<Self::M2>> {
+        Arc::clone(&self.matcher2)
     }
 }
 

--- a/rustfst/src/algorithms/compose/compose_filters/match_compose_filter.rs
+++ b/rustfst/src/algorithms/compose/compose_filters/match_compose_filter.rs
@@ -7,14 +7,14 @@ use crate::fst_traits::{CoreFst, Fst};
 use crate::semirings::Semiring;
 use crate::{StateId, Tr, EPS_LABEL, NO_LABEL, NO_STATE_ID};
 use std::cell::RefCell;
-use std::rc::Rc;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct MatchComposeFilter<F1, F2, M1, M2> {
-    fst1: Rc<F1>,
-    fst2: Rc<F2>,
-    matcher1: Rc<RefCell<M1>>,
-    matcher2: Rc<RefCell<M2>>,
+    fst1: Arc<F1>,
+    fst2: Arc<F2>,
+    matcher1: Arc<RefCell<M1>>,
+    matcher2: Arc<RefCell<M2>>,
     /// Current fst1 state
     s1: StateId,
     /// Current fst2 state
@@ -38,22 +38,22 @@ impl<W: Semiring + 'static, M1: Matcher<W>, M2: Matcher<W>> ComposeFilter<W>
     type M2 = M2;
     type FS = IntegerFilterState;
 
-    fn new<IM1: Into<Option<Rc<RefCell<Self::M1>>>>, IM2: Into<Option<Rc<RefCell<Self::M2>>>>>(
-        fst1: Rc<<Self::M1 as Matcher<W>>::F>,
-        fst2: Rc<<Self::M2 as Matcher<W>>::F>,
+    fn new<IM1: Into<Option<Arc<RefCell<Self::M1>>>>, IM2: Into<Option<Arc<RefCell<Self::M2>>>>>(
+        fst1: Arc<<Self::M1 as Matcher<W>>::F>,
+        fst2: Arc<<Self::M2 as Matcher<W>>::F>,
         m1: IM1,
         m2: IM2,
     ) -> Result<Self> {
         Ok(Self {
-            fst1: Rc::clone(&fst1),
-            fst2: Rc::clone(&fst2),
+            fst1: Arc::clone(&fst1),
+            fst2: Arc::clone(&fst2),
             matcher1: m1.into().unwrap_or_else(|| {
-                Rc::new(RefCell::new(
+                Arc::new(RefCell::new(
                     Self::M1::new(fst1, MatchType::MatchOutput).unwrap(),
                 ))
             }),
             matcher2: m2.into().unwrap_or_else(|| {
-                Rc::new(RefCell::new(
+                Arc::new(RefCell::new(
                     Self::M2::new(fst2, MatchType::MatchInput).unwrap(),
                 ))
             }),
@@ -148,11 +148,11 @@ impl<W: Semiring + 'static, M1: Matcher<W>, M2: Matcher<W>> ComposeFilter<W>
         Ok(())
     }
 
-    fn matcher1(&self) -> Rc<RefCell<Self::M1>> {
-        Rc::clone(&self.matcher1)
+    fn matcher1(&self) -> Arc<RefCell<Self::M1>> {
+        Arc::clone(&self.matcher1)
     }
 
-    fn matcher2(&self) -> Rc<RefCell<Self::M2>> {
-        Rc::clone(&self.matcher2)
+    fn matcher2(&self) -> Arc<RefCell<Self::M2>> {
+        Arc::clone(&self.matcher2)
     }
 }

--- a/rustfst/src/algorithms/compose/compose_filters/mod.rs
+++ b/rustfst/src/algorithms/compose/compose_filters/mod.rs
@@ -1,6 +1,6 @@
 use std::cell::RefCell;
 use std::fmt::Debug;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use anyhow::Result;
 
@@ -32,9 +32,9 @@ pub trait ComposeFilter<W: Semiring>: Debug {
     type M2: Matcher<W>;
     type FS: FilterState;
 
-    fn new<IM1: Into<Option<Rc<RefCell<Self::M1>>>>, IM2: Into<Option<Rc<RefCell<Self::M2>>>>>(
-        fst1: Rc<<Self::M1 as Matcher<W>>::F>,
-        fst2: Rc<<Self::M2 as Matcher<W>>::F>,
+    fn new<IM1: Into<Option<Arc<RefCell<Self::M1>>>>, IM2: Into<Option<Arc<RefCell<Self::M2>>>>>(
+        fst1: Arc<<Self::M1 as Matcher<W>>::F>,
+        fst2: Arc<<Self::M2 as Matcher<W>>::F>,
         m1: IM1,
         m2: IM2,
     ) -> Result<Self>
@@ -49,7 +49,7 @@ pub trait ComposeFilter<W: Semiring>: Debug {
 
     fn filter_final(&self, w1: &mut W, w2: &mut W) -> Result<()>;
 
-    fn matcher1(&self) -> Rc<RefCell<Self::M1>>;
+    fn matcher1(&self) -> Arc<RefCell<Self::M1>>;
 
-    fn matcher2(&self) -> Rc<RefCell<Self::M2>>;
+    fn matcher2(&self) -> Arc<RefCell<Self::M2>>;
 }

--- a/rustfst/src/algorithms/compose/compose_filters/multi_eps_filter.rs
+++ b/rustfst/src/algorithms/compose/compose_filters/multi_eps_filter.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use anyhow::Result;
 
@@ -19,9 +19,9 @@ impl<W: Semiring, F: ComposeFilter<W>> ComposeFilter<W> for MultiEpsFilter<F> {
     type M2 = F::M2;
     type FS = F::FS;
 
-    fn new<IM1: Into<Option<Rc<RefCell<Self::M1>>>>, IM2: Into<Option<Rc<RefCell<Self::M2>>>>>(
-        fst1: Rc<<Self::M1 as Matcher<W>>::F>,
-        fst2: Rc<<Self::M2 as Matcher<W>>::F>,
+    fn new<IM1: Into<Option<Arc<RefCell<Self::M1>>>>, IM2: Into<Option<Arc<RefCell<Self::M2>>>>>(
+        fst1: Arc<<Self::M1 as Matcher<W>>::F>,
+        fst2: Arc<<Self::M2 as Matcher<W>>::F>,
         m1: IM1,
         m2: IM2,
     ) -> Result<Self> {
@@ -57,11 +57,11 @@ impl<W: Semiring, F: ComposeFilter<W>> ComposeFilter<W> for MultiEpsFilter<F> {
         self.filter.filter_final(w1, w2)
     }
 
-    fn matcher1(&self) -> Rc<RefCell<Self::M1>> {
-        Rc::clone(&self.filter.matcher1())
+    fn matcher1(&self) -> Arc<RefCell<Self::M1>> {
+        Arc::clone(&self.filter.matcher1())
     }
 
-    fn matcher2(&self) -> Rc<RefCell<Self::M2>> {
-        Rc::clone(&self.filter.matcher2())
+    fn matcher2(&self) -> Arc<RefCell<Self::M2>> {
+        Arc::clone(&self.filter.matcher2())
     }
 }

--- a/rustfst/src/algorithms/compose/compose_filters/no_match_compose_filter.rs
+++ b/rustfst/src/algorithms/compose/compose_filters/no_match_compose_filter.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use anyhow::Result;
 
@@ -11,8 +11,8 @@ use crate::{Tr, EPS_LABEL};
 
 #[derive(Debug)]
 pub struct NoMatchComposeFilter<M1, M2> {
-    matcher1: Rc<RefCell<M1>>,
-    matcher2: Rc<RefCell<M2>>,
+    matcher1: Arc<RefCell<M1>>,
+    matcher2: Arc<RefCell<M2>>,
 }
 
 impl<W: Semiring, M1: Matcher<W>, M2: Matcher<W>> ComposeFilter<W>
@@ -22,20 +22,20 @@ impl<W: Semiring, M1: Matcher<W>, M2: Matcher<W>> ComposeFilter<W>
     type M2 = M2;
     type FS = TrivialFilterState;
 
-    fn new<IM1: Into<Option<Rc<RefCell<Self::M1>>>>, IM2: Into<Option<Rc<RefCell<Self::M2>>>>>(
-        fst1: Rc<<Self::M1 as Matcher<W>>::F>,
-        fst2: Rc<<Self::M2 as Matcher<W>>::F>,
+    fn new<IM1: Into<Option<Arc<RefCell<Self::M1>>>>, IM2: Into<Option<Arc<RefCell<Self::M2>>>>>(
+        fst1: Arc<<Self::M1 as Matcher<W>>::F>,
+        fst2: Arc<<Self::M2 as Matcher<W>>::F>,
         m1: IM1,
         m2: IM2,
     ) -> Result<Self> {
         Ok(Self {
             matcher1: m1.into().unwrap_or_else(|| {
-                Rc::new(RefCell::new(
+                Arc::new(RefCell::new(
                     Self::M1::new(fst1, MatchType::MatchOutput).unwrap(),
                 ))
             }),
             matcher2: m2.into().unwrap_or_else(|| {
-                Rc::new(RefCell::new(
+                Arc::new(RefCell::new(
                     Self::M2::new(fst2, MatchType::MatchInput).unwrap(),
                 ))
             }),
@@ -60,11 +60,11 @@ impl<W: Semiring, M1: Matcher<W>, M2: Matcher<W>> ComposeFilter<W>
         Ok(())
     }
 
-    fn matcher1(&self) -> Rc<RefCell<Self::M1>> {
-        Rc::clone(&self.matcher1)
+    fn matcher1(&self) -> Arc<RefCell<Self::M1>> {
+        Arc::clone(&self.matcher1)
     }
 
-    fn matcher2(&self) -> Rc<RefCell<Self::M2>> {
-        Rc::clone(&self.matcher2)
+    fn matcher2(&self) -> Arc<RefCell<Self::M2>> {
+        Arc::clone(&self.matcher2)
     }
 }

--- a/rustfst/src/algorithms/compose/compose_filters/null_compose_filter.rs
+++ b/rustfst/src/algorithms/compose/compose_filters/null_compose_filter.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use anyhow::Result;
 
@@ -11,8 +11,8 @@ use crate::{Tr, NO_LABEL};
 
 #[derive(Debug)]
 pub struct NullComposeFilter<M1, M2> {
-    matcher1: Rc<RefCell<M1>>,
-    matcher2: Rc<RefCell<M2>>,
+    matcher1: Arc<RefCell<M1>>,
+    matcher2: Arc<RefCell<M2>>,
 }
 
 impl<W: Semiring, M1: Matcher<W>, M2: Matcher<W>> ComposeFilter<W> for NullComposeFilter<M1, M2> {
@@ -20,18 +20,18 @@ impl<W: Semiring, M1: Matcher<W>, M2: Matcher<W>> ComposeFilter<W> for NullCompo
     type M2 = M2;
     type FS = TrivialFilterState;
 
-    fn new<IM1: Into<Option<Rc<RefCell<Self::M1>>>>, IM2: Into<Option<Rc<RefCell<Self::M2>>>>>(
-        fst1: Rc<<Self::M1 as Matcher<W>>::F>,
-        fst2: Rc<<Self::M2 as Matcher<W>>::F>,
+    fn new<IM1: Into<Option<Arc<RefCell<Self::M1>>>>, IM2: Into<Option<Arc<RefCell<Self::M2>>>>>(
+        fst1: Arc<<Self::M1 as Matcher<W>>::F>,
+        fst2: Arc<<Self::M2 as Matcher<W>>::F>,
         m1: IM1,
         m2: IM2,
     ) -> Result<Self> {
         Ok(Self {
             matcher1: m1.into().unwrap_or_else(|| {
-                Rc::new(RefCell::new(M1::new(fst1, MatchType::MatchOutput).unwrap()))
+                Arc::new(RefCell::new(M1::new(fst1, MatchType::MatchOutput).unwrap()))
             }),
             matcher2: m2.into().unwrap_or_else(|| {
-                Rc::new(RefCell::new(M2::new(fst2, MatchType::MatchInput).unwrap()))
+                Arc::new(RefCell::new(M2::new(fst2, MatchType::MatchInput).unwrap()))
             }),
         })
     }
@@ -57,11 +57,11 @@ impl<W: Semiring, M1: Matcher<W>, M2: Matcher<W>> ComposeFilter<W> for NullCompo
         Ok(())
     }
 
-    fn matcher1(&self) -> Rc<RefCell<Self::M1>> {
-        Rc::clone(&self.matcher1)
+    fn matcher1(&self) -> Arc<RefCell<Self::M1>> {
+        Arc::clone(&self.matcher1)
     }
 
-    fn matcher2(&self) -> Rc<RefCell<Self::M2>> {
-        Rc::clone(&self.matcher2)
+    fn matcher2(&self) -> Arc<RefCell<Self::M2>> {
+        Arc::clone(&self.matcher2)
     }
 }

--- a/rustfst/src/algorithms/compose/compose_filters/sequence_compose_filter.rs
+++ b/rustfst/src/algorithms/compose/compose_filters/sequence_compose_filter.rs
@@ -7,15 +7,15 @@ use crate::fst_traits::{CoreFst, Fst};
 use crate::semirings::Semiring;
 use crate::{StateId, Tr, EPS_LABEL, NO_LABEL, NO_STATE_ID};
 use std::cell::RefCell;
-use std::rc::Rc;
+use std::sync::Arc;
 
 #[derive(Debug)]
 /// This filter requires epsilons on FST1 to be read before epsilons on FST2.
 pub struct SequenceComposeFilter<W: Semiring, M1: Matcher<W>, M2: Matcher<W>> {
-    fst1: Rc<M1::F>,
-    fst2: Rc<M2::F>,
-    matcher1: Rc<RefCell<M1>>,
-    matcher2: Rc<RefCell<M2>>,
+    fst1: Arc<M1::F>,
+    fst2: Arc<M2::F>,
+    matcher1: Arc<RefCell<M1>>,
+    matcher2: Arc<RefCell<M2>>,
     /// Current fst1 state
     s1: StateId,
     /// Current fst2 state
@@ -35,22 +35,22 @@ impl<W: Semiring + 'static, M1: Matcher<W>, M2: Matcher<W>> ComposeFilter<W>
     type M2 = M2;
     type FS = IntegerFilterState;
 
-    fn new<IM1: Into<Option<Rc<RefCell<Self::M1>>>>, IM2: Into<Option<Rc<RefCell<Self::M2>>>>>(
-        fst1: Rc<M1::F>,
-        fst2: Rc<M2::F>,
+    fn new<IM1: Into<Option<Arc<RefCell<Self::M1>>>>, IM2: Into<Option<Arc<RefCell<Self::M2>>>>>(
+        fst1: Arc<M1::F>,
+        fst2: Arc<M2::F>,
         m1: IM1,
         m2: IM2,
     ) -> Result<Self> {
         Ok(Self {
-            fst1: Rc::clone(&fst1),
-            fst2: Rc::clone(&fst2),
+            fst1: Arc::clone(&fst1),
+            fst2: Arc::clone(&fst2),
             matcher1: m1.into().unwrap_or_else(|| {
-                Rc::new(RefCell::new(
+                Arc::new(RefCell::new(
                     Self::M1::new(fst1, MatchType::MatchOutput).unwrap(),
                 ))
             }),
             matcher2: m2.into().unwrap_or_else(|| {
-                Rc::new(RefCell::new(
+                Arc::new(RefCell::new(
                     Self::M2::new(fst2, MatchType::MatchInput).unwrap(),
                 ))
             }),
@@ -110,11 +110,11 @@ impl<W: Semiring + 'static, M1: Matcher<W>, M2: Matcher<W>> ComposeFilter<W>
         Ok(())
     }
 
-    fn matcher1(&self) -> Rc<RefCell<Self::M1>> {
-        Rc::clone(&self.matcher1)
+    fn matcher1(&self) -> Arc<RefCell<Self::M1>> {
+        Arc::clone(&self.matcher1)
     }
 
-    fn matcher2(&self) -> Rc<RefCell<Self::M2>> {
-        Rc::clone(&self.matcher2)
+    fn matcher2(&self) -> Arc<RefCell<Self::M2>> {
+        Arc::clone(&self.matcher2)
     }
 }

--- a/rustfst/src/algorithms/compose/compose_filters/trivial_compose_filter.rs
+++ b/rustfst/src/algorithms/compose/compose_filters/trivial_compose_filter.rs
@@ -6,12 +6,12 @@ use crate::algorithms::compose::matchers::{MatchType, Matcher};
 use crate::semirings::Semiring;
 use crate::Tr;
 use std::cell::RefCell;
-use std::rc::Rc;
+use std::sync::Arc;
 
 #[derive(Debug, PartialEq)]
 pub struct TrivialComposeFilter<M1, M2> {
-    matcher1: Rc<RefCell<M1>>,
-    matcher2: Rc<RefCell<M2>>,
+    matcher1: Arc<RefCell<M1>>,
+    matcher2: Arc<RefCell<M2>>,
 }
 
 impl<W: Semiring, M1: Matcher<W>, M2: Matcher<W>> ComposeFilter<W>
@@ -21,20 +21,20 @@ impl<W: Semiring, M1: Matcher<W>, M2: Matcher<W>> ComposeFilter<W>
     type M2 = M2;
     type FS = TrivialFilterState;
 
-    fn new<IM1: Into<Option<Rc<RefCell<Self::M1>>>>, IM2: Into<Option<Rc<RefCell<Self::M2>>>>>(
-        fst1: Rc<<Self::M1 as Matcher<W>>::F>,
-        fst2: Rc<<Self::M2 as Matcher<W>>::F>,
+    fn new<IM1: Into<Option<Arc<RefCell<Self::M1>>>>, IM2: Into<Option<Arc<RefCell<Self::M2>>>>>(
+        fst1: Arc<<Self::M1 as Matcher<W>>::F>,
+        fst2: Arc<<Self::M2 as Matcher<W>>::F>,
         m1: IM1,
         m2: IM2,
     ) -> Result<Self> {
         Ok(Self {
             matcher1: m1.into().unwrap_or_else(|| {
-                Rc::new(RefCell::new(
+                Arc::new(RefCell::new(
                     Self::M1::new(fst1, MatchType::MatchOutput).unwrap(),
                 ))
             }),
             matcher2: m2.into().unwrap_or_else(|| {
-                Rc::new(RefCell::new(
+                Arc::new(RefCell::new(
                     Self::M2::new(fst2, MatchType::MatchInput).unwrap(),
                 ))
             }),
@@ -57,11 +57,11 @@ impl<W: Semiring, M1: Matcher<W>, M2: Matcher<W>> ComposeFilter<W>
         Ok(())
     }
 
-    fn matcher1(&self) -> Rc<RefCell<Self::M1>> {
-        Rc::clone(&self.matcher1)
+    fn matcher1(&self) -> Arc<RefCell<Self::M1>> {
+        Arc::clone(&self.matcher1)
     }
 
-    fn matcher2(&self) -> Rc<RefCell<Self::M2>> {
-        Rc::clone(&self.matcher2)
+    fn matcher2(&self) -> Arc<RefCell<Self::M2>> {
+        Arc::clone(&self.matcher2)
     }
 }

--- a/rustfst/src/algorithms/compose/composition.rs
+++ b/rustfst/src/algorithms/compose/composition.rs
@@ -380,8 +380,8 @@ impl<W: Semiring, CF: ComposeFilter<W>> ComposeFst<W, CF> {
     where
         W: 'static,
     {
-        let isymt = fst1.input_symbols();
-        let osymt = fst2.output_symbols();
+        let isymt = fst1.input_symbols().cloned();
+        let osymt = fst2.output_symbols().cloned();
         let compose_impl = ComposeFstImpl::new(fst1, fst2, opts)?;
         Ok(Self::from_impl(compose_impl, isymt, osymt))
     }
@@ -402,8 +402,8 @@ impl<W: Semiring + 'static, F1: ExpandedFst<W = W>, F2: ExpandedFst<W = W>>
     ComposeFst<W, SequenceComposeFilter<W, GenericMatcher<F1>, GenericMatcher<F2>>>
 {
     pub fn new_auto(fst1: Rc<F1>, fst2: Rc<F2>) -> Result<Self> {
-        let isymt = fst1.input_symbols();
-        let osymt = fst2.output_symbols();
+        let isymt = fst1.input_symbols().cloned();
+        let osymt = fst2.output_symbols().cloned();
         let compose_impl = create_base(fst1, fst2)?;
         Ok(Self::from_impl(compose_impl, isymt, osymt))
     }

--- a/rustfst/src/algorithms/compose/composition.rs
+++ b/rustfst/src/algorithms/compose/composition.rs
@@ -1,6 +1,6 @@
 use std::cell::RefCell;
 use std::hash::Hash;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use anyhow::Result;
 use itertools::Itertools;
@@ -21,8 +21,8 @@ use crate::semirings::Semiring;
 use crate::{StateId, Tr, EPS_LABEL, NO_LABEL};
 
 pub struct ComposeFstImplOptions<M1, M2, CF, ST> {
-    matcher1: Option<Rc<RefCell<M1>>>,
-    matcher2: Option<Rc<RefCell<M2>>>,
+    matcher1: Option<Arc<RefCell<M1>>>,
+    matcher2: Option<Arc<RefCell<M2>>>,
     filter: Option<CF>,
     state_table: Option<ST>,
 }
@@ -40,8 +40,8 @@ impl<M1, M2, CF, ST> Default for ComposeFstImplOptions<M1, M2, CF, ST> {
 
 impl<M1, M2, CF, ST> ComposeFstImplOptions<M1, M2, CF, ST> {
     pub fn new<
-        IM1: Into<Option<Rc<RefCell<M1>>>>,
-        IM2: Into<Option<Rc<RefCell<M2>>>>,
+        IM1: Into<Option<Arc<RefCell<M1>>>>,
+        IM2: Into<Option<Arc<RefCell<M2>>>>,
         ICF: Into<Option<CF>>,
         IST: Into<Option<ST>>,
     >(
@@ -68,10 +68,10 @@ pub struct ComposeStateTuple<FS> {
 
 #[derive(Clone, Debug)]
 pub struct ComposeFstImpl<W: Semiring, CF: ComposeFilter<W>> {
-    fst1: Rc<<CF::M1 as Matcher<W>>::F>,
-    fst2: Rc<<CF::M2 as Matcher<W>>::F>,
-    matcher1: Rc<RefCell<CF::M1>>,
-    matcher2: Rc<RefCell<CF::M2>>,
+    fst1: Arc<<CF::M1 as Matcher<W>>::F>,
+    fst2: Arc<<CF::M2 as Matcher<W>>::F>,
+    matcher1: Arc<RefCell<CF::M1>>,
+    matcher2: Arc<RefCell<CF::M2>>,
     compose_filter: CF,
     cache_impl: CacheImpl<W>,
     state_table: StateTable<ComposeStateTuple<CF::FS>>,
@@ -89,16 +89,16 @@ impl<W: Semiring, CF: ComposeFilter<W>> ComposeFstImpl<W, CF> {
     // }
 
     fn new(
-        fst1: Rc<<CF::M1 as Matcher<W>>::F>,
-        fst2: Rc<<CF::M2 as Matcher<W>>::F>,
+        fst1: Arc<<CF::M1 as Matcher<W>>::F>,
+        fst2: Arc<<CF::M2 as Matcher<W>>::F>,
         opts: ComposeFstImplOptions<CF::M1, CF::M2, CF, StateTable<ComposeStateTuple<CF::FS>>>,
     ) -> Result<Self> {
         let opts_matcher1 = opts.matcher1;
         let opts_matcher2 = opts.matcher2;
         let compose_filter = opts.filter.unwrap_or_else(|| {
             CF::new(
-                Rc::clone(&fst1),
-                Rc::clone(&fst2),
+                Arc::clone(&fst1),
+                Arc::clone(&fst2),
                 opts_matcher1,
                 opts_matcher2,
             )
@@ -119,8 +119,8 @@ impl<W: Semiring, CF: ComposeFilter<W>> ComposeFstImpl<W, CF> {
     }
 
     fn match_type(
-        matcher1: &Rc<RefCell<CF::M1>>,
-        matcher2: &Rc<RefCell<CF::M2>>,
+        matcher1: &Arc<RefCell<CF::M1>>,
+        matcher2: &Arc<RefCell<CF::M2>>,
     ) -> Result<MatchType> {
         if matcher1
             .borrow()
@@ -179,9 +179,9 @@ impl<W: Semiring, CF: ComposeFilter<W>> ComposeFstImpl<W, CF> {
         &mut self,
         s: StateId,
         sa: StateId,
-        fstb: Rc<FB>,
+        fstb: Arc<FB>,
         sb: StateId,
-        matchera: Rc<RefCell<M>>,
+        matchera: Arc<RefCell<M>>,
         match_input: bool,
     ) -> Result<()> {
         let tr_loop = if match_input {
@@ -189,9 +189,9 @@ impl<W: Semiring, CF: ComposeFilter<W>> ComposeFstImpl<W, CF> {
         } else {
             Tr::new(NO_LABEL, EPS_LABEL, W::one(), sb)
         };
-        self.match_tr(s, sa, Rc::clone(&matchera), &tr_loop, match_input)?;
+        self.match_tr(s, sa, Arc::clone(&matchera), &tr_loop, match_input)?;
         for tr in fstb.tr_iter(sb)? {
-            self.match_tr(s, sa, Rc::clone(&matchera), tr, match_input)?;
+            self.match_tr(s, sa, Arc::clone(&matchera), tr, match_input)?;
         }
         Ok(())
     }
@@ -220,7 +220,7 @@ impl<W: Semiring, CF: ComposeFilter<W>> ComposeFstImpl<W, CF> {
         &mut self,
         s: StateId,
         sa: StateId,
-        matchera: Rc<RefCell<M>>,
+        matchera: Arc<RefCell<M>>,
         tr: &Tr<W>,
         match_input: bool,
     ) -> Result<()> {
@@ -277,18 +277,18 @@ impl<W: Semiring + 'static, CF: ComposeFilter<W>> FstImpl for ComposeFstImpl<W, 
             self.ordered_expand(
                 state,
                 s2,
-                Rc::clone(&self.fst1),
+                Arc::clone(&self.fst1),
                 s1,
-                Rc::clone(&self.matcher2),
+                Arc::clone(&self.matcher2),
                 true,
             )?;
         } else {
             self.ordered_expand(
                 state,
                 s1,
-                Rc::clone(&self.fst2),
+                Arc::clone(&self.fst2),
                 s2,
-                Rc::clone(&self.matcher1),
+                Arc::clone(&self.matcher1),
                 false,
             )?;
         }
@@ -357,8 +357,8 @@ pub enum ComposeFilterEnum {
 pub type ComposeFst<W, CF> = LazyFst<ComposeFstImpl<W, CF>>;
 
 fn create_base<W: Semiring + 'static, F1: ExpandedFst<W = W>, F2: ExpandedFst<W = W>>(
-    fst1: Rc<F1>,
-    fst2: Rc<F2>,
+    fst1: Arc<F1>,
+    fst2: Arc<F2>,
 ) -> Result<ComposeFstImpl<W, SequenceComposeFilter<W, GenericMatcher<F1>, GenericMatcher<F2>>>> {
     // TODO: change this once Lookahead matchers are supported.
     let opts = ComposeFstImplOptions::<
@@ -373,8 +373,8 @@ fn create_base<W: Semiring + 'static, F1: ExpandedFst<W = W>, F2: ExpandedFst<W 
 
 impl<W: Semiring, CF: ComposeFilter<W>> ComposeFst<W, CF> {
     pub fn new_with_options(
-        fst1: Rc<<CF::M1 as Matcher<W>>::F>,
-        fst2: Rc<<CF::M2 as Matcher<W>>::F>,
+        fst1: Arc<<CF::M1 as Matcher<W>>::F>,
+        fst2: Arc<<CF::M2 as Matcher<W>>::F>,
         opts: ComposeFstImplOptions<CF::M1, CF::M2, CF, StateTable<ComposeStateTuple<CF::FS>>>,
     ) -> Result<Self>
     where
@@ -388,8 +388,8 @@ impl<W: Semiring, CF: ComposeFilter<W>> ComposeFst<W, CF> {
 
     // TODO: Change API, no really user friendly
     pub fn new(
-        fst1: Rc<<CF::M1 as Matcher<W>>::F>,
-        fst2: Rc<<CF::M2 as Matcher<W>>::F>,
+        fst1: Arc<<CF::M1 as Matcher<W>>::F>,
+        fst2: Arc<<CF::M2 as Matcher<W>>::F>,
     ) -> Result<Self>
     where
         W: 'static,
@@ -401,7 +401,7 @@ impl<W: Semiring, CF: ComposeFilter<W>> ComposeFst<W, CF> {
 impl<W: Semiring + 'static, F1: ExpandedFst<W = W>, F2: ExpandedFst<W = W>>
     ComposeFst<W, SequenceComposeFilter<W, GenericMatcher<F1>, GenericMatcher<F2>>>
 {
-    pub fn new_auto(fst1: Rc<F1>, fst2: Rc<F2>) -> Result<Self> {
+    pub fn new_auto(fst1: Arc<F1>, fst2: Arc<F2>) -> Result<Self> {
         let isymt = fst1.input_symbols().cloned();
         let osymt = fst2.output_symbols().cloned();
         let compose_impl = create_base(fst1, fst2)?;
@@ -425,8 +425,8 @@ impl Default for ComposeConfig {
 }
 
 pub fn compose_with_config<F1: ExpandedFst, F2: ExpandedFst<W = F1::W>, F3: MutableFst<W = F1::W>>(
-    fst1: Rc<F1>,
-    fst2: Rc<F2>,
+    fst1: Arc<F1>,
+    fst2: Arc<F2>,
     config: ComposeConfig,
 ) -> Result<F3>
 where
@@ -484,7 +484,7 @@ where
 /// # use rustfst::semirings::{Semiring, IntegerWeight};
 /// # use rustfst::fst_impls::VectorFst;
 /// # use rustfst::algorithms::compose;
-/// # use std::rc::Rc;
+/// # use std::sync::Arc;
 /// # fn main() -> Result<()> {
 /// let fst_1 : VectorFst<IntegerWeight> = fst![1,2 => 2,3];
 ///
@@ -492,14 +492,14 @@ where
 ///
 /// let fst_ref : VectorFst<IntegerWeight> = fst![1,2 => 3,4];
 ///
-/// let composed_fst : VectorFst<_> = compose(Rc::new(fst_1), Rc::new(fst_2))?;
+/// let composed_fst : VectorFst<_> = compose(Arc::new(fst_1), Arc::new(fst_2))?;
 /// assert_eq!(composed_fst, fst_ref);
 /// # Ok(())
 /// # }
 /// ```
 pub fn compose<F1: ExpandedFst, F2: ExpandedFst<W = F1::W>, F3: MutableFst<W = F1::W>>(
-    fst1: Rc<F1>,
-    fst2: Rc<F2>,
+    fst1: Arc<F1>,
+    fst2: Arc<F2>,
 ) -> Result<F3>
 where
     F1::W: 'static,

--- a/rustfst/src/algorithms/compose/label_reachable.rs
+++ b/rustfst/src/algorithms/compose/label_reachable.rs
@@ -1,7 +1,7 @@
 use std::cell::RefCell;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use anyhow::Result;
 use itertools::Itertools;
@@ -54,7 +54,7 @@ impl LabelReachableData {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct LabelReachable {
-    data: Rc<RefCell<LabelReachableData>>,
+    data: Arc<RefCell<LabelReachableData>>,
     label2state: HashMap<Label, StateId>,
     reach_fst_input: bool,
 }
@@ -74,13 +74,13 @@ impl LabelReachable {
         Self::find_intervals(&fst, nstates, &mut data, &mut label2state)?;
 
         Ok(Self {
-            data: Rc::new(RefCell::new(data)),
+            data: Arc::new(RefCell::new(data)),
             label2state,
             reach_fst_input: false,
         })
     }
 
-    pub fn new_from_data(data: Rc<RefCell<LabelReachableData>>) -> Self {
+    pub fn new_from_data(data: Arc<RefCell<LabelReachableData>>) -> Self {
         Self {
             data,
             label2state: HashMap::new(),
@@ -88,12 +88,12 @@ impl LabelReachable {
         }
     }
 
-    pub fn data(&self) -> &Rc<RefCell<LabelReachableData>> {
+    pub fn data(&self) -> &Arc<RefCell<LabelReachableData>> {
         &self.data
     }
 
-    pub fn shared_data(&self) -> Rc<RefCell<LabelReachableData>> {
-        Rc::clone(&self.data)
+    pub fn shared_data(&self) -> Arc<RefCell<LabelReachableData>> {
+        Arc::clone(&self.data)
     }
 
     pub fn reach_input(&self) -> bool {
@@ -257,7 +257,7 @@ impl LabelReachable {
         pairs
     }
 
-    pub fn reach_init<F: ExpandedFst>(&mut self, fst: &Rc<F>, reach_input: bool) -> Result<()>
+    pub fn reach_init<F: ExpandedFst>(&mut self, fst: &Arc<F>, reach_input: bool) -> Result<()>
     where
         F::W: 'static,
     {

--- a/rustfst/src/algorithms/compose/label_reachable.rs
+++ b/rustfst/src/algorithms/compose/label_reachable.rs
@@ -223,10 +223,10 @@ impl LabelReachable {
 
         if relabel_input {
             tr_sort(fst, ilabel_compare);
-            fst.unset_input_symbols();
+            fst.take_input_symbols();
         } else {
             tr_sort(fst, olabel_compare);
-            fst.unset_output_symbols();
+            fst.take_output_symbols();
         }
 
         Ok(())

--- a/rustfst/src/algorithms/compose/lookahead_filters/lookahead_compose_filter.rs
+++ b/rustfst/src/algorithms/compose/lookahead_filters/lookahead_compose_filter.rs
@@ -1,6 +1,6 @@
 use std::cell::RefCell;
 use std::marker::PhantomData;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use anyhow::Result;
 
@@ -92,9 +92,9 @@ where
     type M2 = CF::M2;
     type FS = CF::FS;
 
-    fn new<IM1: Into<Option<Rc<RefCell<Self::M1>>>>, IM2: Into<Option<Rc<RefCell<Self::M2>>>>>(
-        fst1: Rc<<Self::M1 as Matcher<W>>::F>,
-        fst2: Rc<<Self::M2 as Matcher<W>>::F>,
+    fn new<IM1: Into<Option<Arc<RefCell<Self::M1>>>>, IM2: Into<Option<Arc<RefCell<Self::M2>>>>>(
+        fst1: Arc<<Self::M1 as Matcher<W>>::F>,
+        fst2: Arc<<Self::M2 as Matcher<W>>::F>,
         m1: IM1,
         m2: IM2,
     ) -> Result<Self> {
@@ -166,11 +166,11 @@ where
         self.filter.filter_final(w1, w2)
     }
 
-    fn matcher1(&self) -> Rc<RefCell<Self::M1>> {
+    fn matcher1(&self) -> Arc<RefCell<Self::M1>> {
         self.filter.matcher1()
     }
 
-    fn matcher2(&self) -> Rc<RefCell<Self::M2>> {
+    fn matcher2(&self) -> Arc<RefCell<Self::M2>> {
         self.filter.matcher2()
     }
 }

--- a/rustfst/src/algorithms/compose/lookahead_filters/lookahead_selector.rs
+++ b/rustfst/src/algorithms/compose/lookahead_filters/lookahead_selector.rs
@@ -1,6 +1,6 @@
 use std::cell::RefCell;
 use std::fmt::Debug;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::algorithms::compose::matchers::{MatchType, Matcher};
 use crate::semirings::Semiring;
@@ -56,13 +56,13 @@ impl MatchTypeTrait for SMatchUnknown {
 
 #[derive(Clone, Debug)]
 pub struct LookAheadSelector<F, M> {
-    pub fst: Rc<F>,
-    pub matcher: Rc<RefCell<M>>,
+    pub fst: Arc<F>,
+    pub matcher: Arc<RefCell<M>>,
 }
 
 fn selector_match_input<W: Semiring, M1: Matcher<W>, M2: Matcher<W>>(
-    lmatcher1: Rc<RefCell<M1>>,
-    lmatcher2: Rc<RefCell<M2>>,
+    lmatcher1: Arc<RefCell<M1>>,
+    lmatcher2: Arc<RefCell<M2>>,
 ) -> LookAheadSelector<M1::F, M2> {
     LookAheadSelector {
         fst: lmatcher1.borrow().fst(),
@@ -71,8 +71,8 @@ fn selector_match_input<W: Semiring, M1: Matcher<W>, M2: Matcher<W>>(
 }
 
 fn selector_match_output<W: Semiring, M1: Matcher<W>, M2: Matcher<W>>(
-    lmatcher1: Rc<RefCell<M1>>,
-    lmatcher2: Rc<RefCell<M2>>,
+    lmatcher1: Arc<RefCell<M1>>,
+    lmatcher2: Arc<RefCell<M2>>,
 ) -> LookAheadSelector<M2::F, M1> {
     LookAheadSelector {
         fst: lmatcher2.borrow().fst(),
@@ -87,8 +87,8 @@ pub enum Selector<W: Semiring, M1: Matcher<W>, M2: Matcher<W>> {
 }
 
 pub(crate) fn selector<W: Semiring, M1: Matcher<W>, M2: Matcher<W>>(
-    lmatcher1: Rc<RefCell<M1>>,
-    lmatcher2: Rc<RefCell<M2>>,
+    lmatcher1: Arc<RefCell<M1>>,
+    lmatcher2: Arc<RefCell<M2>>,
     match_type: MatchType,
     lookahead_type: MatchType,
 ) -> Selector<W, M1, M2> {

--- a/rustfst/src/algorithms/compose/lookahead_filters/mod.rs
+++ b/rustfst/src/algorithms/compose/lookahead_filters/mod.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::rc::Rc;
+use std::sync::Arc;
 
 pub use lookahead_compose_filter::LookAheadComposeFilter;
 pub use lookahead_selector::{SMatchBoth, SMatchInput, SMatchNone, SMatchOutput, SMatchUnknown};
@@ -19,8 +19,8 @@ mod push_labels_compose_filter;
 mod push_weights_compose_filter;
 
 pub fn lookahead_match_type<W: Semiring, M1: Matcher<W>, M2: Matcher<W>>(
-    m1: Rc<RefCell<M1>>,
-    m2: Rc<RefCell<M2>>,
+    m1: Arc<RefCell<M1>>,
+    m2: Arc<RefCell<M2>>,
 ) -> MatchType {
     let type1 = m1.borrow().match_type();
     let type2 = m2.borrow().match_type();

--- a/rustfst/src/algorithms/compose/lookahead_filters/push_weights_compose_filter.rs
+++ b/rustfst/src/algorithms/compose/lookahead_filters/push_weights_compose_filter.rs
@@ -1,6 +1,6 @@
 use std::cell::RefCell;
 use std::marker::PhantomData;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use anyhow::Result;
 
@@ -38,9 +38,9 @@ where
     type M2 = CF::M2;
     type FS = PairFilterState<CF::FS, WeightFilterState<W>>;
 
-    fn new<IM1: Into<Option<Rc<RefCell<Self::M1>>>>, IM2: Into<Option<Rc<RefCell<Self::M2>>>>>(
-        fst1: Rc<<Self::M1 as Matcher<W>>::F>,
-        fst2: Rc<<Self::M2 as Matcher<W>>::F>,
+    fn new<IM1: Into<Option<Arc<RefCell<Self::M1>>>>, IM2: Into<Option<Arc<RefCell<Self::M2>>>>>(
+        fst1: Arc<<Self::M1 as Matcher<W>>::F>,
+        fst2: Arc<<Self::M2 as Matcher<W>>::F>,
         m1: IM1,
         m2: IM2,
     ) -> Result<Self> {
@@ -108,11 +108,11 @@ where
         w1.divide_assign(fweight, DivideType::DivideAny)
     }
 
-    fn matcher1(&self) -> Rc<RefCell<Self::M1>> {
+    fn matcher1(&self) -> Arc<RefCell<Self::M1>> {
         self.filter.matcher1()
     }
 
-    fn matcher2(&self) -> Rc<RefCell<Self::M2>> {
+    fn matcher2(&self) -> Arc<RefCell<Self::M2>> {
         self.filter.matcher2()
     }
 }

--- a/rustfst/src/algorithms/compose/lookahead_matchers/label_lookahead_relabeler.rs
+++ b/rustfst/src/algorithms/compose/lookahead_matchers/label_lookahead_relabeler.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use anyhow::Result;
 
@@ -14,8 +14,8 @@ impl LabelLookAheadRelabeler {
         fst_addon: &mut FstAddOn<
             F,
             (
-                Option<Rc<RefCell<LabelReachableData>>>,
-                Option<Rc<RefCell<LabelReachableData>>>,
+                Option<Arc<RefCell<LabelReachableData>>>,
+                Option<Arc<RefCell<LabelReachableData>>>,
             ),
         >,
     ) -> Result<()> {
@@ -25,10 +25,10 @@ impl LabelLookAheadRelabeler {
         let mfst = fst;
 
         if data.0.is_some() {
-            let reachable = LabelReachable::new_from_data(Rc::clone(data.0.as_ref().unwrap()));
+            let reachable = LabelReachable::new_from_data(Arc::clone(data.0.as_ref().unwrap()));
             reachable.relabel_fst(mfst, true)?;
         } else {
-            let reachable = LabelReachable::new_from_data(Rc::clone(data.1.as_ref().unwrap()));
+            let reachable = LabelReachable::new_from_data(Arc::clone(data.1.as_ref().unwrap()));
             reachable.relabel_fst(mfst, false)?;
         }
 
@@ -38,15 +38,15 @@ impl LabelLookAheadRelabeler {
     pub fn relabel<F: MutableFst>(
         fst: &mut F,
         addon: &(
-            Option<Rc<RefCell<LabelReachableData>>>,
-            Option<Rc<RefCell<LabelReachableData>>>,
+            Option<Arc<RefCell<LabelReachableData>>>,
+            Option<Arc<RefCell<LabelReachableData>>>,
         ),
         relabel_input: bool,
     ) -> Result<()> {
         let reachable_data = if addon.0.as_ref().is_some() {
-            Rc::clone(addon.0.as_ref().unwrap())
+            Arc::clone(addon.0.as_ref().unwrap())
         } else {
-            Rc::clone(addon.1.as_ref().unwrap())
+            Arc::clone(addon.1.as_ref().unwrap())
         };
         let reachable = LabelReachable::new_from_data(reachable_data);
         reachable.relabel_fst(fst, relabel_input)

--- a/rustfst/src/algorithms/compose/lookahead_matchers/mod.rs
+++ b/rustfst/src/algorithms/compose/lookahead_matchers/mod.rs
@@ -1,6 +1,6 @@
 use std::cell::RefCell;
 use std::fmt::Debug;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use anyhow::Result;
 
@@ -26,12 +26,12 @@ pub trait MatcherFlagsTrait: Debug {
 
 pub trait LookaheadMatcher<W: Semiring>: Matcher<W> {
     type MatcherData: Clone;
-    fn data(&self) -> Option<&Rc<RefCell<Self::MatcherData>>>;
+    fn data(&self) -> Option<&Arc<RefCell<Self::MatcherData>>>;
 
     fn new_with_data(
-        fst: Rc<Self::F>,
+        fst: Arc<Self::F>,
         match_type: MatchType,
-        data: Option<Rc<RefCell<Self::MatcherData>>>,
+        data: Option<Arc<RefCell<Self::MatcherData>>>,
     ) -> Result<Self>
     where
         Self: std::marker::Sized;
@@ -39,15 +39,15 @@ pub trait LookaheadMatcher<W: Semiring>: Matcher<W> {
     fn create_data<F: ExpandedFst<W = W>>(
         fst: &F,
         match_type: MatchType,
-    ) -> Result<Option<Rc<RefCell<Self::MatcherData>>>>;
+    ) -> Result<Option<Arc<RefCell<Self::MatcherData>>>>;
 
-    fn init_lookahead_fst<LF: ExpandedFst<W = W>>(&mut self, lfst: &Rc<LF>) -> Result<()>;
+    fn init_lookahead_fst<LF: ExpandedFst<W = W>>(&mut self, lfst: &Arc<LF>) -> Result<()>;
     // Are there paths from a state in the lookahead FST that can be read from
     // the curent matcher state?
     fn lookahead_fst<LF: ExpandedFst<W = W>>(
         &mut self,
         matcher_state: StateId,
-        lfst: &Rc<LF>,
+        lfst: &Arc<LF>,
         lfst_state: StateId,
     ) -> Result<bool>;
 

--- a/rustfst/src/algorithms/compose/lookahead_matchers/trivial_lookahead_matcher.rs
+++ b/rustfst/src/algorithms/compose/lookahead_matchers/trivial_lookahead_matcher.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use anyhow::Result;
 
@@ -20,7 +20,7 @@ impl<W: Semiring, M: Matcher<W>> Matcher<W> for TrivialLookAheadMatcher<W, M> {
     type F = M::F;
     type Iter = M::Iter;
 
-    fn new(fst: Rc<Self::F>, match_type: MatchType) -> Result<Self> {
+    fn new(fst: Arc<Self::F>, match_type: MatchType) -> Result<Self> {
         Ok(Self {
             matcher: M::new(fst, match_type)?,
             prefix_tr: Tr::new(0, 0, W::one(), NO_STATE_ID),
@@ -50,7 +50,7 @@ impl<W: Semiring, M: Matcher<W>> Matcher<W> for TrivialLookAheadMatcher<W, M> {
         self.matcher.priority(state)
     }
 
-    fn fst(&self) -> Rc<Self::F> {
+    fn fst(&self) -> Arc<Self::F> {
         self.matcher.fst()
     }
 }
@@ -58,14 +58,14 @@ impl<W: Semiring, M: Matcher<W>> Matcher<W> for TrivialLookAheadMatcher<W, M> {
 impl<W: Semiring, M: Matcher<W>> LookaheadMatcher<W> for TrivialLookAheadMatcher<W, M> {
     type MatcherData = ();
 
-    fn data(&self) -> Option<&Rc<RefCell<Self::MatcherData>>> {
+    fn data(&self) -> Option<&Arc<RefCell<Self::MatcherData>>> {
         None
     }
 
     fn new_with_data(
-        fst: Rc<Self::F>,
+        fst: Arc<Self::F>,
         match_type: MatchType,
-        _data: Option<Rc<RefCell<Self::MatcherData>>>,
+        _data: Option<Arc<RefCell<Self::MatcherData>>>,
     ) -> Result<Self> {
         Self::new(fst, match_type)
     }
@@ -73,18 +73,18 @@ impl<W: Semiring, M: Matcher<W>> LookaheadMatcher<W> for TrivialLookAheadMatcher
     fn create_data<F: ExpandedFst<W = W>>(
         _fst: &F,
         _match_type: MatchType,
-    ) -> Result<Option<Rc<RefCell<Self::MatcherData>>>> {
+    ) -> Result<Option<Arc<RefCell<Self::MatcherData>>>> {
         Ok(None)
     }
 
-    fn init_lookahead_fst<LF: ExpandedFst<W = W>>(&mut self, _lfst: &Rc<LF>) -> Result<()> {
+    fn init_lookahead_fst<LF: ExpandedFst<W = W>>(&mut self, _lfst: &Arc<LF>) -> Result<()> {
         Ok(())
     }
 
     fn lookahead_fst<LF: Fst<W = W>>(
         &mut self,
         _matcher_state: StateId,
-        _lfst: &Rc<LF>,
+        _lfst: &Arc<LF>,
         _s: StateId,
     ) -> Result<bool> {
         Ok(true)

--- a/rustfst/src/algorithms/compose/matcher_fst.rs
+++ b/rustfst/src/algorithms/compose/matcher_fst.rs
@@ -1,7 +1,6 @@
 use std::cell::RefCell;
 use std::fmt::Debug;
 use std::marker::PhantomData;
-use std::rc::Rc;
 use std::sync::Arc;
 
 use anyhow::Result;
@@ -17,7 +16,7 @@ use crate::SymbolTable;
 
 #[derive(Clone, PartialEq, Debug)]
 pub struct MatcherFst<F, M, T> {
-    fst_add_on: FstAddOn<F, (Option<Rc<RefCell<T>>>, Option<Rc<RefCell<T>>>)>,
+    fst_add_on: FstAddOn<F, (Option<Arc<RefCell<T>>>, Option<Arc<RefCell<T>>>)>,
     matcher: PhantomData<M>,
 }
 
@@ -26,11 +25,11 @@ impl<F, M, T> MatcherFst<F, M, T> {
         self.fst_add_on.fst()
     }
 
-    pub fn addon(&self) -> &(Option<Rc<RefCell<T>>>, Option<Rc<RefCell<T>>>) {
+    pub fn addon(&self) -> &(Option<Arc<RefCell<T>>>, Option<Arc<RefCell<T>>>) {
         self.fst_add_on.add_on()
     }
 
-    pub fn data(&self, match_type: MatchType) -> Option<&Rc<RefCell<T>>> {
+    pub fn data(&self, match_type: MatchType) -> Option<&Arc<RefCell<T>>> {
         let data = self.fst_add_on.add_on();
         if match_type == MatchType::MatchInput {
             data.0.as_ref()

--- a/rustfst/src/algorithms/compose/matcher_fst.rs
+++ b/rustfst/src/algorithms/compose/matcher_fst.rs
@@ -2,6 +2,7 @@ use std::cell::RefCell;
 use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::rc::Rc;
+use std::sync::Arc;
 
 use anyhow::Result;
 
@@ -120,28 +121,28 @@ impl<F: Fst, M: Debug, T: Debug> Fst for MatcherFst<F, M, T>
 where
     F::W: 'static,
 {
-    fn input_symbols(&self) -> Option<Rc<SymbolTable>> {
+    fn input_symbols(&self) -> Option<&Arc<SymbolTable>> {
         self.fst_add_on.input_symbols()
     }
 
-    fn output_symbols(&self) -> Option<Rc<SymbolTable>> {
+    fn output_symbols(&self) -> Option<&Arc<SymbolTable>> {
         self.fst_add_on.output_symbols()
     }
 
-    fn set_input_symbols(&mut self, symt: Rc<SymbolTable>) {
+    fn set_input_symbols(&mut self, symt: Arc<SymbolTable>) {
         self.fst_add_on.set_input_symbols(symt)
     }
 
-    fn set_output_symbols(&mut self, symt: Rc<SymbolTable>) {
+    fn set_output_symbols(&mut self, symt: Arc<SymbolTable>) {
         self.fst_add_on.set_output_symbols(symt)
     }
 
-    fn unset_input_symbols(&mut self) -> Option<Rc<SymbolTable>> {
-        self.fst_add_on.unset_input_symbols()
+    fn take_input_symbols(&mut self) -> Option<Arc<SymbolTable>> {
+        self.fst_add_on.take_input_symbols()
     }
 
-    fn unset_output_symbols(&mut self) -> Option<Rc<SymbolTable>> {
-        self.fst_add_on.unset_output_symbols()
+    fn take_output_symbols(&mut self) -> Option<Arc<SymbolTable>> {
+        self.fst_add_on.take_output_symbols()
     }
 }
 

--- a/rustfst/src/algorithms/compose/matchers/mod.rs
+++ b/rustfst/src/algorithms/compose/matchers/mod.rs
@@ -11,7 +11,7 @@ use crate::fst_traits::ExpandedFst;
 use crate::semirings::Semiring;
 use crate::{Label, StateId};
 use crate::{Tr, EPS_LABEL, NO_LABEL};
-use std::rc::Rc;
+use std::sync::Arc;
 
 mod generic_matcher;
 mod multi_eps_matcher;
@@ -101,7 +101,7 @@ pub trait Matcher<W: Semiring>: Debug {
 
     type Iter: Iterator<Item = IterItemMatcher<W>> + Clone;
 
-    fn new(fst: Rc<Self::F>, match_type: MatchType) -> Result<Self>
+    fn new(fst: Arc<Self::F>, match_type: MatchType) -> Result<Self>
     where
         Self: std::marker::Sized;
     fn iter(&self, state: StateId, label: Label) -> Result<Self::Iter>;
@@ -115,5 +115,5 @@ pub trait Matcher<W: Semiring>: Debug {
     /// current state of the matcher invalidates the state of the matcher.
     fn priority(&self, state: StateId) -> Result<usize>;
 
-    fn fst(&self) -> Rc<Self::F>;
+    fn fst(&self) -> Arc<Self::F>;
 }

--- a/rustfst/src/algorithms/compose/matchers/sorted_matcher.rs
+++ b/rustfst/src/algorithms/compose/matchers/sorted_matcher.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use anyhow::Result;
 use superslice::Ext;
@@ -13,7 +13,7 @@ use crate::{Label, StateId, Tr, EPS_LABEL, NO_LABEL};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct SortedMatcher<F: ExpandedFst> {
-    fst: Rc<F>,
+    fst: Arc<F>,
     match_type: MatchType,
 }
 
@@ -21,7 +21,7 @@ impl<W: Semiring + 'static, F: ExpandedFst<W = W>> Matcher<W> for SortedMatcher<
     type F = F;
     type Iter = IteratorSortedMatcher<W>;
 
-    fn new(fst: Rc<F>, match_type: MatchType) -> Result<Self> {
+    fn new(fst: Arc<F>, match_type: MatchType) -> Result<Self> {
         Ok(Self { fst, match_type })
     }
 
@@ -77,8 +77,8 @@ impl<W: Semiring + 'static, F: ExpandedFst<W = W>> Matcher<W> for SortedMatcher<
         self.fst.num_trs(state)
     }
 
-    fn fst(&self) -> Rc<Self::F> {
-        Rc::clone(&self.fst)
+    fn fst(&self) -> Arc<Self::F> {
+        Arc::clone(&self.fst)
     }
 }
 
@@ -165,14 +165,14 @@ where
 {
     type MatcherData = ();
 
-    fn data(&self) -> Option<&Rc<RefCell<Self::MatcherData>>> {
+    fn data(&self) -> Option<&Arc<RefCell<Self::MatcherData>>> {
         unreachable!()
     }
 
     fn new_with_data(
-        _fst: Rc<Self::F>,
+        _fst: Arc<Self::F>,
         _match_type: MatchType,
-        _data: Option<Rc<RefCell<Self::MatcherData>>>,
+        _data: Option<Arc<RefCell<Self::MatcherData>>>,
     ) -> Result<Self>
     where
         Self: std::marker::Sized,
@@ -183,18 +183,18 @@ where
     fn create_data<G: ExpandedFst<W = F::W>>(
         _fst: &G,
         _match_type: MatchType,
-    ) -> Result<Option<Rc<RefCell<Self::MatcherData>>>> {
+    ) -> Result<Option<Arc<RefCell<Self::MatcherData>>>> {
         unreachable!()
     }
 
-    fn init_lookahead_fst<LF: ExpandedFst<W = F::W>>(&mut self, _lfst: &Rc<LF>) -> Result<()> {
+    fn init_lookahead_fst<LF: ExpandedFst<W = F::W>>(&mut self, _lfst: &Arc<LF>) -> Result<()> {
         unreachable!()
     }
 
     fn lookahead_fst<LF: ExpandedFst<W = F::W>>(
         &mut self,
         _matcher_state: usize,
-        _lfst: &Rc<LF>,
+        _lfst: &Arc<LF>,
         _lfst_state: usize,
     ) -> Result<bool> {
         unreachable!()

--- a/rustfst/src/algorithms/concat.rs
+++ b/rustfst/src/algorithms/concat.rs
@@ -7,7 +7,7 @@ use crate::fst_traits::{
 use crate::semirings::Semiring;
 use crate::tr::Tr;
 use crate::{SymbolTable, EPS_LABEL};
-use std::rc::Rc;
+use std::sync::Arc;
 
 /// Performs the concatenation of two wFSTs. If `A` transduces string `x` to `y` with weight `a`
 /// and `B` transduces string `w` to `v` with weight `b`, then their concatenation
@@ -119,10 +119,10 @@ where
         unsafe { rfst.set_start_unchecked(0) };
         unsafe { rfst.set_final_unchecked(2, F::W::one()) };
         if let Some(isymt) = fst1.input_symbols() {
-            rfst.set_input_symbols(isymt);
+            rfst.set_input_symbols(Arc::clone(isymt));
         }
         if let Some(osymt) = fst1.output_symbols() {
-            rfst.set_output_symbols(osymt);
+            rfst.set_output_symbols(Arc::clone(osymt));
         }
         unsafe { rfst.add_tr_unchecked(0, Tr::new(EPS_LABEL, std::usize::MAX, F::W::one(), 1)) };
         unsafe {
@@ -195,28 +195,28 @@ impl<F: Fst + 'static> Fst for ConcatFst<F>
 where
     F::W: 'static,
 {
-    fn input_symbols(&self) -> Option<Rc<SymbolTable>> {
+    fn input_symbols(&self) -> Option<&Arc<SymbolTable>> {
         self.0.input_symbols()
     }
 
-    fn output_symbols(&self) -> Option<Rc<SymbolTable>> {
+    fn output_symbols(&self) -> Option<&Arc<SymbolTable>> {
         self.0.output_symbols()
     }
 
-    fn set_input_symbols(&mut self, symt: Rc<SymbolTable>) {
+    fn set_input_symbols(&mut self, symt: Arc<SymbolTable>) {
         self.0.set_input_symbols(symt)
     }
 
-    fn set_output_symbols(&mut self, symt: Rc<SymbolTable>) {
+    fn set_output_symbols(&mut self, symt: Arc<SymbolTable>) {
         self.0.set_output_symbols(symt)
     }
 
-    fn unset_input_symbols(&mut self) -> Option<Rc<SymbolTable>> {
-        self.0.unset_input_symbols()
+    fn take_input_symbols(&mut self) -> Option<Arc<SymbolTable>> {
+        self.0.take_input_symbols()
     }
 
-    fn unset_output_symbols(&mut self) -> Option<Rc<SymbolTable>> {
-        self.0.unset_output_symbols()
+    fn take_output_symbols(&mut self) -> Option<Arc<SymbolTable>> {
+        self.0.take_output_symbols()
     }
 }
 

--- a/rustfst/src/algorithms/factor_weight.rs
+++ b/rustfst/src/algorithms/factor_weight.rs
@@ -305,8 +305,8 @@ where
     F::W: WeightQuantize + 'static,
 {
     pub fn new(fst: B, opts: FactorWeightOptions) -> Result<Self> {
-        let isymt = fst.borrow().input_symbols();
-        let osymt = fst.borrow().output_symbols();
+        let isymt = fst.borrow().input_symbols().cloned();
+        let osymt = fst.borrow().output_symbols().cloned();
         Ok(Self::from_impl(
             FactorWeightImpl::new(fst, opts)?,
             isymt,

--- a/rustfst/src/algorithms/replace.rs
+++ b/rustfst/src/algorithms/replace.rs
@@ -505,8 +505,8 @@ where
         let mut isymt = None;
         let mut osymt = None;
         if let Some(first_elt) = fst_list.first() {
-            isymt = first_elt.1.borrow().input_symbols();
-            osymt = first_elt.1.borrow().output_symbols();
+            isymt = first_elt.1.borrow().input_symbols().cloned();
+            osymt = first_elt.1.borrow().output_symbols().cloned();
         }
         let opts = ReplaceFstOptions::new(root, epsilon_on_replace);
         let fst = ReplaceFstImpl::new(fst_list, opts)?;

--- a/rustfst/src/algorithms/rm_epsilon.rs
+++ b/rustfst/src/algorithms/rm_epsilon.rs
@@ -439,8 +439,8 @@ where
     F::W: 'static,
 {
     pub fn new(fst: B) -> Self {
-        let isymt = fst.borrow().input_symbols();
-        let osymt = fst.borrow().output_symbols();
+        let isymt = fst.borrow().input_symbols().cloned();
+        let osymt = fst.borrow().output_symbols().cloned();
         Self::from_impl(RmEpsilonImpl::new(fst), isymt, osymt)
     }
 }

--- a/rustfst/src/algorithms/union.rs
+++ b/rustfst/src/algorithms/union.rs
@@ -1,4 +1,4 @@
-use std::rc::Rc;
+use std::sync::Arc;
 
 use anyhow::Result;
 use unsafe_unwrap::UnsafeUnwrap;
@@ -135,10 +135,10 @@ where
         rfst.set_start(0)?;
         unsafe { rfst.set_final_unchecked(1, F::W::one()) };
         if let Some(isymt) = fst1.input_symbols() {
-            rfst.set_input_symbols(isymt);
+            rfst.set_input_symbols(Arc::clone(isymt));
         }
         if let Some(osymt) = fst1.output_symbols() {
-            rfst.set_output_symbols(osymt);
+            rfst.set_output_symbols(Arc::clone(osymt));
         }
         unsafe { rfst.reserve_trs_unchecked(0, 2) };
         unsafe { rfst.add_tr_unchecked(0, Tr::new(EPS_LABEL, std::usize::MAX, F::W::one(), 1)) };
@@ -212,28 +212,28 @@ impl<F: Fst + 'static> Fst for UnionFst<F>
 where
     F::W: 'static,
 {
-    fn input_symbols(&self) -> Option<Rc<SymbolTable>> {
+    fn input_symbols(&self) -> Option<&Arc<SymbolTable>> {
         self.0.input_symbols()
     }
 
-    fn output_symbols(&self) -> Option<Rc<SymbolTable>> {
+    fn output_symbols(&self) -> Option<&Arc<SymbolTable>> {
         self.0.output_symbols()
     }
 
-    fn set_input_symbols(&mut self, symt: Rc<SymbolTable>) {
+    fn set_input_symbols(&mut self, symt: Arc<SymbolTable>) {
         self.0.set_input_symbols(symt)
     }
 
-    fn set_output_symbols(&mut self, symt: Rc<SymbolTable>) {
+    fn set_output_symbols(&mut self, symt: Arc<SymbolTable>) {
         self.0.set_output_symbols(symt)
     }
 
-    fn unset_input_symbols(&mut self) -> Option<Rc<SymbolTable>> {
-        self.0.unset_input_symbols()
+    fn take_input_symbols(&mut self) -> Option<Arc<SymbolTable>> {
+        self.0.take_input_symbols()
     }
 
-    fn unset_output_symbols(&mut self) -> Option<Rc<SymbolTable>> {
-        self.0.unset_output_symbols()
+    fn take_output_symbols(&mut self) -> Option<Arc<SymbolTable>> {
+        self.0.take_output_symbols()
     }
 }
 

--- a/rustfst/src/fst_impls/arc.rs
+++ b/rustfst/src/fst_impls/arc.rs
@@ -1,5 +1,4 @@
 use std::ops::Deref;
-use std::rc::Rc;
 use std::sync::Arc;
 
 use anyhow::Result;
@@ -9,7 +8,7 @@ use crate::fst_traits::{
 };
 use crate::SymbolTable;
 
-impl<F: Fst> Fst for Rc<F>
+impl<F: Fst> Fst for Arc<F>
 where
     F::W: 'static,
 {
@@ -38,7 +37,7 @@ where
     }
 }
 
-impl<F: ExpandedFst> ExpandedFst for Rc<F>
+impl<F: ExpandedFst> ExpandedFst for Arc<F>
 where
     F::W: 'static,
 {
@@ -47,7 +46,7 @@ where
     }
 }
 
-impl<F: CoreFst> CoreFst for Rc<F> {
+impl<F: CoreFst> CoreFst for Arc<F> {
     type W = F::W;
 
     fn start(&self) -> Option<usize> {
@@ -71,7 +70,7 @@ impl<F: CoreFst> CoreFst for Rc<F> {
     }
 }
 
-impl<'a, F: FstIterator<'a>> FstIterator<'a> for Rc<F>
+impl<'a, F: FstIterator<'a>> FstIterator<'a> for Arc<F>
 where
     F::W: 'a,
 {
@@ -83,7 +82,7 @@ where
     }
 }
 
-impl<'a, F: TrIterator<'a>> TrIterator<'a> for Rc<F>
+impl<'a, F: TrIterator<'a>> TrIterator<'a> for Arc<F>
 where
     F::W: 'a,
 {
@@ -98,7 +97,7 @@ where
     }
 }
 
-impl<'a, F: StateIterator<'a>> StateIterator<'a> for Rc<F> {
+impl<'a, F: StateIterator<'a>> StateIterator<'a> for Arc<F> {
     type Iter = F::Iter;
 
     fn states_iter(&'a self) -> Self::Iter {
@@ -106,7 +105,7 @@ impl<'a, F: StateIterator<'a>> StateIterator<'a> for Rc<F> {
     }
 }
 
-impl<F: FstIntoIterator> FstIntoIterator for Rc<F> {
+impl<F: FstIntoIterator> FstIntoIterator for Arc<F> {
     type TrsIter = F::TrsIter;
     type FstIter = F::FstIter;
 

--- a/rustfst/src/fst_impls/const_fst/data_structure.rs
+++ b/rustfst/src/fst_impls/const_fst/data_structure.rs
@@ -1,5 +1,5 @@
 use crate::{StateId, SymbolTable, Tr};
-use std::rc::Rc;
+use std::sync::Arc;
 
 /// Immutable FST whose states and trs each implemented by single arrays,
 #[derive(Debug, PartialEq, Clone)]
@@ -7,8 +7,8 @@ pub struct ConstFst<W> {
     pub(crate) states: Vec<ConstState<W>>,
     pub(crate) trs: Vec<Tr<W>>,
     pub(crate) start: Option<StateId>,
-    pub(crate) isymt: Option<Rc<SymbolTable>>,
-    pub(crate) osymt: Option<Rc<SymbolTable>>,
+    pub(crate) isymt: Option<Arc<SymbolTable>>,
+    pub(crate) osymt: Option<Arc<SymbolTable>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Default)]

--- a/rustfst/src/fst_impls/const_fst/fst.rs
+++ b/rustfst/src/fst_impls/const_fst/fst.rs
@@ -4,30 +4,30 @@ use crate::semirings::Semiring;
 
 use crate::SymbolTable;
 use anyhow::{format_err, Result};
-use std::rc::Rc;
+use std::sync::Arc;
 
 impl<W: Semiring + 'static> Fst for ConstFst<W> {
-    fn input_symbols(&self) -> Option<Rc<SymbolTable>> {
-        self.isymt.clone()
+    fn input_symbols(&self) -> Option<&Arc<SymbolTable>> {
+        self.isymt.as_ref()
     }
 
-    fn output_symbols(&self) -> Option<Rc<SymbolTable>> {
-        self.osymt.clone()
+    fn output_symbols(&self) -> Option<&Arc<SymbolTable>> {
+        self.osymt.as_ref()
     }
 
-    fn set_input_symbols(&mut self, symt: Rc<SymbolTable>) {
-        self.isymt = Some(Rc::clone(&symt))
+    fn set_input_symbols(&mut self, symt: Arc<SymbolTable>) {
+        self.isymt = Some(symt)
     }
 
-    fn set_output_symbols(&mut self, symt: Rc<SymbolTable>) {
-        self.osymt = Some(Rc::clone(&symt));
+    fn set_output_symbols(&mut self, symt: Arc<SymbolTable>) {
+        self.osymt = Some(symt);
     }
 
-    fn unset_input_symbols(&mut self) -> Option<Rc<SymbolTable>> {
+    fn take_input_symbols(&mut self) -> Option<Arc<SymbolTable>> {
         self.isymt.take()
     }
 
-    fn unset_output_symbols(&mut self) -> Option<Rc<SymbolTable>> {
+    fn take_output_symbols(&mut self) -> Option<Arc<SymbolTable>> {
         self.osymt.take()
     }
 }

--- a/rustfst/src/fst_impls/const_fst/serializable_fst.rs
+++ b/rustfst/src/fst_impls/const_fst/serializable_fst.rs
@@ -62,8 +62,8 @@ impl<W: 'static + SerializableSemiring> SerializableFst for ConstFst<W> {
             start: self.start.map(|v| v as i64).unwrap_or(-1),
             num_states: self.num_states() as i64,
             num_trs: self.trs.len() as i64,
-            isymt: self.input_symbols(),
-            osymt: self.output_symbols(),
+            isymt: self.input_symbols().cloned(),
+            osymt: self.output_symbols().cloned(),
         };
         hdr.write(&mut file)?;
 

--- a/rustfst/src/fst_impls/mod.rs
+++ b/rustfst/src/fst_impls/mod.rs
@@ -1,5 +1,5 @@
 pub(crate) mod const_fst;
-mod rc;
+mod arc;
 pub(crate) mod vector_fst;
 
 pub use self::const_fst::ConstFst;

--- a/rustfst/src/fst_impls/rc.rs
+++ b/rustfst/src/fst_impls/rc.rs
@@ -1,5 +1,6 @@
 use std::ops::Deref;
 use std::rc::Rc;
+use std::sync::Arc;
 
 use anyhow::Result;
 
@@ -12,27 +13,27 @@ impl<F: Fst> Fst for Rc<F>
 where
     F::W: 'static,
 {
-    fn input_symbols(&self) -> Option<Rc<SymbolTable>> {
+    fn input_symbols(&self) -> Option<&Arc<SymbolTable>> {
         self.deref().input_symbols()
     }
 
-    fn output_symbols(&self) -> Option<Rc<SymbolTable>> {
+    fn output_symbols(&self) -> Option<&Arc<SymbolTable>> {
         self.deref().output_symbols()
     }
 
-    fn set_input_symbols(&mut self, _symt: Rc<SymbolTable>) {
+    fn set_input_symbols(&mut self, _symt: Arc<SymbolTable>) {
         unimplemented!()
     }
 
-    fn set_output_symbols(&mut self, _symt: Rc<SymbolTable>) {
+    fn set_output_symbols(&mut self, _symt: Arc<SymbolTable>) {
         unimplemented!()
     }
 
-    fn unset_input_symbols(&mut self) -> Option<Rc<SymbolTable>> {
+    fn take_input_symbols(&mut self) -> Option<Arc<SymbolTable>> {
         unimplemented!()
     }
 
-    fn unset_output_symbols(&mut self) -> Option<Rc<SymbolTable>> {
+    fn take_output_symbols(&mut self) -> Option<Arc<SymbolTable>> {
         unimplemented!()
     }
 }

--- a/rustfst/src/fst_impls/vector_fst/data_structure.rs
+++ b/rustfst/src/fst_impls/vector_fst/data_structure.rs
@@ -4,7 +4,7 @@ use crate::semirings::Semiring;
 use crate::symbol_table::SymbolTable;
 use crate::tr::Tr;
 use crate::StateId;
-use std::rc::Rc;
+use std::sync::Arc;
 
 /// Simple concrete, mutable FST whose states and trs are stored in standard vectors.
 ///
@@ -14,8 +14,8 @@ use std::rc::Rc;
 pub struct VectorFst<W> {
     pub(crate) states: Vec<VectorFstState<W>>,
     pub(crate) start_state: Option<StateId>,
-    pub(crate) isymt: Option<Rc<SymbolTable>>,
-    pub(crate) osymt: Option<Rc<SymbolTable>>,
+    pub(crate) isymt: Option<Arc<SymbolTable>>,
+    pub(crate) osymt: Option<Arc<SymbolTable>>,
 }
 
 // In my opinion, it is not a good idea to store values like num_trs, num_input_epsilons

--- a/rustfst/src/fst_impls/vector_fst/fst.rs
+++ b/rustfst/src/fst_impls/vector_fst/fst.rs
@@ -9,7 +9,7 @@ use crate::{StateId, SymbolTable};
 
 impl<W: 'static + Semiring> Fst for VectorFst<W> {
     fn input_symbols(&self) -> Option<&Arc<SymbolTable>> {
-        // Rc is incremented, SymbolTable is not duplicated
+        // Arc is incremented, SymbolTable is not duplicated
         self.isymt.as_ref()
     }
 

--- a/rustfst/src/fst_impls/vector_fst/fst.rs
+++ b/rustfst/src/fst_impls/vector_fst/fst.rs
@@ -1,4 +1,4 @@
-use std::rc::Rc;
+use std::sync::Arc;
 
 use anyhow::Result;
 
@@ -8,28 +8,28 @@ use crate::semirings::Semiring;
 use crate::{StateId, SymbolTable};
 
 impl<W: 'static + Semiring> Fst for VectorFst<W> {
-    fn input_symbols(&self) -> Option<Rc<SymbolTable>> {
+    fn input_symbols(&self) -> Option<&Arc<SymbolTable>> {
         // Rc is incremented, SymbolTable is not duplicated
-        self.isymt.clone()
+        self.isymt.as_ref()
     }
 
-    fn output_symbols(&self) -> Option<Rc<SymbolTable>> {
-        self.osymt.clone()
+    fn output_symbols(&self) -> Option<&Arc<SymbolTable>> {
+        self.osymt.as_ref()
     }
 
-    fn set_input_symbols(&mut self, symt: Rc<SymbolTable>) {
-        self.isymt = Some(Rc::clone(&symt))
+    fn set_input_symbols(&mut self, symt: Arc<SymbolTable>) {
+        self.isymt = Some(symt)
     }
 
-    fn set_output_symbols(&mut self, symt: Rc<SymbolTable>) {
-        self.osymt = Some(Rc::clone(&symt));
+    fn set_output_symbols(&mut self, symt: Arc<SymbolTable>) {
+        self.osymt = Some(symt)
     }
 
-    fn unset_input_symbols(&mut self) -> Option<Rc<SymbolTable>> {
+    fn take_input_symbols(&mut self) -> Option<Arc<SymbolTable>> {
         self.isymt.take()
     }
 
-    fn unset_output_symbols(&mut self) -> Option<Rc<SymbolTable>> {
+    fn take_output_symbols(&mut self) -> Option<Arc<SymbolTable>> {
         self.osymt.take()
     }
 }

--- a/rustfst/src/fst_impls/vector_fst/serializable_fst.rs
+++ b/rustfst/src/fst_impls/vector_fst/serializable_fst.rs
@@ -64,8 +64,8 @@ impl<W: 'static + SerializableSemiring> SerializableFst for VectorFst<W> {
             start: self.start_state.map(|v| v as i64).unwrap_or(-1),
             num_states: self.num_states() as i64,
             num_trs: num_trs as i64,
-            isymt: self.input_symbols(),
-            osymt: self.output_symbols(),
+            isymt: self.input_symbols().cloned(),
+            osymt: self.output_symbols().cloned(),
         };
         hdr.write(&mut file)?;
 

--- a/rustfst/src/fst_impls/vector_fst/test.rs
+++ b/rustfst/src/fst_impls/vector_fst/test.rs
@@ -12,7 +12,7 @@ mod tests {
     use crate::semirings::{ProbabilityWeight, Semiring, TropicalWeight};
     use crate::tr::Tr;
     use crate::SymbolTable;
-    use std::rc::Rc;
+    use std::sync::Arc;
 
     #[test]
     fn test_small_fst() -> Result<()> {
@@ -319,7 +319,7 @@ mod tests {
             symt.add_symbol("b"); // 2
             symt.add_symbol("c"); // 3
 
-            fst.set_input_symbols(Rc::new(symt));
+            fst.set_input_symbols(Arc::new(symt));
         }
         {
             let symt = fst.input_symbols();
@@ -331,7 +331,7 @@ mod tests {
         // Test output symbol table
         {
             let symt = SymbolTable::new();
-            fst.set_output_symbols(Rc::new(symt));
+            fst.set_output_symbols(Arc::new(symt));
         }
         {
             let symt = fst.output_symbols();

--- a/rustfst/src/fst_traits/fst.rs
+++ b/rustfst/src/fst_traits/fst.rs
@@ -1,5 +1,5 @@
 use std::fmt::Debug;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use anyhow::Result;
 
@@ -186,36 +186,36 @@ pub trait Fst:
 
     /// Retrieves the input `SymbolTable` associated to the Fst.
     /// If no SymbolTable has been previously attached then `None` is returned.
-    fn input_symbols(&self) -> Option<Rc<SymbolTable>>;
+    fn input_symbols(&self) -> Option<&Arc<SymbolTable>>;
 
     /// Retrieves the output `SymbolTable` associated to the Fst.
     /// If no SymbolTable has been previously attached then `None` is returned.
-    fn output_symbols(&self) -> Option<Rc<SymbolTable>>;
+    fn output_symbols(&self) -> Option<&Arc<SymbolTable>>;
 
     /// Attaches an output `SymbolTable` to the Fst.
     /// The `SymbolTable` is not duplicated with the use of Rc.
-    fn set_input_symbols(&mut self, symt: Rc<SymbolTable>);
+    fn set_input_symbols(&mut self, symt: Arc<SymbolTable>);
 
     /// Attaches an output `SymbolTable` to the Fst.
     /// The `SymbolTable` is not duplicated with the use of Rc.
-    fn set_output_symbols(&mut self, symt: Rc<SymbolTable>);
+    fn set_output_symbols(&mut self, symt: Arc<SymbolTable>);
 
     /// Removes the input symbol table from the Fst and retrieves it.
-    fn unset_input_symbols(&mut self) -> Option<Rc<SymbolTable>>;
+    fn take_input_symbols(&mut self) -> Option<Arc<SymbolTable>>;
     /// Removes the output symbol table from the Fst and retrieves it.
-    fn unset_output_symbols(&mut self) -> Option<Rc<SymbolTable>>;
+    fn take_output_symbols(&mut self) -> Option<Arc<SymbolTable>>;
 
     fn set_symts_from_fst<OF: Fst>(&mut self, other_fst: &OF) {
         if let Some(symt) = other_fst.input_symbols() {
-            self.set_input_symbols(symt);
+            self.set_input_symbols(Arc::clone(symt));
         } else {
-            self.unset_input_symbols();
+            self.take_input_symbols();
         }
 
         if let Some(symt) = other_fst.output_symbols() {
-            self.set_output_symbols(symt);
+            self.set_output_symbols(Arc::clone(symt));
         } else {
-            self.unset_output_symbols();
+            self.take_output_symbols();
         }
     }
 }

--- a/rustfst/src/fst_traits/fst.rs
+++ b/rustfst/src/fst_traits/fst.rs
@@ -193,11 +193,11 @@ pub trait Fst:
     fn output_symbols(&self) -> Option<&Arc<SymbolTable>>;
 
     /// Attaches an output `SymbolTable` to the Fst.
-    /// The `SymbolTable` is not duplicated with the use of Rc.
+    /// The `SymbolTable` is not duplicated with the use of Arc.
     fn set_input_symbols(&mut self, symt: Arc<SymbolTable>);
 
     /// Attaches an output `SymbolTable` to the Fst.
-    /// The `SymbolTable` is not duplicated with the use of Rc.
+    /// The `SymbolTable` is not duplicated with the use of Arc.
     fn set_output_symbols(&mut self, symt: Arc<SymbolTable>);
 
     /// Removes the input symbol table from the Fst and retrieves it.

--- a/rustfst/src/parsers/bin_fst/fst_header.rs
+++ b/rustfst/src/parsers/bin_fst/fst_header.rs
@@ -13,7 +13,7 @@ use crate::parsers::bin_fst::utils_serialization::{
 };
 use crate::parsers::bin_symt::nom_parser::{parse_symbol_table_bin, write_bin_symt};
 use crate::SymbolTable;
-use std::rc::Rc;
+use std::sync::Arc;
 
 // Identifies stream data as an FST (and its endianity).
 pub(crate) static FST_MAGIC_NUMBER: i32 = 2_125_659_606;
@@ -37,8 +37,8 @@ pub(crate) struct FstHeader {
     pub(crate) start: i64,
     pub(crate) num_states: i64,
     pub(crate) num_trs: i64,
-    pub(crate) isymt: Option<Rc<SymbolTable>>,
-    pub(crate) osymt: Option<Rc<SymbolTable>>,
+    pub(crate) isymt: Option<Arc<SymbolTable>>,
+    pub(crate) osymt: Option<Arc<SymbolTable>>,
 }
 
 #[derive(Debug)]
@@ -56,7 +56,7 @@ fn optionally_parse_symt(i: &[u8], parse_symt: bool) -> IResult<&[u8], Option<Sy
     }
 }
 
-fn optionally_write_symt<W: Write>(file: &mut W, symt: &Option<Rc<SymbolTable>>) -> Result<()> {
+fn optionally_write_symt<W: Write>(file: &mut W, symt: &Option<Arc<SymbolTable>>) -> Result<()> {
     if let Some(symt) = symt {
         write_bin_symt(file, symt)
     } else {
@@ -102,8 +102,8 @@ impl FstHeader {
                 start,
                 num_states,
                 num_trs,
-                isymt: isymt.map(Rc::new),
-                osymt: osymt.map(Rc::new),
+                isymt: isymt.map(Arc::new),
+                osymt: osymt.map(Arc::new),
             },
         ))
     }

--- a/rustfst/src/tests_openfst/algorithms/compose.rs
+++ b/rustfst/src/tests_openfst/algorithms/compose.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use anyhow::Result;
 use pretty_assertions::assert_eq;
@@ -71,8 +71,8 @@ where
     config.compose_filter = filter;
 
     let fst_res_static: VectorFst<_> = compose_with_config(
-        Rc::new(fst_raw.clone()),
-        Rc::new(compose_test_data.fst_2.clone()),
+        Arc::new(fst_raw.clone()),
+        Arc::new(compose_test_data.fst_2.clone()),
         config,
     )?;
 
@@ -153,32 +153,32 @@ where
     let fst1: VectorFst<_> = fst_raw.clone().into();
     let mut fst2: VectorFst<_> = compose_test_data.fst_2.clone();
 
-    let graph1look = Rc::new(TLaFst::new(fst1)?);
+    let graph1look = Arc::new(TLaFst::new(fst1)?);
 
     LabelLookAheadRelabeler::relabel(&mut fst2, graph1look.addon(), true)?;
 
     tr_sort(&mut fst2, ilabel_compare);
-    let fst2 = Rc::new(fst2);
+    let fst2 = Arc::new(fst2);
 
     let matcher1 = TMatcher1::new_with_data(
-        Rc::clone(&graph1look),
+        Arc::clone(&graph1look),
         MatchType::MatchOutput,
         graph1look.data(MatchType::MatchOutput).cloned(),
     )?;
-    let matcher2 = TMatcher2::new(Rc::clone(&fst2), MatchType::MatchInput)?;
+    let matcher2 = TMatcher2::new(Arc::clone(&fst2), MatchType::MatchInput)?;
 
     let compose_filter = TPushLabelsFilter::new_2(
-        Rc::clone(&graph1look),
-        Rc::clone(&fst2),
-        Rc::new(RefCell::new(matcher1)),
-        Rc::new(RefCell::new(matcher2)),
+        Arc::clone(&graph1look),
+        Arc::clone(&fst2),
+        Arc::new(RefCell::new(matcher1)),
+        Arc::new(RefCell::new(matcher2)),
     )?;
 
     // let compose_filter = TComposeFilter::new(
     //     &graph1look,
     //     &fst2,
-    //     Rc::new(RefCell::new(matcher1)),
-    //     Rc::new(RefCell::new(matcher2)),
+    //     Arc::new(RefCell::new(matcher1)),
+    //     Arc::new(RefCell::new(matcher2)),
     // )?;
 
     let compose_options = ComposeFstImplOptions::<_, _, TComposeFilter<_, _, _>, _>::new(

--- a/rustfst/src/tests_openfst/fst_impls/const_fst.rs
+++ b/rustfst/src/tests_openfst/fst_impls/const_fst.rs
@@ -1,4 +1,4 @@
-use std::rc::Rc;
+use std::sync::Arc;
 
 use anyhow::Result;
 
@@ -22,8 +22,8 @@ where
         osymt.add_symbol("b");
         osymt.add_symbol("c");
 
-        raw_fst.set_input_symbols(Rc::new(isymt));
-        raw_fst.set_output_symbols(Rc::new(osymt));
+        raw_fst.set_input_symbols(Arc::new(isymt));
+        raw_fst.set_output_symbols(Arc::new(osymt));
     }
 
     let const_fst: ConstFst<_> = raw_fst.clone().into();

--- a/rustfst/src/tests_openfst/io/const_fst_text_serialization.rs
+++ b/rustfst/src/tests_openfst/io/const_fst_text_serialization.rs
@@ -65,8 +65,8 @@ where
 
     // Text serialization doesn't include the symbol table.
     let mut raw_const_without_symt = raw_const_with_symt;
-    raw_const_without_symt.unset_input_symbols();
-    raw_const_without_symt.unset_output_symbols();
+    raw_const_without_symt.take_input_symbols();
+    raw_const_without_symt.take_output_symbols();
 
     assert_eq!(
         raw_const_without_symt,

--- a/rustfst/src/tests_openfst/io/mod.rs
+++ b/rustfst/src/tests_openfst/io/mod.rs
@@ -7,9 +7,9 @@ pub mod vector_fst_text_serialization;
 
 use crate::fst_traits::Fst;
 use crate::symbol_table::SymbolTable;
-use std::rc::Rc;
+use std::sync::Arc;
 
-fn generate_symbol_table<F: Fst>(prefix: &str, fst: &F) -> (Rc<SymbolTable>, Rc<SymbolTable>) {
+fn generate_symbol_table<F: Fst>(prefix: &str, fst: &F) -> (Arc<SymbolTable>, Arc<SymbolTable>) {
     let mut input_symt = SymbolTable::new();
     let mut output_symt = SymbolTable::new();
     let mut highest_ilabel = 0;
@@ -28,5 +28,5 @@ fn generate_symbol_table<F: Fst>(prefix: &str, fst: &F) -> (Rc<SymbolTable>, Rc<
     let output_symbols =
         (0..(highest_olabel + 1)).map(|it| format!("{}_input_symbol_{}", prefix, it));
     output_symt.add_symbols(output_symbols);
-    (Rc::new(input_symt), Rc::new(output_symt))
+    (Arc::new(input_symt), Arc::new(output_symt))
 }

--- a/rustfst/src/tests_openfst/io/vector_fst_bin_deserializer.rs
+++ b/rustfst/src/tests_openfst/io/vector_fst_bin_deserializer.rs
@@ -28,8 +28,8 @@ where
 {
     let mut parsed_fst_bin = VectorFst::<W>::read(&test_data.raw_vector_with_symt_bin_path)?;
 
-    parsed_fst_bin.unset_input_symbols();
-    parsed_fst_bin.unset_output_symbols();
+    parsed_fst_bin.take_input_symbols();
+    parsed_fst_bin.take_output_symbols();
 
     assert_eq!(
         test_data.raw,

--- a/rustfst/src/tests_openfst/io/vector_fst_text_serialization.rs
+++ b/rustfst/src/tests_openfst/io/vector_fst_text_serialization.rs
@@ -47,8 +47,8 @@ where
 
     // Text serialization doesn't include the symbol table.
     let mut raw_without_symt = raw_with_symt;
-    raw_without_symt.unset_input_symbols();
-    raw_without_symt.unset_output_symbols();
+    raw_without_symt.take_input_symbols();
+    raw_without_symt.take_output_symbols();
 
     assert_eq!(
         raw_without_symt,


### PR DESCRIPTION
- SymbolTable are now wrapped in std::sync::Arc (instead of Rc)
- renamed unset_input_symbols and unset_output_symbols to take_*_symbols
- static FST struct are now Send and Sync