### PR TITLE
Fix text symbol table parsing

### DIFF
--- a/rustfst/src/parsers/text_symt/nom_parser.rs
+++ b/rustfst/src/parsers/text_symt/nom_parser.rs
@@ -1,5 +1,5 @@
 use nom::bytes::complete::tag;
-use nom::character::complete::tab;
+use nom::character::complete::space1;
 use nom::multi::many0;
 use nom::sequence::terminated;
 use nom::IResult;
@@ -10,7 +10,7 @@ use crate::{Label, Symbol};
 
 fn row(i: &str) -> IResult<&str, (Symbol, Label)> {
     let (i, symbol) = word(i)?;
-    let (i, _) = tab(i)?;
+    let (i, _) = space1(i)?;
     let (i, label) = num(i)?;
     Ok((i, (symbol, label)))
 }


### PR DESCRIPTION
In order to be compliant with OpenFST symbol table text format, it is required to support single space character as a separator when parsing a textual symbol table.

See [here](https://github.com/mjansche/openfst/blob/5be570c4e84a5eae1325d8c6c43fdbba3683863e/src/lib/symbol-table.cc#L31):
```
DEFINE_string(fst_field_separator, "\t ", "Set of characters used as a separator between printed fields");
```