### PR TITLE
Extend prelude re-export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Implement `FstOp` for `Deref<FstOp>` and `FstOp2` for `Deref<FstOp2>`
 - Implement `TrMapper<S>` for `Deref<TrMapper<S>>`
+- Expose in `prelude`, top crate constant, traits, structs.
+- Expose in `prelude` `FstProperties`.
+- Expose in `prelude` `tr_mappers`.  
 
 ### Changed
 - `QuantizeMapper` has now a configurable delta value with default set to `KDELTA`

--- a/rustfst/src/lib.rs
+++ b/rustfst/src/lib.rs
@@ -176,7 +176,7 @@ pub mod prelude {
     pub use crate::*;
 }
 
-pub mod proptest_fst;
+mod proptest_fst;
 
 pub(crate) static NO_LABEL: Label = std::usize::MAX;
 pub(crate) static NO_STATE_ID: StateId = std::usize::MAX;

--- a/rustfst/src/lib.rs
+++ b/rustfst/src/lib.rs
@@ -166,14 +166,17 @@ pub const KDELTA: f32 = 1.0f32 / 1024.0f32;
 /// Module re-exporting most of the objects from this crate.
 pub mod prelude {
     pub use crate::algorithms::tr_compares::*;
+    pub use crate::algorithms::tr_mappers::*;
     pub use crate::algorithms::*;
     pub use crate::fst_impls::*;
     pub use crate::fst_traits::*;
     pub use crate::semirings::*;
     pub use crate::tr::Tr;
+    pub use crate::trs::{ TrsVec, Trs, TrsConst };
+    pub use crate::*;
 }
 
-mod proptest_fst;
+pub mod proptest_fst;
 
 pub(crate) static NO_LABEL: Label = std::usize::MAX;
 pub(crate) static NO_STATE_ID: StateId = std::usize::MAX;


### PR DESCRIPTION
Make `rustiest::prelude` as the main entry point for mostly used structs, traits, etc. 