### PR TITLE
Speed up shortest path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - renamed unset_input_symbols and unset_output_symbols to take_*_symbols
 - static FST struct are now Send and Sync
 - `final_weight` method of the `CoreFst` trait now returns a copy instead of a reference.
+- Fix an issue in `SccQueue` which made the `is_empty()` call super slow. As a result, an important speed-up can be observed when running the `shortest_path` algorithm.
 
 ### Fixed
 - Fix olabel display while drawing a FST if no symbol table is provided

--- a/rustfst/src/algorithms/queues/scc_queue.rs
+++ b/rustfst/src/algorithms/queues/scc_queue.rs
@@ -51,14 +51,13 @@ impl Queue for SccQueue {
     }
 
     fn is_empty(&self) -> bool {
-        self.queues.iter().all(|v| v.is_empty())
-        //        if self.front < self.back {
-        //            false
-        //        } else if self.front > self.back {
-        //            true
-        //        } else {
-        //            self.queues[self.front as usize].is_empty()
-        //        }
+       if self.front < self.back {
+           false
+       } else if self.front > self.back {
+           true
+       } else {
+           self.queues[self.front as usize].is_empty()
+       }
     }
 
     fn clear(&mut self) {

--- a/rustfst/src/algorithms/shortest_path.rs
+++ b/rustfst/src/algorithms/shortest_path.rs
@@ -141,7 +141,7 @@ where
         enqueued[s] = false;
         let sd = distance[s].clone();
 
-        if let Some(final_weight) = ifst.final_weight(s)? {
+        if let Some(final_weight) = unsafe {ifst.final_weight_unchecked(s)} {
             let plus = f_distance.plus(&sd.times(final_weight)?)?;
             if f_distance != plus {
                 f_distance = plus;
@@ -192,7 +192,7 @@ where
             }
         } else {
             let pos = parent[d.unwrap()].unwrap().1;
-            let mut tr = ifst.get_trs(state)?.trs().iter().nth(pos).unwrap().clone();
+            let mut tr = ifst.get_trs(state)?.trs()[pos].clone();
             tr.nextstate = d_p.unwrap();
             ofst.add_tr(s_p.unwrap(), tr)?;
         }

--- a/rustfst/src/algorithms/shortest_path.rs
+++ b/rustfst/src/algorithms/shortest_path.rs
@@ -124,15 +124,15 @@ where
             "SingleShortestPath: Weight needs to have the path property and be right distributive"
         )
     }
-    while distance.len() < source {
-        distance.push(W::zero());
-        enqueued.push(false);
-        parent.push(None)
-    }
-    distance.push(W::one());
-    parent.push(None);
+    distance.resize_with(ifst.num_states(), W::zero);
+    enqueued.resize(ifst.num_states(), false);
+    parent.resize(ifst.num_states(), None);
+
+    distance[source] = W::one();
+    parent[source] = None;
+    enqueued[source] = true;
+
     queue.enqueue(source);
-    enqueued.push(true);
 
     while !queue.is_empty() {
         // Safe because non empty
@@ -150,11 +150,6 @@ where
         }
 
         for (pos, tr) in unsafe { ifst.get_trs_unchecked(s).trs().iter().enumerate() } {
-            while distance.len() <= tr.nextstate {
-                distance.push(W::zero());
-                enqueued.push(false);
-                parent.push(None)
-            }
             let nd = &mut distance[tr.nextstate];
             let weight = sd.times(&tr.weight)?;
             if *nd != nd.plus(&weight)? {

--- a/rustfst/src/tests_openfst/algorithms/mod.rs
+++ b/rustfst/src/tests_openfst/algorithms/mod.rs
@@ -18,6 +18,7 @@ pub mod minimize;
 pub mod project;
 pub mod properties;
 pub mod push;
+pub mod queue;
 pub mod replace;
 pub mod reverse;
 pub mod rm_epsilon;

--- a/rustfst/src/tests_openfst/algorithms/queue.rs
+++ b/rustfst/src/tests_openfst/algorithms/queue.rs
@@ -1,0 +1,45 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+use crate::StateId;
+use crate::algorithms::Queue;
+use crate::algorithms::queues::AutoQueue;
+use crate::algorithms::tr_filters::AnyTrFilter;
+use crate::fst_impls::VectorFst;
+use crate::semirings::{SerializableSemiring, WeaklyDivisibleSemiring, WeightQuantize};
+use crate::tests_openfst::FstTestData;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct QueueOperation {
+    op_type: String,
+    state: StateId
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct QueueOperationResult {
+    result: Vec<QueueOperation>,
+}
+
+pub fn test_queue<W>(test_data: &FstTestData<W, VectorFst<W>>) -> Result<()>
+    where
+        W: SerializableSemiring + WeightQuantize + WeaklyDivisibleSemiring,
+{
+    let mut queue = AutoQueue::new(&test_data.raw, None, &AnyTrFilter {})?;
+
+    for op in &test_data.queue.result {
+        match op.op_type.as_str() {
+            "enqueue" => {
+                queue.enqueue(op.state);
+            },
+            "dequeue" => {
+                assert!(!queue.is_empty());
+                assert_eq!(op.state, queue.head().unwrap());
+                queue.dequeue();
+            },
+            _ => panic!("Unknown op_type : {:?}", op.op_type.as_str())
+        };
+    }
+
+    assert!(queue.is_empty());
+    Ok(())
+}

--- a/rustfst/src/tests_openfst/mod.rs
+++ b/rustfst/src/tests_openfst/mod.rs
@@ -94,6 +94,7 @@ use self::fst_impls::test_fst_into_iterator::{
     test_fst_into_iterator_const, test_fst_into_iterator_vector,
 };
 use self::misc::test_del_all_states;
+use crate::tests_openfst::algorithms::queue::{QueueOperationResult, test_queue};
 
 #[macro_use]
 mod macros;
@@ -170,6 +171,7 @@ pub struct ParsedFstTestData {
     // matcher: Vec<MatcherOperationResult>,
     compose: Vec<ComposeOperationResult>,
     state_reachable: StateReachableOperationResult,
+    queue: QueueOperationResult,
 }
 
 pub struct FstTestData<W, F: SerializableFst<W>>
@@ -224,6 +226,7 @@ where
     // pub matcher: Vec<MatcherTestData<F>>,
     pub compose: Vec<ComposeTestData<W, F>>,
     pub state_reachable: StateReachableTestData,
+    pub queue: QueueOperationResult
 }
 
 impl<W, F> FstTestData<W, F>
@@ -300,6 +303,7 @@ where
             // matcher: data.matcher.iter().map(|v| v.parse()).collect(),
             compose: data.compose.iter().map(|v| v.parse()).collect(),
             state_reachable: data.state_reachable.parse(),
+            queue: data.queue.clone()
         }
     }
 }
@@ -738,6 +742,12 @@ macro_rules! test_fst {
             #[test]
             fn test_fst_state_reachable_openfst() -> Result<()> {
                 do_run!(test_state_reachable, $fst_name);
+                Ok(())
+            }
+
+            #[test]
+            fn test_queue_openfst() -> Result<()> {
+                do_run!(test_queue, $fst_name);
                 Ok(())
             }
         }


### PR DESCRIPTION
- Fix an issue in `SccQueue` which made the `is_empty()` call super slow. As a result, an important speed-up can be observed when running the `shortest_path` algorithm.
