### PR TITLE
Speed up num_trs()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix an issue in `SccQueue` which made the `is_empty()` call super slow. As a result, an important speed-up can be observed when running the `shortest_path` algorithm.
 - `ComposeFst` now clonable.
 - Remove call to `collect_vec` when calling `LabelReachable.reach()`.
+- `num_trs` and `num_trs_unchecked` are now mandatory methods of the `Fst` trait. This allows removing useless calls to `Arc::clone`.
 
 ### Fixed
 - Fix olabel display while drawing a FST if no symbol table is provided

--- a/rustfst/src/algorithms/compose/compose_fst.rs
+++ b/rustfst/src/algorithms/compose/compose_fst.rs
@@ -93,6 +93,14 @@ where
         self.0.final_weight_unchecked(state_id)
     }
 
+    fn num_trs(&self, s: usize) -> Result<usize> {
+        self.0.num_trs(s)
+    }
+
+    unsafe fn num_trs_unchecked(&self, s: usize) -> usize {
+        self.0.num_trs_unchecked(s)
+    }
+
     fn get_trs(&self, state_id: usize) -> Result<Self::TRS> {
         self.0.get_trs(state_id)
     }

--- a/rustfst/src/algorithms/determinize/determinize_fsa.rs
+++ b/rustfst/src/algorithms/determinize/determinize_fsa.rs
@@ -34,6 +34,14 @@ where
         self.0.final_weight_unchecked(state_id)
     }
 
+    fn num_trs(&self, s: usize) -> Result<usize> {
+        self.0.num_trs(s)
+    }
+
+    unsafe fn num_trs_unchecked(&self, s: usize) -> usize {
+        self.0.num_trs_unchecked(s)
+    }
+
     fn get_trs(&self, state_id: usize) -> Result<Self::TRS> {
         self.0.get_trs(state_id)
     }

--- a/rustfst/src/algorithms/factor_weight/factor_weight_fst.rs
+++ b/rustfst/src/algorithms/factor_weight/factor_weight_fst.rs
@@ -41,6 +41,14 @@ where
         self.0.final_weight_unchecked(state_id)
     }
 
+    fn num_trs(&self, s: usize) -> Result<usize> {
+        self.0.num_trs(s)
+    }
+
+    unsafe fn num_trs_unchecked(&self, s: usize) -> usize {
+        self.0.num_trs_unchecked(s)
+    }
+
     fn get_trs(&self, state_id: usize) -> Result<Self::TRS> {
         self.0.get_trs(state_id)
     }

--- a/rustfst/src/algorithms/lazy_fst_revamp/fst_cache.rs
+++ b/rustfst/src/algorithms/lazy_fst_revamp/fst_cache.rs
@@ -14,4 +14,5 @@ pub trait FstCache<W: Semiring>: Debug {
     fn insert_final_weight(&self, id: StateId, weight: Option<W>);
 
     fn num_known_states(&self) -> usize;
+    fn num_trs(&self, id: StateId) -> Option<usize>;
 }

--- a/rustfst/src/algorithms/lazy_fst_revamp/lazy_fst.rs
+++ b/rustfst/src/algorithms/lazy_fst_revamp/lazy_fst.rs
@@ -51,6 +51,16 @@ impl<W: Semiring, Op: FstOp<W>, Cache: FstCache<W>> CoreFst<W> for LazyFst<W, Op
         self.final_weight(state_id).unsafe_unwrap()
     }
 
+    fn num_trs(&self, s: usize) -> Result<usize> {
+        self.cache
+            .num_trs(s)
+            .ok_or_else(|| format_err!("State {:?} doesn't exist", s))
+    }
+
+    unsafe fn num_trs_unchecked(&self, s: usize) -> usize {
+        self.cache.num_trs(s).unsafe_unwrap()
+    }
+
     fn get_trs(&self, state_id: usize) -> Result<Self::TRS> {
         if let Some(trs) = self.cache.get_trs(state_id) {
             Ok(trs)

--- a/rustfst/src/algorithms/lazy_fst_revamp/lazy_fst_2.rs
+++ b/rustfst/src/algorithms/lazy_fst_revamp/lazy_fst_2.rs
@@ -52,6 +52,16 @@ impl<W: Semiring, Op: FstOp2<W>, Cache: FstCache<W>> CoreFst<W> for LazyFst2<W, 
         self.final_weight(state_id).unsafe_unwrap()
     }
 
+    fn num_trs(&self, s: usize) -> Result<usize> {
+        self.cache
+            .num_trs(s)
+            .ok_or_else(|| format_err!("State {:?} doesn't exist", s))
+    }
+
+    unsafe fn num_trs_unchecked(&self, s: usize) -> usize {
+        self.cache.num_trs(s).unsafe_unwrap()
+    }
+
     fn get_trs(&self, state_id: usize) -> Result<Self::TRS> {
         if let Some(trs) = self.cache.get_trs(state_id) {
             Ok(trs)

--- a/rustfst/src/algorithms/lazy_fst_revamp/simple_hash_map_cache.rs
+++ b/rustfst/src/algorithms/lazy_fst_revamp/simple_hash_map_cache.rs
@@ -81,4 +81,9 @@ impl<W: Semiring> FstCache<W> for SimpleHashMapCache<W> {
         n = std::cmp::max(n, self.final_weight.lock().unwrap().1);
         n
     }
+
+    fn num_trs(&self, id: usize) -> Option<usize> {
+        let data = self.trs.lock().unwrap();
+        data.0.get(&id).map(|v| v.len())
+    }
 }

--- a/rustfst/src/algorithms/replace/replace_fst.rs
+++ b/rustfst/src/algorithms/replace/replace_fst.rs
@@ -65,6 +65,14 @@ where
         self.0.final_weight_unchecked(state_id)
     }
 
+    fn num_trs(&self, s: usize) -> Result<usize> {
+        self.0.num_trs(s)
+    }
+
+    unsafe fn num_trs_unchecked(&self, s: usize) -> usize {
+        self.0.num_trs_unchecked(s)
+    }
+
     fn get_trs(&self, state_id: usize) -> Result<Self::TRS> {
         self.0.get_trs(state_id)
     }

--- a/rustfst/src/algorithms/rm_epsilon/rm_epsilon_fst.rs
+++ b/rustfst/src/algorithms/rm_epsilon/rm_epsilon_fst.rs
@@ -51,6 +51,14 @@ where
         self.0.final_weight_unchecked(state_id)
     }
 
+    fn num_trs(&self, s: usize) -> Result<usize> {
+        self.0.num_trs(s)
+    }
+
+    unsafe fn num_trs_unchecked(&self, s: usize) -> usize {
+        self.0.num_trs_unchecked(s)
+    }
+
     fn get_trs(&self, state_id: usize) -> Result<Self::TRS> {
         self.0.get_trs(state_id)
     }

--- a/rustfst/src/fst_impls/const_fst/fst.rs
+++ b/rustfst/src/fst_impls/const_fst/fst.rs
@@ -52,6 +52,18 @@ impl<W: Semiring> CoreFst<W> for ConstFst<W> {
         self.states.get_unchecked(state_id).final_weight.clone()
     }
 
+    fn num_trs(&self, s: usize) -> Result<usize> {
+        Ok(self
+            .states
+            .get(s)
+            .ok_or_else(|| format_err!("State {:?} doesn't exist", s))?
+            .ntrs)
+    }
+
+    unsafe fn num_trs_unchecked(&self, s: usize) -> usize {
+        self.states.get_unchecked(s).ntrs
+    }
+
     fn get_trs(&self, state_id: usize) -> Result<Self::TRS> {
         let state = self
             .states

--- a/rustfst/src/fst_impls/vector_fst/fst.rs
+++ b/rustfst/src/fst_impls/vector_fst/fst.rs
@@ -53,6 +53,19 @@ impl<W: 'static + Semiring> CoreFst<W> for VectorFst<W> {
         self.states.get_unchecked(state_id).final_weight.clone()
     }
 
+    fn num_trs(&self, s: usize) -> Result<usize> {
+        Ok(self
+            .states
+            .get(s)
+            .ok_or_else(|| format_err!("State {:?} doesn't exist", s))?
+            .trs
+            .len())
+    }
+
+    unsafe fn num_trs_unchecked(&self, s: usize) -> usize {
+        self.states.get_unchecked(s).trs.len()
+    }
+
     fn get_trs(&self, state_id: usize) -> Result<Self::TRS> {
         let state = self
             .states

--- a/rustfst/src/fst_traits/fst.rs
+++ b/rustfst/src/fst_traits/fst.rs
@@ -74,12 +74,8 @@ pub trait CoreFst<W: Semiring> {
     /// fst.add_tr(s1, Tr::new(3, 5, BooleanWeight::new(true), s2));
     /// assert_eq!(fst.num_trs(s1).unwrap(), 1);
     /// ```
-    fn num_trs(&self, s: StateId) -> Result<usize> {
-        Ok(self.get_trs(s)?.len())
-    }
-    unsafe fn num_trs_unchecked(&self, s: StateId) -> usize {
-        self.get_trs_unchecked(s).len()
-    }
+    fn num_trs(&self, s: StateId) -> Result<usize>;
+    unsafe fn num_trs_unchecked(&self, s: StateId) -> usize;
 
     /// Returns whether or not the state with identifier passed as parameters is a final state.
     ///


### PR DESCRIPTION
- `num_trs` and `num_trs_unchecked` are now mandatory methods of the `Fst` trait. This allows removing useless calls to `Arc::clone`.
