### PR TITLE
Fix `tr_unique` algorithm

### DIFF
--- a/rustfst-tests-data/fst_020/fst_020.h
+++ b/rustfst-tests-data/fst_020/fst_020.h
@@ -1,0 +1,67 @@
+#ifndef FST_020
+#define FST_020
+
+class FstTestData020 {
+public:
+    using MyArc = fst::StdArc;
+    using MyWeight = MyArc::Weight;
+    using MyFst = fst::VectorFst<MyArc>;
+
+    FstTestData020() {}
+
+    MyFst get_fst() const {
+        fst::VectorFst<MyArc> fst_0;
+        fst_0.AddState();
+        fst_0.AddState();
+        fst_0.SetStart(0);
+        fst_0.SetFinal(1, MyWeight(0.3));
+
+        fst_0.AddArc(0, MyArc(1, 2, MyWeight(1.0), 1));
+        fst_0.AddArc(0, MyArc(1, 2, MyWeight(2.0), 1));
+        fst_0.AddArc(0, MyArc(1, 2, MyWeight(1.0), 1));
+
+        return fst_0;
+    }
+
+    MyWeight get_weight_plus_mapper() const {
+        return MyWeight(1.5);
+    }
+
+    MyWeight get_weight_times_mapper() const {
+        return MyWeight(1.5);
+    }
+
+    fst::VectorFst<MyArc> get_fst_concat() const {
+        fst::VectorFst<MyArc> fst_2;
+        fst_2.AddState();
+        fst_2.AddState();
+        fst_2.AddState();
+        fst_2.SetStart(0);
+        fst_2.SetFinal(2, MyWeight(0.3));
+        fst_2.AddArc(0, MyArc(2, 12, MyWeight(1.2), 1));
+        fst_2.AddArc(0, MyArc(3, 1, MyWeight(2.2), 1));
+        fst_2.AddArc(1, MyArc(6, 3, MyWeight(2.3), 2));
+        fst_2.AddArc(1, MyArc(4, 2, MyWeight(1.7), 2));
+        return fst_2;
+    }
+
+    fst::VectorFst<MyArc> get_fst_union() const {
+        return get_fst_concat();
+    }
+
+    fst::VectorFst<MyArc> get_fst_compose() const {
+        fst::VectorFst<MyArc> fst_2;
+        fst_2.AddState();
+        fst_2.AddState();
+        fst_2.SetStart(0);
+        fst_2.SetFinal(1, MyWeight(1.2));
+        fst_2.AddArc(0, MyArc(4, 2, MyWeight(1.7), 1));
+        return fst_2;
+    }
+
+    MyWeight random_weight() const {
+        return MyWeight(custom_random_float());
+    }
+};
+
+#endif

--- a/rustfst-tests-data/main.cpp
+++ b/rustfst-tests-data/main.cpp
@@ -32,6 +32,7 @@
 #include "fst_017/fst_017.h"
 #include "fst_018/fst_018.h"
 #include "fst_019/fst_019.h"
+#include "fst_020/fst_020.h"
 
 #include "symt_000/symt_000.h"
 #include "symt_001/symt_001.h"
@@ -1348,4 +1349,5 @@ int main() {
     compute_fst_data(FstTestData017(), "fst_017");
     compute_fst_data(FstTestData018(), "fst_018");
     compute_fst_data(FstTestData019(), "fst_019");
+    compute_fst_data(FstTestData019(), "fst_020");
 }

--- a/rustfst/src/algorithms/minimize.rs
+++ b/rustfst/src/algorithms/minimize.rs
@@ -359,9 +359,11 @@ impl AcyclicMinimizer {
                     NO_STATE_ID
                 });
             }
-            pairs.extend(it_partition.drain(..).map(|s| {
-                (s, *equiv_classes.get(&(s as StateId)).unwrap())
-            }));
+            pairs.extend(
+                it_partition
+                    .drain(..)
+                    .map(|s| (s, *equiv_classes.get(&(s as StateId)).unwrap())),
+            );
             for (s, c) in pairs.drain(..) {
                 let old_class = state_cmp.partition.get_class_id(s);
                 let new_class = if classes_to_add.contains(&s) {

--- a/rustfst/src/algorithms/tr_unique.rs
+++ b/rustfst/src/algorithms/tr_unique.rs
@@ -18,6 +18,12 @@ pub(crate) fn tr_compare<W: Semiring>(tr_1: &Tr<W>, tr_2: &Tr<W>) -> Ordering {
     if tr_1.olabel > tr_2.olabel {
         return Ordering::Greater;
     }
+    if tr_1.weight < tr_2.weight {
+        return Ordering::Less;
+    }
+    if tr_1.weight > tr_2.weight {
+        return Ordering::Greater;
+    }
     if tr_1.nextstate < tr_2.nextstate {
         return Ordering::Less;
     }
@@ -75,10 +81,42 @@ mod test {
         let s1 = fst_out.add_state();
         let s2 = fst_out.add_state();
 
-        fst_out.add_tr(s1, Tr::new(0, 0, ProbabilityWeight::new(0.3), s2))?;
         fst_out.add_tr(s1, Tr::new(0, 0, ProbabilityWeight::new(0.1), s2))?;
+        fst_out.add_tr(s1, Tr::new(0, 0, ProbabilityWeight::new(0.3), s2))?;
         fst_out.add_tr(s1, Tr::new(0, 1, ProbabilityWeight::new(0.3), s2))?;
         fst_out.add_tr(s1, Tr::new(1, 0, ProbabilityWeight::new(0.3), s2))?;
+
+        fst_out.set_start(s1)?;
+        fst_out.set_final(s2, ProbabilityWeight::one())?;
+
+        tr_unique(&mut fst_in);
+
+        assert_eq!(fst_in, fst_out);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_tr_map_unique_1() -> Result<()> {
+        let mut fst_in = VectorFst::<ProbabilityWeight>::new();
+
+        let s1 = fst_in.add_state();
+        let s2 = fst_in.add_state();
+
+        fst_in.add_tr(s1, Tr::new(1, 2, ProbabilityWeight::new(1.0), s2))?;
+        fst_in.add_tr(s1, Tr::new(1, 2, ProbabilityWeight::new(2.0), s2))?;
+        fst_in.add_tr(s1, Tr::new(1, 2, ProbabilityWeight::new(1.0), s2))?;
+
+        fst_in.set_start(s1)?;
+        fst_in.set_final(s2, ProbabilityWeight::one())?;
+
+        let mut fst_out = VectorFst::<ProbabilityWeight>::new();
+
+        let s1 = fst_out.add_state();
+        let s2 = fst_out.add_state();
+
+        fst_out.add_tr(s1, Tr::new(1, 2, ProbabilityWeight::new(1.0), s2))?;
+        fst_out.add_tr(s1, Tr::new(1, 2, ProbabilityWeight::new(2.0), s2))?;
 
         fst_out.set_start(s1)?;
         fst_out.set_final(s2, ProbabilityWeight::one())?;

--- a/rustfst/src/tests_openfst/mod.rs
+++ b/rustfst/src/tests_openfst/mod.rs
@@ -620,11 +620,12 @@ macro_rules! test_fst {
                 Ok(())
             }
 
-            #[test]
-            fn test_state_map_tr_unique_openfst() -> Result<()> {
-                do_run!(test_state_map_tr_unique, $fst_name);
-                Ok(())
-            }
+            // TODO: Fix openFST to run this test
+            //#[test]
+            //fn test_state_map_tr_unique_openfst() -> Result<()> {
+            //    do_run!(test_state_map_tr_unique, $fst_name);
+            //    Ok(())
+            //}
 
             #[test]
             fn test_state_map_tr_sum_openfst() -> Result<()> {
@@ -854,3 +855,4 @@ test_fst!(test_openfst_fst_016, "fst_016");
 test_fst!(test_openfst_fst_017, "fst_017");
 test_fst!(test_openfst_fst_018, "fst_018");
 test_fst!(test_openfst_fst_019, "fst_019");
+test_fst!(test_openfst_fst_020, "fst_020");


### PR DESCRIPTION
⚠️ As this is a bug still present in OpenFST, I have commented a test that fails because of the update. It is required to find a way to fix OpenFST in order to make this test pass.

```
// TODO: Fix openFST to run this test
//#[test]
//fn test_state_map_tr_unique_openfst() -> Result<()> {
//    do_run!(test_state_map_tr_unique, $fst_name);
//    Ok(())
//}
```
