### PR TITLE
Allow Composition of Lazy Fsts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The `Matcher` object now has a trait bound on an `Fst` instead of on an `ExpandedFst` allowing composing lazy fsts.
 - Lazy implementation of the determinize algorithm has been generalized to use the `Borrow` trait instead of the `Arc` object.
 - `determinize` now requires a `&Fst` instead of an `Arc`.
 - Fixed bug in `Determinize`: `HashMap` -> `BTreeMap` for `LabelMap`.

--- a/rustfst/src/algorithms/compose/compose_filters/mod.rs
+++ b/rustfst/src/algorithms/compose/compose_filters/mod.rs
@@ -43,7 +43,7 @@ pub trait ComposeFilterBuilder<W: Semiring>: Debug {
 
 /// Composition filters determine which matches are allowed to proceed. The
 /// filter's state is represented by the type ComposeFilter::FS.
-pub trait ComposeFilter<W: Semiring>: Debug + Clone {
+pub trait ComposeFilter<W: Semiring>: Debug {
     type M1: Matcher<W>;
     type M2: Matcher<W>;
     type FS: FilterState;

--- a/rustfst/src/algorithms/compose/compose_fst.rs
+++ b/rustfst/src/algorithms/compose/compose_fst.rs
@@ -14,12 +14,12 @@ use crate::semirings::Semiring;
 use crate::{SymbolTable, TrsVec};
 use std::sync::Arc;
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ComposeFst<W: Semiring, CFB: ComposeFilterBuilder<W>, Cache = SimpleVecCache<W>>(
     LazyFst<W, ComposeFstOp<W, CFB>, Cache>,
 );
 
-fn create_base<W: Semiring, F1: Fst<W> + Clone, F2: Fst<W> + Clone>(
+fn create_base<W: Semiring, F1: Fst<W>, F2: Fst<W>>(
     fst1: Arc<F1>,
     fst2: Arc<F2>,
 ) -> Result<
@@ -88,7 +88,7 @@ impl<W: Semiring, CFB: ComposeFilterBuilder<W>, Cache: FstCache<W>> ComposeFst<W
     }
 }
 
-impl<W: Semiring, F1: Fst<W> + Clone, F2: Fst<W> + Clone>
+impl<W: Semiring, F1: Fst<W>, F2: Fst<W>>
     ComposeFst<W, SequenceComposeFilterBuilder<W, GenericMatcher<W, F1>, GenericMatcher<W, F2>>>
 {
     pub fn new_auto(fst1: Arc<F1>, fst2: Arc<F2>) -> Result<Self> {

--- a/rustfst/src/algorithms/compose/compose_fst.rs
+++ b/rustfst/src/algorithms/compose/compose_fst.rs
@@ -8,7 +8,7 @@ use crate::algorithms::compose::{ComposeFstOp, ComposeFstOpOptions, ComposeState
 use crate::algorithms::lazy::{FstCache, LazyFst, SimpleVecCache, StateTable};
 use crate::fst_properties::FstProperties;
 use crate::fst_traits::{
-    AllocableFst, CoreFst, ExpandedFst, Fst, FstIterator, MutableFst, StateIterator,
+    AllocableFst, CoreFst, Fst, FstIterator, MutableFst, StateIterator,
 };
 use crate::semirings::Semiring;
 use crate::{SymbolTable, TrsVec};
@@ -19,7 +19,7 @@ pub struct ComposeFst<W: Semiring, CFB: ComposeFilterBuilder<W>, Cache = SimpleV
     LazyFst<W, ComposeFstOp<W, CFB>, Cache>,
 );
 
-fn create_base<W: Semiring, F1: ExpandedFst<W>, F2: ExpandedFst<W>>(
+fn create_base<W: Semiring, F1: Fst<W> + Clone, F2: Fst<W> + Clone>(
     fst1: Arc<F1>,
     fst2: Arc<F2>,
 ) -> Result<
@@ -88,7 +88,7 @@ impl<W: Semiring, CFB: ComposeFilterBuilder<W>, Cache: FstCache<W>> ComposeFst<W
     }
 }
 
-impl<W: Semiring, F1: ExpandedFst<W>, F2: ExpandedFst<W>>
+impl<W: Semiring, F1: Fst<W> + Clone, F2: Fst<W> + Clone>
     ComposeFst<W, SequenceComposeFilterBuilder<W, GenericMatcher<W, F1>, GenericMatcher<W, F2>>>
 {
     pub fn new_auto(fst1: Arc<F1>, fst2: Arc<F2>) -> Result<Self> {

--- a/rustfst/src/algorithms/compose/label_reachable.rs
+++ b/rustfst/src/algorithms/compose/label_reachable.rs
@@ -267,7 +267,7 @@ impl LabelReachable {
         Ok(())
     }
 
-    pub fn reach_init<W: Semiring, F: ExpandedFst<W>>(
+    pub fn reach_init<W: Semiring, F: Fst<W>>(
         &mut self,
         fst: &Arc<F>,
         reach_input: bool,

--- a/rustfst/src/algorithms/compose/lookahead_filters/lookahead_compose_filter.rs
+++ b/rustfst/src/algorithms/compose/lookahead_filters/lookahead_compose_filter.rs
@@ -15,7 +15,7 @@ use crate::algorithms::compose::lookahead_matchers::{LookAheadMatcherData, Looka
 use crate::algorithms::compose::matchers::MatcherFlags;
 use crate::algorithms::compose::matchers::{MatchType, Matcher};
 use crate::fst_properties::FstProperties;
-use crate::fst_traits::ExpandedFst;
+use crate::fst_traits::Fst;
 use crate::semirings::Semiring;
 use crate::{Tr, EPS_LABEL};
 
@@ -60,8 +60,8 @@ impl<W, F1, F2, M1, M2, CF, CFB, SMT> ComposeFilterBuilder<W>
     for LookAheadComposeFilterBuilder<W, CFB, SMT>
 where
     W: Semiring,
-    F1: ExpandedFst<W>,
-    F2: ExpandedFst<W>,
+    F1: Fst<W>,
+    F2: Fst<W>,
     M1: Matcher<W, F = F1> + LookaheadMatcher<W>,
     M2: Matcher<W, F = F2> + LookaheadMatcher<W>,
     CF: ComposeFilter<W, M1 = M1, M2 = M2> + LookAheadComposeFilterTrait<W>,

--- a/rustfst/src/algorithms/compose/lookahead_matchers/label_lookahead_matcher.rs
+++ b/rustfst/src/algorithms/compose/lookahead_matchers/label_lookahead_matcher.rs
@@ -8,7 +8,7 @@ use crate::algorithms::compose::lookahead_matchers::{
 };
 use crate::algorithms::compose::matchers::{MatchType, Matcher, MatcherFlags};
 use crate::algorithms::compose::{LabelReachable, LabelReachableData};
-use crate::fst_traits::ExpandedFst;
+use crate::fst_traits::Fst;
 use crate::semirings::Semiring;
 use crate::{Tr, Trs, EPS_LABEL};
 
@@ -108,7 +108,7 @@ impl<W: Semiring + 'static, M: Matcher<W>, MFT: MatcherFlagsTrait> LookaheadMatc
         })
     }
 
-    fn create_data<F: ExpandedFst<W>>(
+    fn create_data<F: Fst<W>>(
         fst: &F,
         match_type: MatchType,
     ) -> Result<Option<Self::MatcherData>> {
@@ -122,7 +122,7 @@ impl<W: Semiring + 'static, M: Matcher<W>, MFT: MatcherFlagsTrait> LookaheadMatc
         }
     }
 
-    fn init_lookahead_fst<LF: ExpandedFst<W>>(&mut self, lfst: &Arc<LF>) -> Result<()> {
+    fn init_lookahead_fst<LF: Fst<W> + Clone>(&mut self, lfst: &Arc<LF>) -> Result<()> {
         let reach_input = self.match_type(false)? == MatchType::MatchOutput;
         if let Some(reachable) = &mut self.reachable {
             reachable.reach_init(lfst, reach_input)?;
@@ -130,7 +130,7 @@ impl<W: Semiring + 'static, M: Matcher<W>, MFT: MatcherFlagsTrait> LookaheadMatc
         Ok(())
     }
 
-    fn lookahead_fst<LF: ExpandedFst<W>>(
+    fn lookahead_fst<LF: Fst<W>>(
         &self,
         matcher_state: usize,
         lfst: &Arc<LF>,

--- a/rustfst/src/algorithms/compose/lookahead_matchers/label_lookahead_matcher.rs
+++ b/rustfst/src/algorithms/compose/lookahead_matchers/label_lookahead_matcher.rs
@@ -122,7 +122,7 @@ impl<W: Semiring + 'static, M: Matcher<W>, MFT: MatcherFlagsTrait> LookaheadMatc
         }
     }
 
-    fn init_lookahead_fst<LF: Fst<W> + Clone>(&mut self, lfst: &Arc<LF>) -> Result<()> {
+    fn init_lookahead_fst<LF: Fst<W>>(&mut self, lfst: &Arc<LF>) -> Result<()> {
         let reach_input = self.match_type(false)? == MatchType::MatchOutput;
         if let Some(reachable) = &mut self.reachable {
             reachable.reach_init(lfst, reach_input)?;

--- a/rustfst/src/algorithms/compose/lookahead_matchers/mod.rs
+++ b/rustfst/src/algorithms/compose/lookahead_matchers/mod.rs
@@ -10,7 +10,7 @@ pub use trivial_lookahead_matcher::TrivialLookAheadMatcher;
 
 use crate::algorithms::compose::matchers::MatcherFlags;
 use crate::algorithms::compose::matchers::{MatchType, Matcher};
-use crate::fst_traits::ExpandedFst;
+use crate::fst_traits::Fst;
 use crate::semirings::Semiring;
 use crate::{Label, StateId, Tr, NO_STATE_ID};
 
@@ -77,16 +77,16 @@ pub trait LookaheadMatcher<W: Semiring>: Matcher<W> {
     where
         Self: std::marker::Sized;
 
-    fn create_data<F: ExpandedFst<W>>(
+    fn create_data<F: Fst<W>>(
         fst: &F,
         match_type: MatchType,
     ) -> Result<Option<Self::MatcherData>>;
 
-    fn init_lookahead_fst<LF: ExpandedFst<W>>(&mut self, lfst: &Arc<LF>) -> Result<()>;
+    fn init_lookahead_fst<LF: Fst<W> + Clone>(&mut self, lfst: &Arc<LF>) -> Result<()>;
     // Are there paths from a state in the lookahead FST that can be read from
     // the curent matcher state?
 
-    fn lookahead_fst<LF: ExpandedFst<W>>(
+    fn lookahead_fst<LF: Fst<W>>(
         &self,
         matcher_state: StateId,
         lfst: &Arc<LF>,

--- a/rustfst/src/algorithms/compose/lookahead_matchers/mod.rs
+++ b/rustfst/src/algorithms/compose/lookahead_matchers/mod.rs
@@ -82,7 +82,7 @@ pub trait LookaheadMatcher<W: Semiring>: Matcher<W> {
         match_type: MatchType,
     ) -> Result<Option<Self::MatcherData>>;
 
-    fn init_lookahead_fst<LF: Fst<W> + Clone>(&mut self, lfst: &Arc<LF>) -> Result<()>;
+    fn init_lookahead_fst<LF: Fst<W>>(&mut self, lfst: &Arc<LF>) -> Result<()>;
     // Are there paths from a state in the lookahead FST that can be read from
     // the curent matcher state?
 

--- a/rustfst/src/algorithms/compose/lookahead_matchers/tr_lookahead_matcher.rs
+++ b/rustfst/src/algorithms/compose/lookahead_matchers/tr_lookahead_matcher.rs
@@ -8,7 +8,7 @@ use crate::algorithms::compose::lookahead_matchers::{
     LookAheadMatcherData, LookaheadMatcher, MatcherFlagsTrait,
 };
 use crate::algorithms::compose::matchers::{IterItemMatcher, MatchType, Matcher, MatcherFlags};
-use crate::fst_traits::{CoreFst, ExpandedFst, Fst};
+use crate::fst_traits::{CoreFst, Fst};
 use crate::semirings::Semiring;
 use crate::{Label, StateId, Tr, Trs, EPS_LABEL, NO_LABEL};
 
@@ -81,14 +81,14 @@ impl<W: Semiring, M: Matcher<W>, MFT: MatcherFlagsTrait> LookaheadMatcher<W>
         Self::new(fst, match_type)
     }
 
-    fn create_data<F: ExpandedFst<W>>(
+    fn create_data<F: Fst<W>>(
         _fst: &F,
         _match_type: MatchType,
     ) -> Result<Option<Self::MatcherData>> {
         Ok(None)
     }
 
-    fn init_lookahead_fst<LF: ExpandedFst<W>>(&mut self, _lfst: &Arc<LF>) -> Result<()> {
+    fn init_lookahead_fst<LF: Fst<W>>(&mut self, _lfst: &Arc<LF>) -> Result<()> {
         Ok(())
     }
 

--- a/rustfst/src/algorithms/compose/lookahead_matchers/trivial_lookahead_matcher.rs
+++ b/rustfst/src/algorithms/compose/lookahead_matchers/trivial_lookahead_matcher.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 
 use crate::algorithms::compose::lookahead_matchers::{LookAheadMatcherData, LookaheadMatcher};
 use crate::algorithms::compose::matchers::{MatchType, Matcher, MatcherFlags};
-use crate::fst_traits::{ExpandedFst, Fst};
+use crate::fst_traits::Fst;
 use crate::semirings::Semiring;
 use crate::{Label, StateId, Tr};
 
@@ -68,14 +68,14 @@ impl<W: Semiring, M: Matcher<W>> LookaheadMatcher<W> for TrivialLookAheadMatcher
         Self::new(fst, match_type)
     }
 
-    fn create_data<F: ExpandedFst<W>>(
+    fn create_data<F: Fst<W>>(
         _fst: &F,
         _match_type: MatchType,
     ) -> Result<Option<Self::MatcherData>> {
         Ok(None)
     }
 
-    fn init_lookahead_fst<LF: ExpandedFst<W>>(&mut self, _lfst: &Arc<LF>) -> Result<()> {
+    fn init_lookahead_fst<LF: Fst<W>>(&mut self, _lfst: &Arc<LF>) -> Result<()> {
         Ok(())
     }
 

--- a/rustfst/src/algorithms/compose/matchers/mod.rs
+++ b/rustfst/src/algorithms/compose/matchers/mod.rs
@@ -96,10 +96,10 @@ pub fn eps_loop<W: Semiring>(state: StateId, match_type: MatchType) -> Result<Tr
 /// simplest form, these are just some associative map or search keyed on labels.
 /// More generally, they may implement matching special labels that represent
 /// sets of labels such as sigma (all), rho (rest), or phi (fail).
-pub trait Matcher<W: Semiring>: Debug + Clone {
-    type F: Fst<W> + Clone;
+pub trait Matcher<W: Semiring>: Debug {
+    type F: Fst<W>;
 
-    type Iter: Iterator<Item = IterItemMatcher<W>> + Clone;
+    type Iter: Iterator<Item = IterItemMatcher<W>>;
 
     fn new(fst: Arc<Self::F>, match_type: MatchType) -> Result<Self>
     where

--- a/rustfst/src/algorithms/compose/matchers/mod.rs
+++ b/rustfst/src/algorithms/compose/matchers/mod.rs
@@ -7,7 +7,7 @@ pub use generic_matcher::GenericMatcher;
 pub use multi_eps_matcher::{MultiEpsMatcher, MultiEpsMatcherFlags};
 pub use sorted_matcher::SortedMatcher;
 
-use crate::fst_traits::ExpandedFst;
+use crate::fst_traits::Fst;
 use crate::semirings::Semiring;
 use crate::{Label, StateId};
 use crate::{Tr, EPS_LABEL, NO_LABEL};
@@ -97,7 +97,7 @@ pub fn eps_loop<W: Semiring>(state: StateId, match_type: MatchType) -> Result<Tr
 /// More generally, they may implement matching special labels that represent
 /// sets of labels such as sigma (all), rho (rest), or phi (fail).
 pub trait Matcher<W: Semiring>: Debug + Clone {
-    type F: ExpandedFst<W>;
+    type F: Fst<W> + Clone;
 
     type Iter: Iterator<Item = IterItemMatcher<W>> + Clone;
 

--- a/rustfst/src/algorithms/compose/matchers/sorted_matcher.rs
+++ b/rustfst/src/algorithms/compose/matchers/sorted_matcher.rs
@@ -7,18 +7,18 @@ use superslice::Ext;
 use crate::algorithms::compose::lookahead_matchers::{LookAheadMatcherData, LookaheadMatcher};
 use crate::algorithms::compose::matchers::{IterItemMatcher, MatchType, Matcher, MatcherFlags};
 use crate::fst_properties::FstProperties;
-use crate::fst_traits::{CoreFst, ExpandedFst};
+use crate::fst_traits::{CoreFst, Fst};
 use crate::semirings::Semiring;
 use crate::{Label, StateId, Tr, Trs, EPS_LABEL, NO_LABEL};
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct SortedMatcher<W: Semiring, F: ExpandedFst<W>> {
+pub struct SortedMatcher<W: Semiring, F: Fst<W>> {
     fst: Arc<F>,
     match_type: MatchType,
     w: PhantomData<W>,
 }
 
-impl<W: Semiring, F: ExpandedFst<W>> Matcher<W> for SortedMatcher<W, F> {
+impl<W: Semiring, F: Fst<W> + Clone> Matcher<W> for SortedMatcher<W, F> {
     type F = F;
     type Iter = IteratorSortedMatcher<W, F::TRS>;
 
@@ -173,7 +173,7 @@ impl<W: Semiring, T: Trs<W>> Iterator for IteratorSortedMatcher<W, T> {
     }
 }
 
-impl<W: Semiring, F: ExpandedFst<W>> LookaheadMatcher<W> for SortedMatcher<W, F> {
+impl<W: Semiring, F: Fst<W> + Clone> LookaheadMatcher<W> for SortedMatcher<W, F> {
     type MatcherData = ();
 
     fn data(&self) -> Option<&Arc<Self::MatcherData>> {
@@ -191,18 +191,18 @@ impl<W: Semiring, F: ExpandedFst<W>> LookaheadMatcher<W> for SortedMatcher<W, F>
         unreachable!()
     }
 
-    fn create_data<G: ExpandedFst<W>>(
+    fn create_data<G: Fst<W>>(
         _fst: &G,
         _match_type: MatchType,
     ) -> Result<Option<Self::MatcherData>> {
         unreachable!()
     }
 
-    fn init_lookahead_fst<LF: ExpandedFst<W>>(&mut self, _lfst: &Arc<LF>) -> Result<()> {
+    fn init_lookahead_fst<LF: Fst<W>>(&mut self, _lfst: &Arc<LF>) -> Result<()> {
         unreachable!()
     }
 
-    fn lookahead_fst<LF: ExpandedFst<W>>(
+    fn lookahead_fst<LF: Fst<W>>(
         &self,
         _matcher_state: usize,
         _lfst: &Arc<LF>,

--- a/rustfst/src/algorithms/compose/matchers/sorted_matcher.rs
+++ b/rustfst/src/algorithms/compose/matchers/sorted_matcher.rs
@@ -18,7 +18,7 @@ pub struct SortedMatcher<W: Semiring, F: Fst<W>> {
     w: PhantomData<W>,
 }
 
-impl<W: Semiring, F: Fst<W> + Clone> Matcher<W> for SortedMatcher<W, F> {
+impl<W: Semiring, F: Fst<W>> Matcher<W> for SortedMatcher<W, F> {
     type F = F;
     type Iter = IteratorSortedMatcher<W, F::TRS>;
 
@@ -173,7 +173,7 @@ impl<W: Semiring, T: Trs<W>> Iterator for IteratorSortedMatcher<W, T> {
     }
 }
 
-impl<W: Semiring, F: Fst<W> + Clone> LookaheadMatcher<W> for SortedMatcher<W, F> {
+impl<W: Semiring, F: Fst<W>> LookaheadMatcher<W> for SortedMatcher<W, F> {
     type MatcherData = ();
 
     fn data(&self) -> Option<&Arc<Self::MatcherData>> {


### PR DESCRIPTION
- The `Matcher` object now has a trait bound on an `Fst` instead of on an `ExpandedFst` allowing composing lazy fsts.
