### PR TITLE
SymbolTable improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added a `BuildHasher` generic parameter to `SymbolTable` as long as a method `with_hasher`.
 - Added the `optimize` algorithm.
 - Added the `approx_equal` method to the Semiring trait and implement it for all semirings in the crate.
 - In order to handle default parmeters, some algorithms now have multiple versions:
@@ -26,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Change internal implementation of `SymbolTable`: now used a Vec and a `HashMap` instead of two `HashMap`s. As a result, doesn't support `SymbolTable` with hole anymore.
 - Change implementation of `Default` for `SymbolTable` object: now adds `EPS`.
 - `equal_quantized` in `ExpandedFst` trait has been renamed to `approx_equal`
 - Fix bug in `reverse` happening when the `Fst` was `INITIAL_CYCLIC`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added a `BuildHasher` generic parameter to `SymbolTable` as long as a method `with_hasher`.
+- Added a `BuildHasher` generic parameter to `SymbolTable` as well as a method `with_hasher`.
 - Added the `optimize` algorithm.
 - Added the `approx_equal` method to the Semiring trait and implement it for all semirings in the crate.
 - In order to handle default parmeters, some algorithms now have multiple versions:

--- a/rustfst/src/algorithms/lazy/mod.rs
+++ b/rustfst/src/algorithms/lazy/mod.rs
@@ -4,7 +4,6 @@ pub use fst_op_2::FstOp2;
 pub use lazy_fst::LazyFst;
 pub use lazy_fst_2::LazyFst2;
 pub use state_table::StateTable;
-pub(crate) use state_table::BiHashMap;
 
 mod fst_op;
 mod fst_op_2;

--- a/rustfst/src/algorithms/lazy/mod.rs
+++ b/rustfst/src/algorithms/lazy/mod.rs
@@ -4,6 +4,7 @@ pub use fst_op_2::FstOp2;
 pub use lazy_fst::LazyFst;
 pub use lazy_fst_2::LazyFst2;
 pub use state_table::StateTable;
+pub(crate) use state_table::BiHashMap;
 
 mod fst_op;
 mod fst_op_2;

--- a/rustfst/src/algorithms/lazy/state_table.rs
+++ b/rustfst/src/algorithms/lazy/state_table.rs
@@ -30,20 +30,12 @@ impl<T: Hash + Eq + Clone> BiHashMap<T> {
 }
 
 impl<T: Hash + Eq + Clone, H: BuildHasher> BiHashMap<T, H> {
+    #[allow(unused)]
     pub fn with_hasher(hash_builder: H) -> Self {
         Self {
             tuple_to_id: HashMap::with_hasher(hash_builder),
             id_to_tuple: Vec::new()
         }
-    }
-
-    pub fn len(&self) -> usize {
-        self.id_to_tuple.len()
-    }
-
-    pub fn reserve(&mut self, additional: usize) {
-        self.tuple_to_id.reserve(additional);
-        self.id_to_tuple.reserve(additional);
     }
 
     pub fn get_id_or_insert(&mut self, tuple: T) -> usize {
@@ -58,28 +50,8 @@ impl<T: Hash + Eq + Clone, H: BuildHasher> BiHashMap<T, H> {
         }
     }
 
-    pub fn get_id(&self, tuple: impl AsRef<T>) -> Option<usize> {
-        self.tuple_to_id.get(tuple.as_ref()).cloned()
-    }
-
-    pub fn get_tuple(&self, id: usize) -> Option<&T> {
-        self.id_to_tuple.get(id)
-    }
-
     pub fn get_tuple_unchecked(&self, id: usize) -> T {
         self.id_to_tuple[id].clone()
-    }
-
-    pub fn iter_ids(&self) -> impl Iterator<Item=usize> {
-        0..self.id_to_tuple.len()
-    }
-
-    pub fn iter_tuples(&self) -> impl Iterator<Item=&T> {
-        self.tuple_to_id.keys()
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item=(usize, &T)> {
-        self.id_to_tuple.iter().enumerate()
     }
 }
 

--- a/rustfst/src/algorithms/lazy/state_table.rs
+++ b/rustfst/src/algorithms/lazy/state_table.rs
@@ -4,12 +4,12 @@ use std::sync::Mutex;
 
 use crate::StateId;
 use std::collections::hash_map::Entry;
+use std::collections::hash_map::RandomState;
 use std::collections::HashMap;
-use std::collections::hash_map::{RandomState};
 use std::hash::BuildHasher;
 
 #[derive(Clone, Debug, Default)]
-pub(crate) struct BiHashMap<T: Hash + Eq + Clone, H : BuildHasher = RandomState> {
+pub(crate) struct BiHashMap<T: Hash + Eq + Clone, H: BuildHasher = RandomState> {
     tuple_to_id: HashMap<T, StateId, H>,
     id_to_tuple: Vec<T>,
 }
@@ -24,7 +24,7 @@ impl<T: Hash + Eq + Clone> BiHashMap<T> {
     pub fn new() -> Self {
         Self {
             tuple_to_id: HashMap::new(),
-            id_to_tuple: Vec::new()
+            id_to_tuple: Vec::new(),
         }
     }
 }
@@ -34,7 +34,7 @@ impl<T: Hash + Eq + Clone, H: BuildHasher> BiHashMap<T, H> {
     pub fn with_hasher(hash_builder: H) -> Self {
         Self {
             tuple_to_id: HashMap::with_hasher(hash_builder),
-            id_to_tuple: Vec::new()
+            id_to_tuple: Vec::new(),
         }
     }
 

--- a/rustfst/src/algorithms/lazy/state_table.rs
+++ b/rustfst/src/algorithms/lazy/state_table.rs
@@ -5,22 +5,48 @@ use std::sync::Mutex;
 use crate::StateId;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
+use std::collections::hash_map::{RandomState};
+use std::hash::BuildHasher;
 
-#[derive(Clone, Debug, PartialEq)]
-pub struct BiHashMap<T: Hash + Eq + Clone> {
-    tuple_to_id: HashMap<T, StateId>,
+#[derive(Clone, Debug, Default)]
+pub(crate) struct BiHashMap<T: Hash + Eq + Clone, H : BuildHasher = RandomState> {
+    tuple_to_id: HashMap<T, StateId, H>,
     id_to_tuple: Vec<T>,
+}
+
+impl<T: Hash + Eq + Clone, H: BuildHasher> PartialEq for BiHashMap<T, H> {
+    fn eq(&self, other: &Self) -> bool {
+        self.tuple_to_id.eq(&other.tuple_to_id) && self.id_to_tuple.eq(&other.id_to_tuple)
+    }
 }
 
 impl<T: Hash + Eq + Clone> BiHashMap<T> {
     pub fn new() -> Self {
         Self {
             tuple_to_id: HashMap::new(),
-            id_to_tuple: Vec::new(),
+            id_to_tuple: Vec::new()
+        }
+    }
+}
+
+impl<T: Hash + Eq + Clone, H: BuildHasher> BiHashMap<T, H> {
+    pub fn with_hasher(hash_builder: H) -> Self {
+        Self {
+            tuple_to_id: HashMap::with_hasher(hash_builder),
+            id_to_tuple: Vec::new()
         }
     }
 
-    pub fn get_id(&mut self, tuple: T) -> usize {
+    pub fn len(&self) -> usize {
+        self.id_to_tuple.len()
+    }
+
+    pub fn reserve(&mut self, additional: usize) {
+        self.tuple_to_id.reserve(additional);
+        self.id_to_tuple.reserve(additional);
+    }
+
+    pub fn get_id_or_insert(&mut self, tuple: T) -> usize {
         match self.tuple_to_id.entry(tuple) {
             Entry::Occupied(e) => *e.get(),
             Entry::Vacant(e) => {
@@ -32,8 +58,28 @@ impl<T: Hash + Eq + Clone> BiHashMap<T> {
         }
     }
 
-    pub fn get_tuple(&self, id: usize) -> T {
+    pub fn get_id(&self, tuple: impl AsRef<T>) -> Option<usize> {
+        self.tuple_to_id.get(tuple.as_ref()).cloned()
+    }
+
+    pub fn get_tuple(&self, id: usize) -> Option<&T> {
+        self.id_to_tuple.get(id)
+    }
+
+    pub fn get_tuple_unchecked(&self, id: usize) -> T {
         self.id_to_tuple[id].clone()
+    }
+
+    pub fn iter_ids(&self) -> impl Iterator<Item=usize> {
+        0..self.id_to_tuple.len()
+    }
+
+    pub fn iter_tuples(&self) -> impl Iterator<Item=&T> {
+        self.tuple_to_id.keys()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item=(usize, &T)> {
+        self.id_to_tuple.iter().enumerate()
     }
 }
 
@@ -83,17 +129,17 @@ impl<T: Hash + Eq + Clone> StateTable<T> {
     /// Looks up integer ID from entry. If it doesn't exist and insert
     pub fn find_id_from_ref(&self, tuple: &T) -> StateId {
         let mut table = self.table.lock().unwrap();
-        table.get_id(tuple.clone())
+        table.get_id_or_insert(tuple.clone())
     }
 
     pub fn find_id(&self, tuple: T) -> StateId {
         let mut table = self.table.lock().unwrap();
-        table.get_id(tuple)
+        table.get_id_or_insert(tuple)
     }
 
     /// Looks up tuple from integer ID.
     pub fn find_tuple(&self, tuple_id: StateId) -> T {
         let table = self.table.lock().unwrap();
-        table.get_tuple(tuple_id)
+        table.get_tuple_unchecked(tuple_id)
     }
 }

--- a/rustfst/src/fst_impls/const_fst/serializable_fst.rs
+++ b/rustfst/src/fst_impls/const_fst/serializable_fst.rs
@@ -21,10 +21,10 @@ use crate::fst_traits::{ExpandedFst, Fst, SerializableFst};
 use crate::parsers::bin_fst::fst_header::{FstFlags, FstHeader, OpenFstString, FST_MAGIC_NUMBER};
 use crate::parsers::bin_fst::utils_parsing::{parse_final_weight, parse_fst_tr, parse_start_state};
 use crate::parsers::bin_fst::utils_serialization::write_bin_i32;
+use crate::parsers::nom_utils::NomCustomError;
 use crate::parsers::text_fst::ParsedTextFst;
 use crate::semirings::SerializableSemiring;
 use crate::{Tr, EPS_LABEL};
-use crate::parsers::nom_utils::NomCustomError;
 
 impl<W: SerializableSemiring> SerializableFst<W> for ConstFst<W> {
     fn fst_type() -> String {
@@ -185,7 +185,9 @@ impl<W: SerializableSemiring> SerializableFst<W> for ConstFst<W> {
     }
 }
 
-fn parse_const_state<W: SerializableSemiring>(i: &[u8]) -> IResult<&[u8], ConstState<W>, NomCustomError<&[u8]>> {
+fn parse_const_state<W: SerializableSemiring>(
+    i: &[u8],
+) -> IResult<&[u8], ConstState<W>, NomCustomError<&[u8]>> {
     let (i, final_weight) = W::parse_binary(i)?;
     let (i, pos) = le_i32(i)?;
     let (i, ntrs) = le_i32(i)?;
@@ -204,7 +206,9 @@ fn parse_const_state<W: SerializableSemiring>(i: &[u8]) -> IResult<&[u8], ConstS
     ))
 }
 
-fn parse_const_fst<W: SerializableSemiring>(i: &[u8]) -> IResult<&[u8], ConstFst<W>, NomCustomError<&[u8]>> {
+fn parse_const_fst<W: SerializableSemiring>(
+    i: &[u8],
+) -> IResult<&[u8], ConstFst<W>, NomCustomError<&[u8]>> {
     let stream_len = i.len();
 
     let (mut i, hdr) = FstHeader::parse(

--- a/rustfst/src/fst_impls/const_fst/serializable_fst.rs
+++ b/rustfst/src/fst_impls/const_fst/serializable_fst.rs
@@ -24,6 +24,7 @@ use crate::parsers::bin_fst::utils_serialization::write_bin_i32;
 use crate::parsers::text_fst::ParsedTextFst;
 use crate::semirings::SerializableSemiring;
 use crate::{Tr, EPS_LABEL};
+use crate::parsers::nom_utils::NomCustomError;
 
 impl<W: SerializableSemiring> SerializableFst<W> for ConstFst<W> {
     fn fst_type() -> String {
@@ -184,7 +185,7 @@ impl<W: SerializableSemiring> SerializableFst<W> for ConstFst<W> {
     }
 }
 
-fn parse_const_state<W: SerializableSemiring>(i: &[u8]) -> IResult<&[u8], ConstState<W>> {
+fn parse_const_state<W: SerializableSemiring>(i: &[u8]) -> IResult<&[u8], ConstState<W>, NomCustomError<&[u8]>> {
     let (i, final_weight) = W::parse_binary(i)?;
     let (i, pos) = le_i32(i)?;
     let (i, ntrs) = le_i32(i)?;
@@ -203,7 +204,7 @@ fn parse_const_state<W: SerializableSemiring>(i: &[u8]) -> IResult<&[u8], ConstS
     ))
 }
 
-fn parse_const_fst<W: SerializableSemiring>(i: &[u8]) -> IResult<&[u8], ConstFst<W>> {
+fn parse_const_fst<W: SerializableSemiring>(i: &[u8]) -> IResult<&[u8], ConstFst<W>, NomCustomError<&[u8]>> {
     let stream_len = i.len();
 
     let (mut i, hdr) = FstHeader::parse(

--- a/rustfst/src/fst_impls/vector_fst/parse_const.rs
+++ b/rustfst/src/fst_impls/vector_fst/parse_const.rs
@@ -19,6 +19,7 @@ use crate::parsers::bin_fst::fst_header::FstHeader;
 use crate::parsers::bin_fst::utils_parsing::{parse_final_weight, parse_fst_tr, parse_start_state};
 use crate::semirings::SerializableSemiring;
 use crate::{Tr, TrsVec};
+use crate::parsers::nom_utils::NomCustomError;
 
 impl<W: SerializableSemiring> VectorFst<W> {
     /// Load a VectorFst directly from a ConstFst file.
@@ -44,7 +45,7 @@ struct TempState<W> {
     noepsilons: usize,
 }
 
-fn parse_const_state<W: SerializableSemiring>(i: &[u8]) -> IResult<&[u8], TempState<W>> {
+fn parse_const_state<W: SerializableSemiring>(i: &[u8]) -> IResult<&[u8], TempState<W>, NomCustomError<&[u8]>> {
     let (i, final_weight) = W::parse_binary(i)?;
     let (i, _pos) = le_i32(i)?;
     let (i, ntrs) = le_i32(i)?;
@@ -62,7 +63,7 @@ fn parse_const_state<W: SerializableSemiring>(i: &[u8]) -> IResult<&[u8], TempSt
     ))
 }
 
-fn parse_const_fst<W: SerializableSemiring>(i: &[u8]) -> IResult<&[u8], VectorFst<W>> {
+fn parse_const_fst<W: SerializableSemiring>(i: &[u8]) -> IResult<&[u8], VectorFst<W>, NomCustomError<&[u8]>> {
     let stream_len = i.len();
 
     let (mut i, hdr) = FstHeader::parse(

--- a/rustfst/src/fst_impls/vector_fst/parse_const.rs
+++ b/rustfst/src/fst_impls/vector_fst/parse_const.rs
@@ -17,9 +17,9 @@ use crate::fst_properties::FstProperties;
 use crate::fst_traits::SerializableFst;
 use crate::parsers::bin_fst::fst_header::FstHeader;
 use crate::parsers::bin_fst::utils_parsing::{parse_final_weight, parse_fst_tr, parse_start_state};
+use crate::parsers::nom_utils::NomCustomError;
 use crate::semirings::SerializableSemiring;
 use crate::{Tr, TrsVec};
-use crate::parsers::nom_utils::NomCustomError;
 
 impl<W: SerializableSemiring> VectorFst<W> {
     /// Load a VectorFst directly from a ConstFst file.
@@ -45,7 +45,9 @@ struct TempState<W> {
     noepsilons: usize,
 }
 
-fn parse_const_state<W: SerializableSemiring>(i: &[u8]) -> IResult<&[u8], TempState<W>, NomCustomError<&[u8]>> {
+fn parse_const_state<W: SerializableSemiring>(
+    i: &[u8],
+) -> IResult<&[u8], TempState<W>, NomCustomError<&[u8]>> {
     let (i, final_weight) = W::parse_binary(i)?;
     let (i, _pos) = le_i32(i)?;
     let (i, ntrs) = le_i32(i)?;
@@ -63,7 +65,9 @@ fn parse_const_state<W: SerializableSemiring>(i: &[u8]) -> IResult<&[u8], TempSt
     ))
 }
 
-fn parse_const_fst<W: SerializableSemiring>(i: &[u8]) -> IResult<&[u8], VectorFst<W>, NomCustomError<&[u8]>> {
+fn parse_const_fst<W: SerializableSemiring>(
+    i: &[u8],
+) -> IResult<&[u8], VectorFst<W>, NomCustomError<&[u8]>> {
     let stream_len = i.len();
 
     let (mut i, hdr) = FstHeader::parse(

--- a/rustfst/src/fst_impls/vector_fst/serializable_fst.rs
+++ b/rustfst/src/fst_impls/vector_fst/serializable_fst.rs
@@ -16,10 +16,10 @@ use crate::fst_traits::{CoreFst, ExpandedFst, Fst, MutableFst, SerializableFst};
 use crate::parsers::bin_fst::fst_header::{FstFlags, FstHeader, OpenFstString, FST_MAGIC_NUMBER};
 use crate::parsers::bin_fst::utils_parsing::{parse_final_weight, parse_fst_tr, parse_start_state};
 use crate::parsers::bin_fst::utils_serialization::{write_bin_i32, write_bin_i64};
+use crate::parsers::nom_utils::NomCustomError;
 use crate::parsers::text_fst::ParsedTextFst;
 use crate::semirings::SerializableSemiring;
 use crate::{Tr, Trs, TrsVec, EPS_LABEL};
-use crate::parsers::nom_utils::NomCustomError;
 
 impl<W: SerializableSemiring> SerializableFst<W> for VectorFst<W> {
     fn fst_type() -> String {
@@ -136,7 +136,9 @@ struct Transition {
     nextstate: i32,
 }
 
-fn parse_vector_fst_state<W: SerializableSemiring>(i: &[u8]) -> IResult<&[u8], VectorFstState<W>, NomCustomError<&[u8]>> {
+fn parse_vector_fst_state<W: SerializableSemiring>(
+    i: &[u8],
+) -> IResult<&[u8], VectorFstState<W>, NomCustomError<&[u8]>> {
     let (i, final_weight) = W::parse_binary(i)?;
     let (i, num_trs) = le_i64(i)?;
     let (i, trs) = count(parse_fst_tr, num_trs as usize)(i)?;
@@ -153,7 +155,9 @@ fn parse_vector_fst_state<W: SerializableSemiring>(i: &[u8]) -> IResult<&[u8], V
     ))
 }
 
-fn parse_vector_fst<W: SerializableSemiring>(i: &[u8]) -> IResult<&[u8], VectorFst<W>, NomCustomError<&[u8]>> {
+fn parse_vector_fst<W: SerializableSemiring>(
+    i: &[u8],
+) -> IResult<&[u8], VectorFst<W>, NomCustomError<&[u8]>> {
     let (i, header) = FstHeader::parse(
         i,
         VECTOR_MIN_FILE_VERSION,

--- a/rustfst/src/fst_impls/vector_fst/serializable_fst.rs
+++ b/rustfst/src/fst_impls/vector_fst/serializable_fst.rs
@@ -19,6 +19,7 @@ use crate::parsers::bin_fst::utils_serialization::{write_bin_i32, write_bin_i64}
 use crate::parsers::text_fst::ParsedTextFst;
 use crate::semirings::SerializableSemiring;
 use crate::{Tr, Trs, TrsVec, EPS_LABEL};
+use crate::parsers::nom_utils::NomCustomError;
 
 impl<W: SerializableSemiring> SerializableFst<W> for VectorFst<W> {
     fn fst_type() -> String {
@@ -135,7 +136,7 @@ struct Transition {
     nextstate: i32,
 }
 
-fn parse_vector_fst_state<W: SerializableSemiring>(i: &[u8]) -> IResult<&[u8], VectorFstState<W>> {
+fn parse_vector_fst_state<W: SerializableSemiring>(i: &[u8]) -> IResult<&[u8], VectorFstState<W>, NomCustomError<&[u8]>> {
     let (i, final_weight) = W::parse_binary(i)?;
     let (i, num_trs) = le_i64(i)?;
     let (i, trs) = count(parse_fst_tr, num_trs as usize)(i)?;
@@ -152,7 +153,7 @@ fn parse_vector_fst_state<W: SerializableSemiring>(i: &[u8]) -> IResult<&[u8], V
     ))
 }
 
-fn parse_vector_fst<W: SerializableSemiring>(i: &[u8]) -> IResult<&[u8], VectorFst<W>> {
+fn parse_vector_fst<W: SerializableSemiring>(i: &[u8]) -> IResult<&[u8], VectorFst<W>, NomCustomError<&[u8]>> {
     let (i, header) = FstHeader::parse(
         i,
         VECTOR_MIN_FILE_VERSION,

--- a/rustfst/src/parsers/bin_fst/fst_header.rs
+++ b/rustfst/src/parsers/bin_fst/fst_header.rs
@@ -12,9 +12,9 @@ use crate::parsers::bin_fst::utils_serialization::{
     write_bin_i32, write_bin_i64, write_bin_u32, write_bin_u64,
 };
 use crate::parsers::bin_symt::nom_parser::{parse_symbol_table_bin, write_bin_symt};
+use crate::parsers::nom_utils::NomCustomError;
 use crate::SymbolTable;
 use std::sync::Arc;
-use crate::parsers::nom_utils::NomCustomError;
 
 // Identifies stream data as an FST (and its endianity).
 pub(crate) static FST_MAGIC_NUMBER: i32 = 2_125_659_606;
@@ -48,7 +48,10 @@ pub(crate) struct OpenFstString {
     s: String,
 }
 
-fn optionally_parse_symt(i: &[u8], parse_symt: bool) -> IResult<&[u8], Option<SymbolTable>, NomCustomError<&[u8]>> {
+fn optionally_parse_symt(
+    i: &[u8],
+    parse_symt: bool,
+) -> IResult<&[u8], Option<SymbolTable>, NomCustomError<&[u8]>> {
     if parse_symt {
         let (i, symt) = parse_symbol_table_bin(i)?;
         Ok((i, Some(symt)))

--- a/rustfst/src/parsers/bin_fst/utils_parsing.rs
+++ b/rustfst/src/parsers/bin_fst/utils_parsing.rs
@@ -1,11 +1,11 @@
 use nom::number::complete::le_i32;
 use nom::IResult;
 
+use crate::parsers::nom_utils::NomCustomError;
 use crate::semirings::SerializableSemiring;
 use crate::StateId;
 use crate::Tr;
 use crate::NO_STATE_ID;
-use crate::parsers::nom_utils::NomCustomError;
 
 #[inline]
 pub(crate) fn parse_start_state(s: i64) -> Option<StateId> {
@@ -27,7 +27,9 @@ pub(crate) fn parse_final_weight<W: SerializableSemiring>(weight: W) -> Option<W
     }
 }
 
-pub(crate) fn parse_fst_tr<W: SerializableSemiring>(i: &[u8]) -> IResult<&[u8], Tr<W>, NomCustomError<&[u8]>> {
+pub(crate) fn parse_fst_tr<W: SerializableSemiring>(
+    i: &[u8],
+) -> IResult<&[u8], Tr<W>, NomCustomError<&[u8]>> {
     let (i, ilabel) = le_i32(i)?;
     let (i, olabel) = le_i32(i)?;
     let (i, weight) = W::parse_binary(i)?;

--- a/rustfst/src/parsers/bin_fst/utils_parsing.rs
+++ b/rustfst/src/parsers/bin_fst/utils_parsing.rs
@@ -5,6 +5,7 @@ use crate::semirings::SerializableSemiring;
 use crate::StateId;
 use crate::Tr;
 use crate::NO_STATE_ID;
+use crate::parsers::nom_utils::NomCustomError;
 
 #[inline]
 pub(crate) fn parse_start_state(s: i64) -> Option<StateId> {
@@ -26,7 +27,7 @@ pub(crate) fn parse_final_weight<W: SerializableSemiring>(weight: W) -> Option<W
     }
 }
 
-pub(crate) fn parse_fst_tr<W: SerializableSemiring>(i: &[u8]) -> IResult<&[u8], Tr<W>> {
+pub(crate) fn parse_fst_tr<W: SerializableSemiring>(i: &[u8]) -> IResult<&[u8], Tr<W>, NomCustomError<&[u8]>> {
     let (i, ilabel) = le_i32(i)?;
     let (i, olabel) = le_i32(i)?;
     let (i, weight) = W::parse_binary(i)?;

--- a/rustfst/src/parsers/bin_symt/nom_parser.rs
+++ b/rustfst/src/parsers/bin_symt/nom_parser.rs
@@ -5,10 +5,11 @@ use nom::IResult;
 
 use crate::parsers::bin_fst::fst_header::OpenFstString;
 use crate::parsers::bin_fst::utils_serialization::{write_bin_i32, write_bin_i64};
+use crate::parsers::nom_utils::NomCustomError;
 use crate::SymbolTable;
 use anyhow::Result;
+use bitflags::_core::hash::BuildHasher;
 use std::io::Write;
-use crate::parsers::nom_utils::NomCustomError;
 
 static SYMBOL_TABLE_MAGIC_NUMBER: i32 = 2_125_658_996;
 
@@ -18,7 +19,9 @@ fn parse_row_symt(i: &[u8]) -> IResult<&[u8], (i64, OpenFstString), NomCustomErr
     Ok((i, (key, symbol)))
 }
 
-pub(crate) fn parse_symbol_table_bin(i: &[u8]) -> IResult<&[u8], SymbolTable, NomCustomError<&[u8]>> {
+pub(crate) fn parse_symbol_table_bin(
+    i: &[u8],
+) -> IResult<&[u8], SymbolTable, NomCustomError<&[u8]>> {
     let (i, _magic_number) = verify(le_i32, |v| *v == SYMBOL_TABLE_MAGIC_NUMBER)(i)?;
     let (i, _name) = OpenFstString::parse(i)?;
     let (i, _available_key) = le_i64(i)?;
@@ -31,14 +34,17 @@ pub(crate) fn parse_symbol_table_bin(i: &[u8]) -> IResult<&[u8], SymbolTable, No
         if inserted_label != key as usize {
             return Err(nom::Err::Error(NomCustomError::SymbolTableError(
                 format!("SymbolTable must contain increasing labels with no hole. Expected : {} and Got : {}", inserted_label, key)
-            )))
+            )));
         }
     }
 
     Ok((i, symt))
 }
 
-pub(crate) fn write_bin_symt<W: Write>(file: &mut W, symt: &SymbolTable) -> Result<()> {
+pub(crate) fn write_bin_symt<W: Write, H: BuildHasher>(
+    file: &mut W,
+    symt: &SymbolTable<H>,
+) -> Result<()> {
     write_bin_i32(file, SYMBOL_TABLE_MAGIC_NUMBER)?;
     OpenFstString::new("rustfst_symboltable").write(file)?;
     // TODO: Might not be available

--- a/rustfst/src/parsers/bin_symt/nom_parser.rs
+++ b/rustfst/src/parsers/bin_symt/nom_parser.rs
@@ -26,7 +26,10 @@ pub(crate) fn parse_symbol_table_bin(i: &[u8]) -> IResult<&[u8], SymbolTable> {
 
     let mut symt = SymbolTable::empty();
     for (key, symbol) in pairs_idx_symbols.into_iter() {
-        symt.add_symbol_key(symbol, key as usize);
+        let inserted_label = symt.add_symbol(symbol);
+        if inserted_label != key as usize {
+            bail!("SymbolTable must contain increasing labels with no hole. Expected : {} and Got : {}", inserted_label, key)
+        }
     }
 
     Ok((i, symt))
@@ -40,7 +43,7 @@ pub(crate) fn write_bin_symt<W: Write>(file: &mut W, symt: &SymbolTable) -> Resu
     write_bin_i64(file, symt.len() as i64)?;
     for (label, symbol) in symt.iter() {
         OpenFstString::new(symbol).write(file)?;
-        write_bin_i64(file, *label as i64)?;
+        write_bin_i64(file, label as i64)?;
     }
 
     Ok(())

--- a/rustfst/src/parsers/bin_symt/nom_parser.rs
+++ b/rustfst/src/parsers/bin_symt/nom_parser.rs
@@ -8,23 +8,34 @@ use crate::parsers::bin_fst::utils_serialization::{write_bin_i32, write_bin_i64}
 use crate::SymbolTable;
 use anyhow::Result;
 use std::io::Write;
+use crate::parsers::nom_utils::NomCustomError;
 
 static SYMBOL_TABLE_MAGIC_NUMBER: i32 = 2_125_658_996;
 
-fn parse_row_symt(i: &[u8]) -> IResult<&[u8], (i64, OpenFstString)> {
+fn parse_row_symt(i: &[u8]) -> IResult<&[u8], (i64, OpenFstString), NomCustomError<&[u8]>> {
     let (i, symbol) = OpenFstString::parse(i)?;
     let (i, key) = le_i64(i)?;
     Ok((i, (key, symbol)))
 }
 
-pub(crate) fn parse_symbol_table_bin(i: &[u8]) -> IResult<&[u8], Vec<(i64, OpenFstString)>> {
+pub(crate) fn parse_symbol_table_bin(i: &[u8]) -> IResult<&[u8], SymbolTable, NomCustomError<&[u8]>> {
     let (i, _magic_number) = verify(le_i32, |v| *v == SYMBOL_TABLE_MAGIC_NUMBER)(i)?;
     let (i, _name) = OpenFstString::parse(i)?;
     let (i, _available_key) = le_i64(i)?;
     let (i, num_symbols) = le_i64(i)?;
     let (i, pairs_idx_symbols) = count(parse_row_symt, num_symbols as usize)(i)?;
 
-    Ok((i, pairs_idx_symbols))
+    let mut symt = SymbolTable::empty();
+    for (key, symbol) in pairs_idx_symbols.into_iter() {
+        let inserted_label = symt.add_symbol(symbol);
+        if inserted_label != key as usize {
+            return Err(nom::Err::Error(NomCustomError::SymbolTableError(
+                format!("SymbolTable must contain increasing labels with no hole. Expected : {} and Got : {}", inserted_label, key)
+            )))
+        }
+    }
+
+    Ok((i, symt))
 }
 
 pub(crate) fn write_bin_symt<W: Write>(file: &mut W, symt: &SymbolTable) -> Result<()> {

--- a/rustfst/src/parsers/nom_utils.rs
+++ b/rustfst/src/parsers/nom_utils.rs
@@ -3,6 +3,25 @@ use nom::character::complete::digit1;
 use nom::combinator::map_res;
 use nom::IResult;
 
+use nom::error::ErrorKind;
+use nom::error::ParseError;
+
+#[derive(Debug, PartialEq)]
+pub enum NomCustomError<I> {
+    SymbolTableError(String),
+    Nom(I, ErrorKind),
+}
+
+impl<I> ParseError<I> for NomCustomError<I> {
+    fn from_error_kind(input: I, kind: ErrorKind) -> Self {
+        NomCustomError::Nom(input, kind)
+    }
+
+    fn append(_: I, _: ErrorKind, other: Self) -> Self {
+        other
+    }
+}
+
 pub fn num(i: &str) -> IResult<&str, usize> {
     map_res(digit1, |s: &str| s.parse())(i)
 }

--- a/rustfst/src/semirings/gallic_weight.rs
+++ b/rustfst/src/semirings/gallic_weight.rs
@@ -7,6 +7,7 @@ use std::marker::PhantomData;
 use anyhow::Result;
 use nom::IResult;
 
+use crate::parsers::nom_utils::NomCustomError;
 use crate::semirings::Semiring;
 #[cfg(test)]
 use crate::semirings::TropicalWeight;
@@ -16,7 +17,6 @@ use crate::semirings::{
 };
 use crate::semirings::{ProductWeight, ReverseBack};
 use crate::Label;
-use crate::parsers::nom_utils::NomCustomError;
 
 /// Product of StringWeightLeft and an arbitrary weight.
 #[derive(PartialOrd, PartialEq, Eq, Clone, Hash, Debug)]

--- a/rustfst/src/semirings/gallic_weight.rs
+++ b/rustfst/src/semirings/gallic_weight.rs
@@ -16,6 +16,7 @@ use crate::semirings::{
 };
 use crate::semirings::{ProductWeight, ReverseBack};
 use crate::Label;
+use crate::parsers::nom_utils::NomCustomError;
 
 /// Product of StringWeightLeft and an arbitrary weight.
 #[derive(PartialOrd, PartialEq, Eq, Clone, Hash, Debug)]
@@ -226,7 +227,7 @@ macro_rules! gallic_weight {
                 }
             }
 
-            fn parse_binary(i: &[u8]) -> IResult<&[u8], Self> {
+            fn parse_binary(i: &[u8]) -> IResult<&[u8], Self, NomCustomError<&[u8]>> {
                 let (i, w) = ProductWeight::<$string_weight, W>::parse_binary(i)?;
                 Ok((i, Self(w)))
             }
@@ -481,7 +482,7 @@ impl<W: SerializableSemiring> SerializableSemiring for GallicWeight<W> {
         "gallic".to_string()
     }
 
-    fn parse_binary(i: &[u8]) -> IResult<&[u8], Self> {
+    fn parse_binary(i: &[u8]) -> IResult<&[u8], Self, NomCustomError<&[u8]>> {
         let (i, w) = UnionWeight::<
             GallicWeightRestrict<W>,
             GallicUnionWeightOption<GallicWeightRestrict<W>>,

--- a/rustfst/src/semirings/log_weight.rs
+++ b/rustfst/src/semirings/log_weight.rs
@@ -15,6 +15,7 @@ use crate::semirings::{
     StarSemiring, WeaklyDivisibleSemiring, WeightQuantize,
 };
 use crate::KDELTA;
+use crate::parsers::nom_utils::NomCustomError;
 
 /// Log semiring: (log(e^-x + e^-y), +, inf, 0).
 #[derive(Clone, Debug, PartialOrd, Default, Copy, Eq)]
@@ -143,7 +144,7 @@ impl SerializableSemiring for LogWeight {
         "log".to_string()
     }
 
-    fn parse_binary(i: &[u8]) -> IResult<&[u8], Self> {
+    fn parse_binary(i: &[u8]) -> IResult<&[u8], Self, NomCustomError<&[u8]>> {
         let (i, weight) = le_f32(i)?;
         Ok((i, Self::new(weight)))
     }

--- a/rustfst/src/semirings/log_weight.rs
+++ b/rustfst/src/semirings/log_weight.rs
@@ -9,13 +9,13 @@ use nom::IResult;
 use ordered_float::OrderedFloat;
 
 use crate::parsers::bin_fst::utils_serialization::write_bin_f32;
+use crate::parsers::nom_utils::NomCustomError;
 use crate::semirings::utils_float::float_approx_equal;
 use crate::semirings::{
     CompleteSemiring, DivideType, ReverseBack, Semiring, SemiringProperties, SerializableSemiring,
     StarSemiring, WeaklyDivisibleSemiring, WeightQuantize,
 };
 use crate::KDELTA;
-use crate::parsers::nom_utils::NomCustomError;
 
 /// Log semiring: (log(e^-x + e^-y), +, inf, 0).
 #[derive(Clone, Debug, PartialOrd, Default, Copy, Eq)]

--- a/rustfst/src/semirings/probability_weight.rs
+++ b/rustfst/src/semirings/probability_weight.rs
@@ -9,13 +9,13 @@ use nom::IResult;
 use ordered_float::OrderedFloat;
 
 use crate::parsers::bin_fst::utils_serialization::write_bin_f32;
+use crate::parsers::nom_utils::NomCustomError;
 use crate::semirings::utils_float::float_approx_equal;
 use crate::semirings::{
     CompleteSemiring, DivideType, ReverseBack, Semiring, SemiringProperties, SerializableSemiring,
     StarSemiring, WeaklyDivisibleSemiring, WeightQuantize,
 };
 use crate::KDELTA;
-use crate::parsers::nom_utils::NomCustomError;
 
 /// Probability semiring: (x, +, 0.0, 1.0).
 #[derive(Clone, Debug, PartialOrd, Default, Copy, Eq)]

--- a/rustfst/src/semirings/probability_weight.rs
+++ b/rustfst/src/semirings/probability_weight.rs
@@ -15,6 +15,7 @@ use crate::semirings::{
     StarSemiring, WeaklyDivisibleSemiring, WeightQuantize,
 };
 use crate::KDELTA;
+use crate::parsers::nom_utils::NomCustomError;
 
 /// Probability semiring: (x, +, 0.0, 1.0).
 #[derive(Clone, Debug, PartialOrd, Default, Copy, Eq)]
@@ -101,7 +102,7 @@ impl SerializableSemiring for ProbabilityWeight {
         "probability".to_string()
     }
 
-    fn parse_binary(i: &[u8]) -> IResult<&[u8], Self> {
+    fn parse_binary(i: &[u8]) -> IResult<&[u8], Self, NomCustomError<&[u8]>> {
         let (i, weight) = le_f32(i)?;
         Ok((i, Self::new(weight)))
     }

--- a/rustfst/src/semirings/product_weight.rs
+++ b/rustfst/src/semirings/product_weight.rs
@@ -6,13 +6,13 @@ use std::io::Write;
 use anyhow::Result;
 use nom::IResult;
 
+use crate::parsers::nom_utils::NomCustomError;
 use crate::semirings::{
     DivideType, ReverseBack, Semiring, SemiringProperties, SerializableSemiring,
     WeaklyDivisibleSemiring, WeightQuantize,
 };
 #[cfg(test)]
 use crate::semirings::{LogWeight, TropicalWeight};
-use crate::parsers::nom_utils::NomCustomError;
 
 /// Product semiring: W1 * W2.
 #[derive(Debug, Eq, PartialOrd, PartialEq, Clone, Default, Hash)]

--- a/rustfst/src/semirings/product_weight.rs
+++ b/rustfst/src/semirings/product_weight.rs
@@ -12,6 +12,7 @@ use crate::semirings::{
 };
 #[cfg(test)]
 use crate::semirings::{LogWeight, TropicalWeight};
+use crate::parsers::nom_utils::NomCustomError;
 
 /// Product semiring: W1 * W2.
 #[derive(Debug, Eq, PartialOrd, PartialEq, Clone, Default, Hash)]
@@ -185,7 +186,7 @@ where
         format!("{}_X_{}", W1::weight_type(), W2::weight_type())
     }
 
-    fn parse_binary(i: &[u8]) -> IResult<&[u8], Self> {
+    fn parse_binary(i: &[u8]) -> IResult<&[u8], Self, NomCustomError<&[u8]>> {
         let (i, weight_1) = W1::parse_binary(i)?;
         let (i, weight_2) = W2::parse_binary(i)?;
         Ok((i, Self::new((weight_1, weight_2))))

--- a/rustfst/src/semirings/semiring.rs
+++ b/rustfst/src/semirings/semiring.rs
@@ -5,10 +5,10 @@ use std::hash::Hash;
 
 use bitflags::bitflags;
 
+use crate::parsers::nom_utils::NomCustomError;
 use anyhow::Result;
 use nom::IResult;
 use std::io::Write;
-use crate::parsers::nom_utils::NomCustomError;
 
 bitflags! {
     /// Properties verified by the Semiring.

--- a/rustfst/src/semirings/semiring.rs
+++ b/rustfst/src/semirings/semiring.rs
@@ -8,6 +8,7 @@ use bitflags::bitflags;
 use anyhow::Result;
 use nom::IResult;
 use std::io::Write;
+use crate::parsers::nom_utils::NomCustomError;
 
 bitflags! {
     /// Properties verified by the Semiring.
@@ -175,7 +176,7 @@ macro_rules! partial_eq_and_hash_f32 {
 
 pub trait SerializableSemiring: Semiring + Display {
     fn weight_type() -> String;
-    fn parse_binary(i: &[u8]) -> IResult<&[u8], Self>;
+    fn parse_binary(i: &[u8]) -> IResult<&[u8], Self, NomCustomError<&[u8]>>;
     fn write_binary<F: Write>(&self, file: &mut F) -> Result<()>;
 
     fn parse_text(i: &str) -> IResult<&str, Self>;

--- a/rustfst/src/semirings/string_weight.rs
+++ b/rustfst/src/semirings/string_weight.rs
@@ -10,7 +10,7 @@ use nom::number::complete::le_i32;
 use nom::IResult;
 
 use crate::parsers::bin_fst::utils_serialization::write_bin_i32;
-use crate::parsers::nom_utils::num;
+use crate::parsers::nom_utils::{num, NomCustomError};
 use crate::semirings::string_variant::StringWeightVariant;
 use crate::semirings::{
     DivideType, ReverseBack, Semiring, SemiringProperties, SerializableSemiring,
@@ -263,7 +263,7 @@ macro_rules! string_semiring {
                 }
             }
 
-            fn parse_binary(i: &[u8]) -> IResult<&[u8], Self> {
+            fn parse_binary(i: &[u8]) -> IResult<&[u8], Self, NomCustomError<&[u8]>> {
                 let (i, n) = le_i32(i)?;
                 let (i, labels) = count(le_i32, n as usize)(i)?;
                 // Check for infinity

--- a/rustfst/src/semirings/tropical_weight.rs
+++ b/rustfst/src/semirings/tropical_weight.rs
@@ -9,6 +9,7 @@ use nom::IResult;
 use ordered_float::OrderedFloat;
 
 use crate::parsers::bin_fst::utils_serialization::write_bin_f32;
+use crate::parsers::nom_utils::NomCustomError;
 use crate::semirings::semiring::SerializableSemiring;
 use crate::semirings::utils_float::float_approx_equal;
 use crate::semirings::{
@@ -16,7 +17,6 @@ use crate::semirings::{
     WeaklyDivisibleSemiring, WeightQuantize,
 };
 use crate::KDELTA;
-use crate::parsers::nom_utils::NomCustomError;
 
 /// Tropical semiring: (min, +, inf, 0).
 #[derive(Clone, Debug, PartialOrd, Default, Copy, Eq)]

--- a/rustfst/src/semirings/tropical_weight.rs
+++ b/rustfst/src/semirings/tropical_weight.rs
@@ -16,6 +16,7 @@ use crate::semirings::{
     WeaklyDivisibleSemiring, WeightQuantize,
 };
 use crate::KDELTA;
+use crate::parsers::nom_utils::NomCustomError;
 
 /// Tropical semiring: (min, +, inf, 0).
 #[derive(Clone, Debug, PartialOrd, Default, Copy, Eq)]
@@ -135,7 +136,7 @@ impl SerializableSemiring for TropicalWeight {
         "tropical".to_string()
     }
 
-    fn parse_binary(i: &[u8]) -> IResult<&[u8], Self> {
+    fn parse_binary(i: &[u8]) -> IResult<&[u8], Self, NomCustomError<&[u8]>> {
         let (i, weight) = le_f32(i)?;
         Ok((i, Self::new(weight)))
     }

--- a/rustfst/src/semirings/union_weight.rs
+++ b/rustfst/src/semirings/union_weight.rs
@@ -18,6 +18,7 @@ use crate::semirings::{
     DivideType, ReverseBack, Semiring, SemiringProperties, SerializableSemiring,
     WeaklyDivisibleSemiring, WeightQuantize,
 };
+use crate::parsers::nom_utils::NomCustomError;
 
 pub trait UnionWeightOption<W: Semiring>:
     Debug + Hash + Clone + PartialOrd + Eq + Sync + 'static
@@ -301,7 +302,7 @@ where
         format!("{}_union", W::weight_type())
     }
 
-    fn parse_binary(i: &[u8]) -> IResult<&[u8], Self> {
+    fn parse_binary(i: &[u8]) -> IResult<&[u8], Self, NomCustomError<&[u8]>> {
         let (i, n) = le_i32(i)?;
         let (i, labels) = count(W::parse_binary, n as usize)(i)?;
         Ok((i, Self::new(labels)))

--- a/rustfst/src/semirings/union_weight.rs
+++ b/rustfst/src/semirings/union_weight.rs
@@ -14,11 +14,11 @@ use nom::number::complete::le_i32;
 use nom::IResult;
 
 use crate::parsers::bin_fst::utils_serialization::write_bin_i32;
+use crate::parsers::nom_utils::NomCustomError;
 use crate::semirings::{
     DivideType, ReverseBack, Semiring, SemiringProperties, SerializableSemiring,
     WeaklyDivisibleSemiring, WeightQuantize,
 };
-use crate::parsers::nom_utils::NomCustomError;
 
 pub trait UnionWeightOption<W: Semiring>:
     Debug + Hash + Clone + PartialOrd + Eq + Sync + 'static

--- a/rustfst/src/symbol_table.rs
+++ b/rustfst/src/symbol_table.rs
@@ -86,9 +86,9 @@ impl SymbolTable {
 
 impl<H: BuildHasher> SymbolTable<H> {
     pub fn with_hasher(hasher_builder: H) -> Self {
-        Self {
-            bimap: BiHashMapString::with_hasher(hasher_builder),
-        }
+        let mut bimap = BiHashMapString::with_hasher(hasher_builder);
+        bimap.get_id_or_insert(EPS_SYMBOL);
+        Self { bimap }
     }
 
     pub fn is_empty(&self) -> bool {


### PR DESCRIPTION
- Added a `BuildHasher` generic parameter to `SymbolTable` as well as a method `with_hasher`.
- Change internal implementation of `SymbolTable`: now used a Vec and a `HashMap` instead of two `HashMap`s. As a result, doesn't support `SymbolTable` with hole anymore.