### PR TITLE
Add serialization support to FstAddOn

### DIFF
--- a/rustfst/src/algorithms/compose/add_on.rs
+++ b/rustfst/src/algorithms/compose/add_on.rs
@@ -20,11 +20,12 @@ pub struct FstAddOn<W, F, T>
     pub(crate) fst: F,
     pub(crate) add_on: T,
     w: PhantomData<W>,
+    fst_type: String
 }
 
 impl<W: Semiring, F: Fst<W>, T> FstAddOn<W, F, T> {
-    pub fn new(fst: F, add_on: T) -> Self {
-        Self { fst, add_on, w: PhantomData }
+    pub fn new(fst: F, add_on: T, fst_type: String) -> Self {
+        Self { fst, add_on, w: PhantomData, fst_type }
     }
 
     pub fn fst(&self) -> &F {

--- a/rustfst/src/algorithms/compose/interval_set.rs
+++ b/rustfst/src/algorithms/compose/interval_set.rs
@@ -150,6 +150,23 @@ pub struct IntervalSet {
     pub(crate) intervals: VectorIntervalStore,
 }
 
+impl SerializeBinary for IntervalSet {
+    fn parse_binary(i: &[u8]) -> IResult<&[u8], Self, NomCustomError<&[u8]>> {
+        let (i, intervals) = VectorIntervalStore::parse_binary(i)?;
+        Ok((
+            i,
+            IntervalSet {
+                intervals
+            },
+        ))
+    }
+
+    fn write_binary<WB: Write>(&self, writer: &mut WB) -> anyhow::Result<()> {
+        self.intervals.write_binary(writer)?;
+        Ok(())
+    }
+}
+
 impl IntervalSet {
     pub fn len(&self) -> usize {
         self.intervals.len()

--- a/rustfst/src/algorithms/compose/matcher_fst.rs
+++ b/rustfst/src/algorithms/compose/matcher_fst.rs
@@ -58,8 +58,12 @@ where
         LabelLookAheadRelabeler::init(&mut fst, &mut add_on)?;
 
         let add_on = (add_on.0.map(Arc::new), add_on.1.map(Arc::new));
-
-        let fst_add_on = FstAddOn::new(fst, add_on);
+        let fst_type = if add_on.0.is_some() {
+            "ilabel_lookahead".to_string()
+        } else {
+            "olabel_lookahead".to_string()
+        };
+        let fst_add_on = FstAddOn::new(fst, add_on, fst_type);
         Ok(Self {
             fst_add_on,
             matcher: PhantomData,
@@ -81,8 +85,12 @@ where
         LabelLookAheadRelabeler::relabel(fst2, &mut add_on, relabel_input)?;
 
         let add_on = (add_on.0.map(Arc::new), add_on.1.map(Arc::new));
-
-        let fst_add_on = FstAddOn::new(fst, add_on);
+        let fst_type = if add_on.0.is_some() {
+            "ilabel_lookahead".to_string()
+        } else {
+            "olabel_lookahead".to_string()
+        };
+        let fst_add_on = FstAddOn::new(fst, add_on, fst_type);
         Ok(Self {
             fst_add_on,
             matcher: PhantomData,

--- a/rustfst/src/algorithms/compose/matcher_fst.rs
+++ b/rustfst/src/algorithms/compose/matcher_fst.rs
@@ -42,6 +42,23 @@ impl<W: Semiring, F: Fst<W>, B, M, T> MatcherFst<W, F, B, M, T> {
     }
 }
 
+impl<W, F, B, M> MatcherFst<W, F, B, M, M::MatcherData>
+where
+    W: Semiring,
+    F: Fst<W>,
+    B: Borrow<F>,
+    M: LookaheadMatcher<W, F, B, MatcherData = LabelReachableData>,
+{
+    pub fn new_with_fst_add_on(fst_add_on: FstAddOn<W, F, (Option<Arc<M::MatcherData>>, Option<Arc<M::MatcherData>>)>) -> Result<Self> {
+        Ok(Self {
+            fst_add_on,
+            matcher: PhantomData,
+            w: PhantomData
+        })
+    }
+
+}
+
 // TODO: To be generalized
 impl<W, F, B, M> MatcherFst<W, F, B, M, M::MatcherData>
 where

--- a/rustfst/src/fst_impls/const_fst/serializable_fst.rs
+++ b/rustfst/src/fst_impls/const_fst/serializable_fst.rs
@@ -32,7 +32,7 @@ impl<W: SerializableSemiring> SerializeBinary for ConstFst<W> {
         let (mut i, hdr) = FstHeader::parse(
             i,
             CONST_MIN_FILE_VERSION,
-            ConstFst::<W>::fst_type(),
+            Some(ConstFst::<W>::fst_type()),
             Tr::<W>::tr_type(),
         )?;
         let aligned = hdr.version == CONST_ALIGNED_FILE_VERSION;

--- a/rustfst/src/fst_impls/const_fst/serializable_fst.rs
+++ b/rustfst/src/fst_impls/const_fst/serializable_fst.rs
@@ -1,9 +1,6 @@
-use std::fs::{read, File};
-use std::io::BufWriter;
-use std::path::Path;
+use std::io::Write;
 use std::sync::Arc;
 
-use anyhow::Context;
 use anyhow::Result;
 use itertools::Itertools;
 use nom::bytes::complete::take;
@@ -22,34 +19,52 @@ use crate::parsers::bin_fst::utils_parsing::{
     parse_bin_fst_tr, parse_final_weight, parse_start_state,
 };
 use crate::parsers::nom_utils::NomCustomError;
-use crate::parsers::parse_bin_i32;
+use crate::parsers::{parse_bin_i32, SerializeBinary};
 use crate::parsers::text_fst::ParsedTextFst;
 use crate::parsers::write_bin_i32;
 use crate::semirings::SerializableSemiring;
 use crate::{Tr, EPS_LABEL};
 
-impl<W: SerializableSemiring> SerializableFst<W> for ConstFst<W> {
-    fn fst_type() -> String {
-        "const".to_string()
+impl<W: SerializableSemiring> SerializeBinary for ConstFst<W> {
+    fn parse_binary(i: &[u8]) -> IResult<&[u8], Self, NomCustomError<&[u8]>> {
+        let stream_len = i.len();
+
+        let (mut i, hdr) = FstHeader::parse(
+            i,
+            CONST_MIN_FILE_VERSION,
+            ConstFst::<W>::fst_type(),
+            Tr::<W>::tr_type(),
+        )?;
+        let aligned = hdr.version == CONST_ALIGNED_FILE_VERSION;
+        let pos = stream_len - i.len();
+
+        // Align input
+        if aligned && hdr.num_states > 0 && pos % CONST_ARCH_ALIGNMENT > 0 {
+            i = take(CONST_ARCH_ALIGNMENT - (pos % CONST_ARCH_ALIGNMENT))(i)?.0;
+        }
+        let (mut i, const_states) = count(parse_const_state, hdr.num_states as usize)(i)?;
+        let pos = stream_len - i.len();
+
+        // Align input
+        if aligned && hdr.num_trs > 0 && pos % CONST_ARCH_ALIGNMENT > 0 {
+            i = take(CONST_ARCH_ALIGNMENT - (pos % CONST_ARCH_ALIGNMENT))(i)?.0;
+        }
+        let (i, const_trs) = count(parse_bin_fst_tr, hdr.num_trs as usize)(i)?;
+
+        Ok((
+            i,
+            ConstFst {
+                start: parse_start_state(hdr.start),
+                states: const_states,
+                trs: Arc::new(const_trs),
+                isymt: hdr.isymt,
+                osymt: hdr.osymt,
+                properties: FstProperties::from_bits_truncate(hdr.properties),
+            },
+        ))
     }
 
-    fn read<P: AsRef<Path>>(path_bin_fst: P) -> Result<Self> {
-        let data = read(path_bin_fst.as_ref()).with_context(|| {
-            format!(
-                "Can't open ConstFst binary file : {:?}",
-                path_bin_fst.as_ref()
-            )
-        })?;
-
-        let (_, parsed_fst) = parse_const_fst(&data)
-            .map_err(|_| format_err!("Error while parsing binary ConstFst"))?;
-
-        Ok(parsed_fst)
-    }
-
-    fn write<P: AsRef<Path>>(&self, path_bin_fst: P) -> Result<()> {
-        let mut file = BufWriter::new(File::create(path_bin_fst)?);
-
+    fn write_binary<WB: Write>(&self, writer: &mut WB) -> Result<()> {
         let mut flags = FstFlags::empty();
         if self.input_symbols().is_some() {
             flags |= FstFlags::HAS_ISYMBOLS;
@@ -72,27 +87,33 @@ impl<W: SerializableSemiring> SerializableFst<W> for ConstFst<W> {
             isymt: self.input_symbols().cloned(),
             osymt: self.output_symbols().cloned(),
         };
-        hdr.write(&mut file)?;
+        hdr.write(writer)?;
 
         let zero = W::zero();
         for const_state in &self.states {
             let f_weight = const_state.final_weight.as_ref().unwrap_or_else(|| &zero);
-            f_weight.write_binary(&mut file)?;
+            f_weight.write_binary(writer)?;
 
-            write_bin_i32(&mut file, const_state.pos as i32)?;
-            write_bin_i32(&mut file, const_state.ntrs as i32)?;
-            write_bin_i32(&mut file, const_state.niepsilons as i32)?;
-            write_bin_i32(&mut file, const_state.noepsilons as i32)?;
+            write_bin_i32(writer, const_state.pos as i32)?;
+            write_bin_i32(writer, const_state.ntrs as i32)?;
+            write_bin_i32(writer, const_state.niepsilons as i32)?;
+            write_bin_i32(writer, const_state.noepsilons as i32)?;
         }
 
         for tr in &*self.trs {
-            write_bin_i32(&mut file, tr.ilabel as i32)?;
-            write_bin_i32(&mut file, tr.olabel as i32)?;
-            tr.weight.write_binary(&mut file)?;
-            write_bin_i32(&mut file, tr.nextstate as i32)?;
+            write_bin_i32(writer, tr.ilabel as i32)?;
+            write_bin_i32(writer, tr.olabel as i32)?;
+            tr.weight.write_binary(writer)?;
+            write_bin_i32(writer, tr.nextstate as i32)?;
         }
 
         Ok(())
+    }
+}
+
+impl<W: SerializableSemiring> SerializableFst<W> for ConstFst<W> {
+    fn fst_type() -> String {
+        "const".to_string()
     }
 
     fn from_parsed_fst_text(mut parsed_fst_text: ParsedTextFst<W>) -> Result<Self> {
@@ -204,46 +225,6 @@ fn parse_const_state<W: SerializableSemiring>(
             ntrs: ntrs as usize,
             niepsilons: niepsilons as usize,
             noepsilons: noepsilons as usize,
-        },
-    ))
-}
-
-fn parse_const_fst<W: SerializableSemiring>(
-    i: &[u8],
-) -> IResult<&[u8], ConstFst<W>, NomCustomError<&[u8]>> {
-    let stream_len = i.len();
-
-    let (mut i, hdr) = FstHeader::parse(
-        i,
-        CONST_MIN_FILE_VERSION,
-        ConstFst::<W>::fst_type(),
-        Tr::<W>::tr_type(),
-    )?;
-    let aligned = hdr.version == CONST_ALIGNED_FILE_VERSION;
-    let pos = stream_len - i.len();
-
-    // Align input
-    if aligned && hdr.num_states > 0 && pos % CONST_ARCH_ALIGNMENT > 0 {
-        i = take(CONST_ARCH_ALIGNMENT - (pos % CONST_ARCH_ALIGNMENT))(i)?.0;
-    }
-    let (mut i, const_states) = count(parse_const_state, hdr.num_states as usize)(i)?;
-    let pos = stream_len - i.len();
-
-    // Align input
-    if aligned && hdr.num_trs > 0 && pos % CONST_ARCH_ALIGNMENT > 0 {
-        i = take(CONST_ARCH_ALIGNMENT - (pos % CONST_ARCH_ALIGNMENT))(i)?.0;
-    }
-    let (i, const_trs) = count(parse_bin_fst_tr, hdr.num_trs as usize)(i)?;
-
-    Ok((
-        i,
-        ConstFst {
-            start: parse_start_state(hdr.start),
-            states: const_states,
-            trs: Arc::new(const_trs),
-            isymt: hdr.isymt,
-            osymt: hdr.osymt,
-            properties: FstProperties::from_bits_truncate(hdr.properties),
         },
     ))
 }

--- a/rustfst/src/fst_impls/vector_fst/parse_const.rs
+++ b/rustfst/src/fst_impls/vector_fst/parse_const.rs
@@ -76,7 +76,7 @@ fn parse_const_fst<W: SerializableSemiring>(
         i,
         CONST_MIN_FILE_VERSION,
         // Intentional as the ConstFst file is being parsed.
-        ConstFst::<W>::fst_type(),
+        Some(ConstFst::<W>::fst_type()),
         Tr::<W>::tr_type(),
     )?;
     let aligned = hdr.version == CONST_ALIGNED_FILE_VERSION;

--- a/rustfst/src/fst_impls/vector_fst/serializable_fst.rs
+++ b/rustfst/src/fst_impls/vector_fst/serializable_fst.rs
@@ -27,7 +27,7 @@ impl<W: SerializableSemiring> SerializeBinary for VectorFst<W> {
         let (i, header) = FstHeader::parse(
             i,
             VECTOR_MIN_FILE_VERSION,
-            VectorFst::<W>::fst_type(),
+            Some(VectorFst::<W>::fst_type()),
             Tr::<W>::tr_type(),
         )?;
         let (i, states) = count(parse_vector_fst_state, header.num_states as usize)(i)?;

--- a/rustfst/src/parsers/bin_fst/fst_header.rs
+++ b/rustfst/src/parsers/bin_fst/fst_header.rs
@@ -159,6 +159,10 @@ impl OpenFstString {
         write_bin_i32(file, self.n)?;
         file.write_all(self.s.as_bytes()).map_err(|e| e.into())
     }
+
+    pub(crate) fn s(&self) -> &String {
+        &self.s
+    }
 }
 
 impl Into<String> for OpenFstString {

--- a/rustfst/src/parsers/bin_fst/fst_header.rs
+++ b/rustfst/src/parsers/bin_fst/fst_header.rs
@@ -70,12 +70,12 @@ impl FstHeader {
     pub(crate) fn parse<S1: AsRef<str>, S2: AsRef<str>>(
         i: &[u8],
         min_file_version: i32,
-        fst_loading_type: S1,
+        fst_loading_type: Option<S1>, // Do not verify if None
         tr_loading_type: S2,
     ) -> IResult<&[u8], FstHeader, NomCustomError<&[u8]>> {
         let (i, magic_number) = verify(parse_bin_i32, |v: &i32| *v == FST_MAGIC_NUMBER)(i)?;
         let (i, fst_type) = verify(OpenFstString::parse, |v| {
-            v.s.as_str() == fst_loading_type.as_ref()
+            fst_loading_type.is_none() || v.s.as_str() == fst_loading_type.as_ref().unwrap().as_ref()
         })(i)?;
         let (i, tr_type) = verify(OpenFstString::parse, |v| {
             v.s.as_str() == tr_loading_type.as_ref()

--- a/rustfst/src/parsers/utils_parsing.rs
+++ b/rustfst/src/parsers/utils_parsing.rs
@@ -32,3 +32,8 @@ pub fn parse_bin_f32(i: &[u8]) -> IResult<&[u8], f32, NomCustomError<&[u8]>> {
 pub fn parse_bin_u8(i: &[u8]) -> IResult<&[u8], u8, NomCustomError<&[u8]>> {
     le_u8(i)
 }
+
+#[inline]
+pub fn parse_bin_bool(i: &[u8]) -> IResult<&[u8], bool, NomCustomError<&[u8]>> {
+    le_u8(i).map(|(s, v)| (s, v != 0))
+}

--- a/rustfst/src/parsers/utils_serialization.rs
+++ b/rustfst/src/parsers/utils_serialization.rs
@@ -31,3 +31,8 @@ pub fn write_bin_f32<F: Write>(file: &mut F, i: f32) -> Result<()> {
 pub(crate) fn write_bin_u8<F: Write>(file: &mut F, i: u8) -> Result<()> {
     file.write_all(&i.to_le_bytes()).map_err(|e| e.into())
 }
+
+#[inline]
+pub(crate) fn write_bin_bool<F: Write>(file: &mut F, i: bool) -> Result<()> {
+    file.write_all(&((if i { 1u8 } else { 0u8 }).to_le_bytes())).map_err(|e| e.into())
+}


### PR DESCRIPTION
## Description

This PR adds the possibility to serialize/deserialize a `FstAddOn` from binary data. This makes it possible to load a lookahead FST (special `MatcherFst`) from binary data. 

## Changes

- Added `SerializeBinary` requirement for `SerializableFst` trait. This made it possible to read/write an FST from/to binary data slice, instead of a path.
- Added `SerializeBinary` for `IntInterval`, `VectorIntervalStore`, `IntervalSet` and `LabelReachableData`. These implementations are ported from relevant OpenFst implementations to make it compatible with files created by OpenFst. `Label` is assumed as 32 bit data, because OpenFst uses `int` for `Label`.
- Added `Fst<W>` requirement for `fst` field of `FstAddOn`. I think this is better to add this requirement by definition of the struct.
- Implemented `SerializeBinary` for `FstAddOn` with AddOnPair (`(Option<Arc<AO1>>, Option<Arc<AO2>>)`). For now, this seems to be the only variant of `FstAddOn` used in the project. More generic implementation may be added.
  - `fst_type` field is added to `FstAddOn` to implement this, OpenFst has a type name field in `AddOnImpl` as well. I have given names `{i,o}label_lookahead` to `FstAddOn` variables defined in `matcher_fst.rs`. Names are taken from OpenFst, and they seem compatible with the binary output of OpenFst.
- Finally, added new constructor to `MatcherFst` allowing to create it from already computed (or read) `FstAddOn`.

## Status

- These changes do not break any API currently available.
- Current tests of the project are not affected from these changes, and they pass as expected.
- I have tested this with a `olabel_lookahead` FST file created with OpenFst. I did not added a proper test yet. I think it may be necessary to add it.