### PR TITLE
ComposeFst clonable if possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Make `ComposeFst` clonable if all the elements that compose it are clonable.
 - The `Matcher` object now has a trait bound on an `Fst` instead of on an `ExpandedFst` allowing composing lazy fsts.
 - Lazy implementation of the determinize algorithm has been generalized to use the `Borrow` trait instead of the `Arc` object.
 - `determinize` now requires a `&Fst` instead of an `Arc`.

--- a/rustfst/src/algorithms/compose/compose_fst.rs
+++ b/rustfst/src/algorithms/compose/compose_fst.rs
@@ -19,6 +19,14 @@ pub struct ComposeFst<W: Semiring, CFB: ComposeFilterBuilder<W>, Cache = SimpleV
     LazyFst<W, ComposeFstOp<W, CFB>, Cache>,
 );
 
+impl<W: Semiring + Clone, CFB: ComposeFilterBuilder<W> + Clone, Cache: FstCache<W> + Clone> Clone for ComposeFst<W, CFB, Cache>
+where CFB::CF: Clone
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
 fn create_base<W: Semiring, F1: Fst<W>, F2: Fst<W>>(
     fst1: Arc<F1>,
     fst2: Arc<F2>,
@@ -218,6 +226,21 @@ mod test {
     fn test_compose_fst_sync() {
         fn is_sync<T: Sync>() {}
         is_sync::<
+            ComposeFst<
+                TropicalWeight,
+                SequenceComposeFilterBuilder<
+                    _,
+                    SortedMatcher<_, VectorFst<_>>,
+                    SortedMatcher<_, VectorFst<_>>,
+                >,
+            >,
+        >();
+    }
+
+    #[test]
+    fn test_compose_fst_clonable() {
+        fn is_clone<T: Clone>() {}
+        is_clone::<
             ComposeFst<
                 TropicalWeight,
                 SequenceComposeFilterBuilder<

--- a/rustfst/src/tests_openfst/algorithms/compose.rs
+++ b/rustfst/src/tests_openfst/algorithms/compose.rs
@@ -191,6 +191,10 @@ where
         compose_options,
     )?;
 
+    // Check clonability
+    fn is_clone<T: Clone>(_v: &T) {}
+    is_clone(&dyn_fst);
+
     let static_fst: VectorFst<_> = dyn_fst.compute()?;
 
     test_eq_fst(


### PR DESCRIPTION
- Make `ComposeFst` clonable if all the elements that compose it are clonable.