### PR TITLE
Read VectorFst from ConstFst file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Re-organized most of the algorithms into their own modules.
 - All the lazy fsts except `rm_epsilon` are now Send and Sync.
 - Remove the `TrIterator` in favor of the `get_trs` method in the CoreFst trait.
+- Add method `read_from_const` to `VectorFst` allowing to load a `VectorFst` from a `ConstFst` file.
 
 ### Changed
 - `fst_convert` now consumes its input. Use `fst_convert_from_ref` to pass a borrow.

--- a/rustfst/src/fst_impls/const_fst/mod.rs
+++ b/rustfst/src/fst_impls/const_fst/mod.rs
@@ -7,3 +7,8 @@ mod fst;
 mod iterators;
 mod misc;
 mod serializable_fst;
+
+pub(super) static CONST_MIN_FILE_VERSION: i32 = 1;
+pub(super) static CONST_ALIGNED_FILE_VERSION: i32 = 1;
+pub(super) static CONST_FILE_VERSION: i32 = 2;
+pub(super) static CONST_ARCH_ALIGNMENT: usize = 16;

--- a/rustfst/src/fst_impls/const_fst/serializable_fst.rs
+++ b/rustfst/src/fst_impls/const_fst/serializable_fst.rs
@@ -11,6 +11,9 @@ use nom::number::complete::le_i32;
 use nom::IResult;
 
 use crate::fst_impls::const_fst::data_structure::ConstState;
+use crate::fst_impls::const_fst::{
+    CONST_ALIGNED_FILE_VERSION, CONST_ARCH_ALIGNMENT, CONST_FILE_VERSION, CONST_MIN_FILE_VERSION,
+};
 use crate::fst_impls::ConstFst;
 use crate::fst_traits::{ExpandedFst, Fst, SerializableFst};
 use crate::parsers::bin_fst::fst_header::{FstFlags, FstHeader, OpenFstString, FST_MAGIC_NUMBER};
@@ -21,7 +24,7 @@ use crate::semirings::SerializableSemiring;
 use crate::{Tr, EPS_LABEL};
 use std::sync::Arc;
 
-impl<W: 'static + SerializableSemiring> SerializableFst<W> for ConstFst<W> {
+impl<W: SerializableSemiring> SerializableFst<W> for ConstFst<W> {
     fn fst_type() -> String {
         "const".to_string()
     }
@@ -167,11 +170,6 @@ impl<W: 'static + SerializableSemiring> SerializableFst<W> for ConstFst<W> {
     }
 }
 
-static CONST_MIN_FILE_VERSION: i32 = 1;
-static CONST_ALIGNED_FILE_VERSION: i32 = 1;
-static CONST_FILE_VERSION: i32 = 2;
-static CONST_ARCH_ALIGNMENT: usize = 16;
-
 fn parse_const_state<W: SerializableSemiring>(i: &[u8]) -> IResult<&[u8], ConstState<W>> {
     let (i, final_weight) = W::parse_binary(i)?;
     let (i, pos) = le_i32(i)?;
@@ -191,7 +189,7 @@ fn parse_const_state<W: SerializableSemiring>(i: &[u8]) -> IResult<&[u8], ConstS
     ))
 }
 
-fn parse_const_fst<W: SerializableSemiring + 'static>(i: &[u8]) -> IResult<&[u8], ConstFst<W>> {
+fn parse_const_fst<W: SerializableSemiring>(i: &[u8]) -> IResult<&[u8], ConstFst<W>> {
     let stream_len = i.len();
 
     let (mut i, hdr) = FstHeader::parse(

--- a/rustfst/src/fst_impls/vector_fst/mod.rs
+++ b/rustfst/src/fst_impls/vector_fst/mod.rs
@@ -8,5 +8,6 @@ mod fst;
 mod iterators;
 mod misc;
 mod mutable_fst;
+mod parse_const;
 mod serializable_fst;
 mod test;

--- a/rustfst/src/fst_impls/vector_fst/parse_const.rs
+++ b/rustfst/src/fst_impls/vector_fst/parse_const.rs
@@ -1,0 +1,104 @@
+use std::fs::read;
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use nom::bytes::complete::take;
+use nom::multi::count;
+use nom::number::complete::le_i32;
+use nom::IResult;
+
+use crate::fst_impls::const_fst::{
+    CONST_ALIGNED_FILE_VERSION, CONST_ARCH_ALIGNMENT, CONST_MIN_FILE_VERSION,
+};
+use crate::fst_impls::vector_fst::VectorFstState;
+use crate::fst_impls::{ConstFst, VectorFst};
+use crate::fst_traits::SerializableFst;
+use crate::parsers::bin_fst::fst_header::FstHeader;
+use crate::parsers::bin_fst::utils_parsing::{parse_final_weight, parse_fst_tr, parse_start_state};
+use crate::semirings::SerializableSemiring;
+use crate::{Tr, TrsVec};
+
+impl<W: SerializableSemiring> VectorFst<W> {
+    /// Load a VectorFst directly from a ConstFst file.
+    pub fn read_from_const<P: AsRef<Path>>(path_bin_fst: P) -> Result<Self> {
+        let data = read(path_bin_fst.as_ref()).with_context(|| {
+            format!(
+                "Can't open ConstFst binary file : {:?}",
+                path_bin_fst.as_ref()
+            )
+        })?;
+
+        let (_, parsed_fst) = parse_const_fst(&data)
+            .map_err(|_| format_err!("Error while parsing binary ConstFst file as a VectorFst"))?;
+
+        Ok(parsed_fst)
+    }
+}
+
+struct TempState<W> {
+    final_weight: Option<W>,
+    ntrs: usize,
+}
+
+fn parse_const_state<W: SerializableSemiring>(i: &[u8]) -> IResult<&[u8], TempState<W>> {
+    let (i, final_weight) = W::parse_binary(i)?;
+    let (i, _pos) = le_i32(i)?;
+    let (i, ntrs) = le_i32(i)?;
+    let (i, _niepsilons) = le_i32(i)?;
+    let (i, _noepsilons) = le_i32(i)?;
+
+    Ok((
+        i,
+        TempState {
+            final_weight: parse_final_weight(final_weight),
+            ntrs: ntrs as usize,
+        },
+    ))
+}
+
+fn parse_const_fst<W: SerializableSemiring>(i: &[u8]) -> IResult<&[u8], VectorFst<W>> {
+    let stream_len = i.len();
+
+    let (mut i, hdr) = FstHeader::parse(
+        i,
+        CONST_MIN_FILE_VERSION,
+        // Intentional as the ConstFst file is being parsed.
+        ConstFst::<W>::fst_type(),
+        Tr::<W>::tr_type(),
+    )?;
+    let aligned = hdr.version == CONST_ALIGNED_FILE_VERSION;
+    let pos = stream_len - i.len();
+
+    // Align input
+    if aligned && hdr.num_states > 0 && pos % CONST_ARCH_ALIGNMENT > 0 {
+        i = take(CONST_ARCH_ALIGNMENT - (pos % CONST_ARCH_ALIGNMENT))(i)?.0;
+    }
+    let (mut i, temp_states) = count(parse_const_state::<W>, hdr.num_states as usize)(i)?;
+    let pos = stream_len - i.len();
+
+    // Align input
+    if aligned && hdr.num_trs > 0 && pos % CONST_ARCH_ALIGNMENT > 0 {
+        i = take(CONST_ARCH_ALIGNMENT - (pos % CONST_ARCH_ALIGNMENT))(i)?.0;
+    }
+
+    let mut vector_states = Vec::with_capacity(temp_states.len());
+    for temp_state in temp_states {
+        let (j, trs) = count(parse_fst_tr, temp_state.ntrs)(i)?;
+        i = j;
+        vector_states.push(VectorFstState {
+            final_weight: temp_state.final_weight,
+            trs: TrsVec(Arc::new(trs)),
+        });
+    }
+
+    Ok((
+        i,
+        VectorFst {
+            start_state: parse_start_state(hdr.start),
+            states: vector_states,
+            isymt: hdr.isymt,
+            osymt: hdr.osymt,
+        },
+    ))
+}

--- a/rustfst/src/fst_impls/vector_fst/serializable_fst.rs
+++ b/rustfst/src/fst_impls/vector_fst/serializable_fst.rs
@@ -19,7 +19,7 @@ use crate::semirings::SerializableSemiring;
 use crate::{Tr, Trs, TrsVec};
 use std::sync::Arc;
 
-impl<W: 'static + SerializableSemiring> SerializableFst<W> for VectorFst<W> {
+impl<W: SerializableSemiring> SerializableFst<W> for VectorFst<W> {
     fn fst_type() -> String {
         "vector".to_string()
     }
@@ -143,7 +143,7 @@ fn parse_vector_fst_state<W: SerializableSemiring>(i: &[u8]) -> IResult<&[u8], V
     ))
 }
 
-fn parse_vector_fst<W: SerializableSemiring + 'static>(i: &[u8]) -> IResult<&[u8], VectorFst<W>> {
+fn parse_vector_fst<W: SerializableSemiring>(i: &[u8]) -> IResult<&[u8], VectorFst<W>> {
     let (i, header) = FstHeader::parse(
         i,
         VECTOR_MIN_FILE_VERSION,

--- a/rustfst/src/tests_openfst/io/const_fst_bin_deserializer.rs
+++ b/rustfst/src/tests_openfst/io/const_fst_bin_deserializer.rs
@@ -37,3 +37,39 @@ where
 
     Ok(())
 }
+
+// Test parsing a VectorFst from a ConstFst file.
+pub fn test_const_fst_bin_deserializer_as_vector<W>(
+    test_data: &FstTestData<W, VectorFst<W>>,
+) -> Result<()>
+where
+    W: SerializableSemiring + WeightQuantize,
+{
+    let parsed_fst_bin = VectorFst::<W>::read_from_const(&test_data.raw_const_bin_path)
+        .with_context(|| format_err!("Failed parsing ConstFst Aligned"))?;
+
+    test_eq_fst(
+        &test_data.raw,
+        &parsed_fst_bin,
+        "Deserializer ConstFst Bin as VectorFst",
+    );
+    Ok(())
+}
+
+pub fn test_const_fst_aligned_bin_deserializer_as_vector<W>(
+    test_data: &FstTestData<W, VectorFst<W>>,
+) -> Result<()>
+where
+    W: SerializableSemiring + WeightQuantize,
+{
+    let parsed_fst_bin = VectorFst::<W>::read_from_const(&test_data.raw_const_aligned_bin_path)
+        .with_context(|| format_err!("Failed parsing ConstFst Aligned Bin"))?;
+
+    test_eq_fst(
+        &test_data.raw,
+        &parsed_fst_bin,
+        "Deserializer ConstFst Aligned Bin as VectorFst",
+    );
+
+    Ok(())
+}

--- a/rustfst/src/tests_openfst/mod.rs
+++ b/rustfst/src/tests_openfst/mod.rs
@@ -46,7 +46,8 @@ use crate::tests_openfst::algorithms::state_reachable::{
 };
 use crate::tests_openfst::algorithms::union::{test_union, test_union_lazy};
 use crate::tests_openfst::io::const_fst_bin_deserializer::{
-    test_const_fst_aligned_bin_deserializer, test_const_fst_bin_deserializer,
+    test_const_fst_aligned_bin_deserializer, test_const_fst_aligned_bin_deserializer_as_vector,
+    test_const_fst_bin_deserializer, test_const_fst_bin_deserializer_as_vector,
 };
 use crate::tests_openfst::io::const_fst_bin_serializer::test_const_fst_bin_serializer;
 use crate::tests_openfst::io::const_fst_bin_serializer::test_const_fst_bin_serializer_with_symt;
@@ -748,6 +749,18 @@ macro_rules! test_fst {
             #[test]
             fn test_queue_openfst() -> Result<()> {
                 do_run!(test_queue, $fst_name);
+                Ok(())
+            }
+
+            #[test]
+            fn test_const_fst_bin_deserializer_as_vector_openfst() -> Result<()> {
+                do_run!(test_const_fst_bin_deserializer_as_vector, $fst_name);
+                Ok(())
+            }
+
+            #[test]
+            fn test_const_fst_aligned_bin_deserializer_as_vector_openfst() -> Result<()> {
+                do_run!(test_const_fst_aligned_bin_deserializer_as_vector, $fst_name);
                 Ok(())
             }
         }


### PR DESCRIPTION
- Add method `read_from_const` to `VectorFst` allowing to load a `VectorFst` from a `ConstFst` file.
