### PR TITLE
RandGen + (__add__, __mul__ and __or__) added to VectorFst class

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -169,7 +169,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest ]
 
     runs-on: ${{ matrix.os }}
 

--- a/rustfst-ffi/src/algorithms/mod.rs
+++ b/rustfst-ffi/src/algorithms/mod.rs
@@ -5,6 +5,7 @@ pub mod determinize;
 pub mod isomorphic;
 pub mod optimize;
 pub mod project;
+pub mod randgen;
 pub mod replace;
 pub mod reverse;
 pub mod rm_epsilon;
@@ -13,7 +14,6 @@ pub mod top_sort;
 pub mod tr_sort;
 pub mod tr_unique;
 pub mod union;
-pub mod randgen;
 
 #[derive(Debug)]
 pub struct EnumConversionError {}

--- a/rustfst-ffi/src/algorithms/mod.rs
+++ b/rustfst-ffi/src/algorithms/mod.rs
@@ -13,6 +13,7 @@ pub mod top_sort;
 pub mod tr_sort;
 pub mod tr_unique;
 pub mod union;
+pub mod randgen;
 
 #[derive(Debug)]
 pub struct EnumConversionError {}

--- a/rustfst-ffi/src/algorithms/randgen.rs
+++ b/rustfst-ffi/src/algorithms/randgen.rs
@@ -4,10 +4,10 @@ use ffi_convert::RawPointerConverter;
 use rustfst::algorithms::randgen::{randgen_with_config, RandGenConfig, UniformTrSelector};
 use rustfst::prelude::{TropicalWeight, VectorFst};
 
-use crate::{RUSTFST_FFI_RESULT, wrap};
 use crate::fst::as_fst;
 use crate::fst::CFst;
 use crate::get;
+use crate::{wrap, RUSTFST_FFI_RESULT};
 
 #[no_mangle]
 pub extern "C" fn fst_randgen(
@@ -18,7 +18,7 @@ pub extern "C" fn fst_randgen(
     max_length: libc::size_t,
     weight: bool,
     remove_total_weight: bool,
-    res_fst: *mut *const CFst
+    res_fst: *mut *const CFst,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let ifst = get!(CFst, ptr);
@@ -30,7 +30,7 @@ pub extern "C" fn fst_randgen(
             .with_weighted(weight)
             .with_max_length(max_length)
             .with_remove_total_weight(remove_total_weight);
-        let res : VectorFst<_> = randgen_with_config(ifst, config)?;
+        let res: VectorFst<_> = randgen_with_config(ifst, config)?;
 
         let fst_ptr = CFst(Box::new(res)).into_raw_pointer();
         unsafe { *res_fst = fst_ptr };

--- a/rustfst-ffi/src/algorithms/randgen.rs
+++ b/rustfst-ffi/src/algorithms/randgen.rs
@@ -1,0 +1,39 @@
+use anyhow::anyhow;
+use ffi_convert::RawPointerConverter;
+
+use rustfst::algorithms::randgen::{randgen_with_config, RandGenConfig, UniformTrSelector};
+use rustfst::prelude::{TropicalWeight, VectorFst};
+
+use crate::{RUSTFST_FFI_RESULT, wrap};
+use crate::fst::as_fst;
+use crate::fst::CFst;
+use crate::get;
+
+#[no_mangle]
+pub extern "C" fn fst_randgen(
+    ptr: *const CFst,
+    npath: libc::size_t,
+    seed: libc::size_t,
+    select: *const libc::c_char,
+    max_length: libc::size_t,
+    weight: bool,
+    remove_total_weight: bool,
+    res_fst: *mut *const CFst
+) -> RUSTFST_FFI_RESULT {
+    wrap(|| {
+        let ifst = get!(CFst, ptr);
+        let ifst = as_fst!(VectorFst<TropicalWeight>, ifst);
+        // let select : String = select.as_rust()?;
+
+        let config = RandGenConfig::new(UniformTrSelector::from_seed(seed as u64))
+            .with_npath(npath)
+            .with_weighted(weight)
+            .with_max_length(max_length)
+            .with_remove_total_weight(remove_total_weight);
+        let res : VectorFst<_> = randgen_with_config(ifst, config)?;
+
+        let fst_ptr = CFst(Box::new(res)).into_raw_pointer();
+        unsafe { *res_fst = fst_ptr };
+        Ok(())
+    })
+}

--- a/rustfst-ffi/src/algorithms/randgen.rs
+++ b/rustfst-ffi/src/algorithms/randgen.rs
@@ -14,7 +14,6 @@ pub extern "C" fn fst_randgen(
     ptr: *const CFst,
     npath: libc::size_t,
     seed: libc::size_t,
-    select: *const libc::c_char,
     max_length: libc::size_t,
     weight: bool,
     remove_total_weight: bool,
@@ -23,7 +22,6 @@ pub extern "C" fn fst_randgen(
     wrap(|| {
         let ifst = get!(CFst, ptr);
         let ifst = as_fst!(VectorFst<TropicalWeight>, ifst);
-        // let select : String = select.as_rust()?;
 
         let config = RandGenConfig::new(UniformTrSelector::from_seed(seed as u64))
             .with_npath(npath)

--- a/rustfst-python/rustfst/algorithms/randgen.py
+++ b/rustfst-python/rustfst/algorithms/randgen.py
@@ -1,0 +1,69 @@
+import ctypes
+
+from rustfst.fst.vector_fst import Fst, VectorFst
+from rustfst.utils import (
+    lib,
+    check_ffi_error,
+)
+
+
+def randgen(
+    ifst: Fst,
+    npath=1,
+    seed=0,
+    select="uniform",
+    max_length=2147483647,
+    weight=False,
+    remove_total_weight=False,
+) -> VectorFst:
+    """
+    Randomly generate successful paths in an FST.
+    This operation randomly generates a set of successful paths in the input FST.
+    This relies on a mechanism for selecting arcs, specified using the `select`
+    argument. The default selector, "uniform", randomly selects a transition
+    using a uniform distribution. The "log_prob" selector randomly selects a
+    transition w.r.t. the weights treated as negative log probabilities after
+    normalizing for the total weight leaving the state. In all cases, finality is
+    treated as a transition to a super-final state.
+
+    Args:
+        ifst: The input FST.
+        npath: The number of random paths to generate.
+        seed: An optional seed value for random path generation; if zero, the
+            current time and process ID is used.
+        select: A string matching a known random arc selection type; one of:
+            "uniform", "log_prob", "fast_log_prob".
+        max_length: The maximum length of each random path.
+        weight: Should the output be weighted by path count?
+        remove_total_weight: Should the total weight be removed (ignored when
+            `weighted` is False)?
+
+    Returns:
+        An FST containing one or more random paths.
+
+    Raises:
+      ValueError: when something wrong happened.
+    """
+
+    npath = ctypes.c_size_t(npath)
+    seed = ctypes.c_size_t(seed)
+    max_length = ctypes.c_size_t(max_length)
+    weight = ctypes.c_bool(weight)
+    remove_total_weight = ctypes.c_bool(remove_total_weight)
+    select = select.encode("utf-8")
+    randgen_fst = ctypes.pointer(ctypes.c_void_p())
+
+    ret_code = lib.fst_randgen(
+        ifst.ptr,
+        npath,
+        seed,
+        select,
+        max_length,
+        weight,
+        remove_total_weight,
+        ctypes.byref(randgen_fst),
+    )
+    err_msg = "Error during randgen"
+    check_ffi_error(ret_code, err_msg)
+
+    return VectorFst(ptr=randgen_fst)

--- a/rustfst-python/rustfst/algorithms/randgen.py
+++ b/rustfst-python/rustfst/algorithms/randgen.py
@@ -45,19 +45,22 @@ def randgen(
       ValueError: when something wrong happened.
     """
 
+    if select != "uniform":
+        raise ValueError(
+            f"Only the uniform distribution is supported for now. Found {select}"
+        )
+
     npath = ctypes.c_size_t(npath)
     seed = ctypes.c_size_t(seed)
     max_length = ctypes.c_size_t(max_length)
     weight = ctypes.c_bool(weight)
     remove_total_weight = ctypes.c_bool(remove_total_weight)
-    select = select.encode("utf-8")
     randgen_fst = ctypes.pointer(ctypes.c_void_p())
 
     ret_code = lib.fst_randgen(
         ifst.ptr,
         npath,
         seed,
-        select,
         max_length,
         weight,
         remove_total_weight,

--- a/rustfst-python/rustfst/algorithms/randgen.py
+++ b/rustfst-python/rustfst/algorithms/randgen.py
@@ -9,12 +9,12 @@ from rustfst.utils import (
 
 def randgen(
     ifst: Fst,
-    npath=1,
-    seed=0,
-    select="uniform",
-    max_length=2147483647,
-    weight=False,
-    remove_total_weight=False,
+    npath: int = 1,
+    seed: int = 0,
+    select: str = "uniform",
+    max_length: int = 2147483647,
+    weight: bool = False,
+    remove_total_weight: bool = False,
 ) -> VectorFst:
     """
     Randomly generate successful paths in an FST.

--- a/rustfst-python/rustfst/fst/vector_fst.py
+++ b/rustfst-python/rustfst/fst/vector_fst.py
@@ -398,11 +398,43 @@ class VectorFst(Fst):
 
         return isomorphic(self, other)
 
-    def __add__(self, y) -> VectorFst:
-        """x.__add__(y) <==> x+y"""
+    def __add__(self, other: VectorFst) -> VectorFst:
+        """
+        `fst_1 + fst_2` is a shortcut to perform the concatenation of `fst_1` and `fst_2`.
+        Args:
+            other: VectorFst to concatenate after the current Fst.
+
+        Returns:
+            The concatenated Fst.
+        """
         x = self.copy()
 
-        return x.concat(y)
+        return x.concat(other)
+
+    def __mul__(self, other: VectorFst) -> VectorFst:
+        """
+        `fst_1 * fst_2` is a shortcut to perform the composition of `fst_1` and `fst_2`.
+        Args:
+            other: VectorFst to compose with.
+
+        Returns:
+            The composed Fst.
+
+        """
+        return self.compose(other)
+
+    def __or__(self, other: VectorFst) -> VectorFst:
+        """
+        `fst_1 | fst_2` is a shortcut to perform the union of `fst_1` and `fst_2`.
+        Args:
+            other: VectorFst to perform the union with.
+
+        Returns:
+            The resulting Fst.
+        """
+        x = self.copy()
+
+        return x.union(other)
 
     def __str__(self):
         s = ctypes.c_void_p()

--- a/rustfst-python/tests/algorithms/test_randgen.py
+++ b/rustfst-python/tests/algorithms/test_randgen.py
@@ -1,0 +1,22 @@
+from rustfst import VectorFst, Tr
+from rustfst.weight import weight_one
+from rustfst.algorithms.randgen import randgen
+
+
+def test_randgen():
+    fst = VectorFst()
+    s0 = fst.add_state()
+    s1 = fst.add_state()
+
+    fst.set_start(s0)
+    fst.set_final(s1)
+
+    fst.add_tr(s0, Tr(2, 2, weight_one(), s1))
+    fst.add_tr(s0, Tr(3, 3, weight_one(), s1))
+
+    res = randgen(ifst=fst, seed=33)
+
+    assert res.num_states() == 2
+    for tr in fst.trs(fst.start()):
+        assert tr.ilabel in {2, 3}
+        assert tr.olabel in {2, 3}

--- a/rustfst/Cargo.toml
+++ b/rustfst/Cargo.toml
@@ -26,6 +26,7 @@ bimap = '0.3'
 binary-heap-plus = '0.1'
 bitflags = '1'
 generic-array = '0.12'
+getrandom = { version = "0.2", features = ["js"] }
 itertools = '0.9'
 nom = '6'
 num-traits = '0.2'

--- a/rustfst/Cargo.toml
+++ b/rustfst/Cargo.toml
@@ -30,6 +30,8 @@ itertools = '0.9'
 nom = '6'
 num-traits = '0.2'
 ordered-float = '1'
+rand = '0.8'
+rand_chacha = '0.3'
 serde = { version = '1', features = ['derive'] }
 stable_bst = '0.2'
 superslice ='1'
@@ -38,7 +40,6 @@ unsafe_unwrap = '0.1'
 
 [dev-dependencies]
 counter = '0.4'
-rand = '0.5'
 serde_json = '1.0'
 tempfile = '3.0'
 path_abs = '0.5'

--- a/rustfst/src/algorithms/connect.rs
+++ b/rustfst/src/algorithms/connect.rs
@@ -13,7 +13,7 @@ use crate::StateId;
 use crate::Tr;
 use crate::NO_STATE_ID;
 
-/// This operation trims an FST, removing states and trs that are not on successful paths.
+/// This operation trims an Fst, removing states and trs that are not on successful paths.
 ///
 /// # Example 1
 /// ```

--- a/rustfst/src/algorithms/mod.rs
+++ b/rustfst/src/algorithms/mod.rs
@@ -49,11 +49,15 @@ mod partition;
 mod projection;
 mod push;
 mod queue;
+
+/// Module providing functions to randomly generate paths through an Fst. A static and a delayed version are available.
 pub mod randgen;
 mod relabel_pairs;
 pub mod replace;
 mod reverse;
 mod reweight;
+
+/// Module providing functions to remove epsilon transitions from an Fst. A static and a delayed version are available.
 pub mod rm_epsilon;
 mod rm_final_epsilon;
 mod shortest_distance;
@@ -67,7 +71,7 @@ pub(crate) mod tr_unique;
 pub mod union;
 mod weight_convert;
 
-/// Module that provides different structures implementing the `Queue` trait.
+/// Module providing different structures implementing the `Queue` trait.
 pub mod queues;
 
 /// Function objects to restrict which trs are traversed in an FST.
@@ -78,7 +82,7 @@ pub mod tr_mappers;
 
 pub(crate) mod visitors;
 
-/// Module that provides structures implementing the `WeightConverter` trait.
+/// Module providing structures implementing the `WeightConverter` trait.
 pub mod weight_converters;
 
 /// Functions to compare / sort the Trs of an FST.
@@ -87,4 +91,5 @@ pub mod tr_compares {
     pub use super::tr_sort::{ILabelCompare, OLabelCompare, TrCompare};
 }
 
+/// Module providing the necessary functions to implement a new Delayed Fst.
 pub mod lazy;

--- a/rustfst/src/algorithms/mod.rs
+++ b/rustfst/src/algorithms/mod.rs
@@ -49,6 +49,7 @@ mod partition;
 mod projection;
 mod push;
 mod queue;
+pub mod randgen;
 mod relabel_pairs;
 pub mod replace;
 mod reverse;

--- a/rustfst/src/algorithms/randgen/mod.rs
+++ b/rustfst/src/algorithms/randgen/mod.rs
@@ -1,0 +1,119 @@
+use anyhow::Result;
+
+use crate::algorithms::randgen::tr_selector::UniformTrSelector;
+use crate::algorithms::tr_filters::AnyTrFilter;
+use crate::fst_impls::VectorFst;
+pub use randgen_config::RandGenConfig;
+pub use randgen_fst::RandGenFst;
+use tr_sampler::TrSampler;
+pub use tr_selector::TrSelector;
+
+use crate::fst_traits::Fst;
+use crate::prelude::dfs_visit::dfs_visit;
+use crate::prelude::randgen::randgen_visitor::RandGenVisitor;
+use crate::prelude::MutableFst;
+use crate::Semiring;
+
+mod rand_state;
+mod randgen_config;
+mod randgen_fst;
+mod randgen_fst_op;
+mod randgen_visitor;
+mod tr_sampler;
+mod tr_selector;
+
+/// Randomly generate paths through an FST; details controlled by
+/// RandGenConfig.
+pub fn randgen_with_config<
+    W: Semiring<Type = f32>,
+    FI: Fst<W>,
+    FO: MutableFst<W>,
+    S: TrSelector,
+>(
+    ifst: &FI,
+    config: RandGenConfig<S>,
+) -> Result<FO> {
+    let sampler = TrSampler::<_, FI, _, _>::new(ifst, config.selector, config.max_length);
+    let randgen_fst = RandGenFst::new(
+        ifst,
+        sampler,
+        config.npath,
+        config.weighted,
+        config.remove_total_weight,
+    );
+    if config.weighted {
+        randgen_fst.compute()
+    } else {
+        // TODO: No need to do that if dfs_visit supports NOT expanded FST.
+        let randgen_fst_static: VectorFst<_> = randgen_fst.compute()?;
+        let mut visitor = RandGenVisitor::new();
+        dfs_visit(&randgen_fst_static, &mut visitor, &AnyTrFilter {}, false);
+        Ok(visitor.into_output_fst())
+    }
+}
+
+/// Randomly generate a path through an FST with the uniform distribution
+/// over the transitions.
+pub fn randgen<W: Semiring<Type = f32>, FI: Fst<W>, FO: MutableFst<W>>(ifst: &FI) -> Result<FO> {
+    let selector = UniformTrSelector::new();
+    let config = RandGenConfig::new(selector);
+    randgen_with_config(ifst, config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::algorithms::union::union;
+    use crate::fst_traits::PathsIterator;
+    use crate::prelude::fst;
+    use crate::semirings::TropicalWeight;
+    use crate::utils::acceptor;
+
+    #[test]
+    fn test_randgen_weighted() -> Result<()> {
+        let mut fst: VectorFst<TropicalWeight> = acceptor(&[1, 2, 3], TropicalWeight::one());
+        union(
+            &mut fst,
+            &acceptor::<_, VectorFst<_>>(&[4, 5], TropicalWeight::one()),
+        )?;
+
+        let config = RandGenConfig::new(UniformTrSelector::new())
+            .with_npath(10)
+            .with_weighted(true);
+        let res: VectorFst<_> = randgen_with_config(&fst, config)?;
+
+        let paths = res.paths_iter().collect::<Vec<_>>();
+        assert_eq!(paths.len(), 2);
+
+        for path in paths {
+            assert!(path.ilabels == vec![1, 2, 3] || path.ilabels == vec![4,5]);
+            assert!(path.olabels == vec![1, 2, 3] || path.olabels == vec![4,5]);
+        }
+
+        Ok(())
+    }
+
+        #[test]
+    fn test_randgen_unweighted() -> Result<()> {
+        let mut fst: VectorFst<TropicalWeight> = acceptor(&[1, 2, 3], TropicalWeight::one());
+        union(
+            &mut fst,
+            &acceptor::<_, VectorFst<_>>(&[4, 5], TropicalWeight::one()),
+        )?;
+
+        let config = RandGenConfig::new(UniformTrSelector::new())
+            .with_npath(10)
+            .with_weighted(false);
+        let res: VectorFst<_> = randgen_with_config(&fst, config)?;
+
+        let paths = res.paths_iter().collect::<Vec<_>>();
+        assert_eq!(paths.len(), 10);
+
+        for path in paths {
+            assert!(path.ilabels == vec![1, 2, 3] || path.ilabels == vec![4,5]);
+            assert!(path.olabels == vec![1, 2, 3] || path.olabels == vec![4,5]);
+        }
+
+        Ok(())
+    }
+}

--- a/rustfst/src/algorithms/randgen/mod.rs
+++ b/rustfst/src/algorithms/randgen/mod.rs
@@ -21,7 +21,7 @@ mod randgen_visitor;
 mod tr_sampler;
 mod tr_selector;
 
-/// Randomly generate paths through an FST; details controlled by
+/// Randomly generate paths through an Fst; execution controlled by
 /// RandGenConfig.
 pub fn randgen_with_config<
     W: Semiring<Type = f32>,
@@ -51,7 +51,7 @@ pub fn randgen_with_config<
     }
 }
 
-/// Randomly generate a path through an FST with the uniform distribution
+/// Randomly generate a path through an Fst with the uniform distribution
 /// over the transitions.
 pub fn randgen<W: Semiring<Type = f32>, FI: Fst<W>, FO: MutableFst<W>>(ifst: &FI) -> Result<FO> {
     let selector = UniformTrSelector::new();

--- a/rustfst/src/algorithms/randgen/mod.rs
+++ b/rustfst/src/algorithms/randgen/mod.rs
@@ -64,7 +64,6 @@ mod tests {
     use super::*;
     use crate::algorithms::union::union;
     use crate::fst_traits::PathsIterator;
-    use crate::prelude::fst;
     use crate::semirings::TropicalWeight;
     use crate::utils::acceptor;
 

--- a/rustfst/src/algorithms/randgen/mod.rs
+++ b/rustfst/src/algorithms/randgen/mod.rs
@@ -1,12 +1,11 @@
 use anyhow::Result;
 
-use crate::algorithms::randgen::tr_selector::UniformTrSelector;
 use crate::algorithms::tr_filters::AnyTrFilter;
 use crate::fst_impls::VectorFst;
 pub use randgen_config::RandGenConfig;
 pub use randgen_fst::RandGenFst;
 use tr_sampler::TrSampler;
-pub use tr_selector::TrSelector;
+pub use tr_selector::{TrSelector, UniformTrSelector};
 
 use crate::fst_traits::Fst;
 use crate::prelude::dfs_visit::dfs_visit;
@@ -86,14 +85,14 @@ mod tests {
         assert_eq!(paths.len(), 2);
 
         for path in paths {
-            assert!(path.ilabels == vec![1, 2, 3] || path.ilabels == vec![4,5]);
-            assert!(path.olabels == vec![1, 2, 3] || path.olabels == vec![4,5]);
+            assert!(path.ilabels == vec![1, 2, 3] || path.ilabels == vec![4, 5]);
+            assert!(path.olabels == vec![1, 2, 3] || path.olabels == vec![4, 5]);
         }
 
         Ok(())
     }
 
-        #[test]
+    #[test]
     fn test_randgen_unweighted() -> Result<()> {
         let mut fst: VectorFst<TropicalWeight> = acceptor(&[1, 2, 3], TropicalWeight::one());
         union(
@@ -110,8 +109,8 @@ mod tests {
         assert_eq!(paths.len(), 10);
 
         for path in paths {
-            assert!(path.ilabels == vec![1, 2, 3] || path.ilabels == vec![4,5]);
-            assert!(path.olabels == vec![1, 2, 3] || path.olabels == vec![4,5]);
+            assert!(path.ilabels == vec![1, 2, 3] || path.ilabels == vec![4, 5]);
+            assert!(path.olabels == vec![1, 2, 3] || path.olabels == vec![4, 5]);
         }
 
         Ok(())

--- a/rustfst/src/algorithms/randgen/rand_state.rs
+++ b/rustfst/src/algorithms/randgen/rand_state.rs
@@ -1,0 +1,45 @@
+use crate::StateId;
+use std::rc::Rc;
+
+/// Random path state info maintained by RandGenFst and passed to samplers.
+#[derive(Debug, Clone)]
+pub struct RandState {
+    /// Current input FST state.
+    pub state_id: StateId,
+    /// Number of samples to be sampled at this state.
+    pub nsamples: usize,
+    /// Length of path to this random state.
+    pub length: usize,
+    /// Previous sample arc selection.
+    pub select: usize,
+    /// Previous random state on this path.
+    pub parent: Option<Rc<RandState>>,
+}
+
+impl RandState {
+    pub fn new(state_id: StateId) -> Self {
+        Self {
+            state_id,
+            nsamples: 0,
+            length: 0,
+            select: 0,
+            parent: None,
+        }
+    }
+
+    pub fn with_nsamples(self, nsamples: usize) -> Self {
+        Self { nsamples, ..self }
+    }
+
+    pub fn with_length(self, length: usize) -> Self {
+        Self { length, ..self }
+    }
+
+    pub fn with_select(self, select: usize) -> Self {
+        Self { select, ..self }
+    }
+
+    pub fn with_parent(self, parent: Option<Rc<Self>>) -> Self {
+        Self { parent, ..self }
+    }
+}

--- a/rustfst/src/algorithms/randgen/randgen_config.rs
+++ b/rustfst/src/algorithms/randgen/randgen_config.rs
@@ -1,0 +1,46 @@
+use crate::algorithms::randgen::TrSelector;
+
+/// Config for random path generation.
+pub struct RandGenConfig<S: TrSelector> {
+    /// How an arc is selected at a state.
+    pub selector: S,
+    /// Maximum path length.
+    pub max_length: usize,
+    /// Number of paths to generate.
+    pub npath: usize,
+    ///Is the output tree weighted by path count, or is it just an unweighted DAG?
+    pub weighted: bool,
+    /// Remove total weight when output is weighted?
+    pub remove_total_weight: bool,
+}
+
+impl<S: TrSelector> RandGenConfig<S> {
+    pub fn new(selector: S) -> Self {
+        Self {
+            selector,
+            max_length: usize::MAX,
+            npath: 1,
+            weighted: false,
+            remove_total_weight: false,
+        }
+    }
+
+    pub fn with_max_length(self, max_length: usize) -> Self {
+        Self { max_length, ..self }
+    }
+
+    pub fn with_npath(self, npath: usize) -> Self {
+        Self { npath, ..self }
+    }
+
+    pub fn with_weighted(self, weighted: bool) -> Self {
+        Self { weighted, ..self }
+    }
+
+    pub fn with_remove_total_weight(self, remove_total_weight: bool) -> Self {
+        Self {
+            remove_total_weight,
+            ..self
+        }
+    }
+}

--- a/rustfst/src/algorithms/randgen/randgen_config.rs
+++ b/rustfst/src/algorithms/randgen/randgen_config.rs
@@ -1,6 +1,6 @@
 use crate::algorithms::randgen::TrSelector;
 
-/// Config for random path generation.
+/// Configuration struct for random path generation.
 pub struct RandGenConfig<S: TrSelector> {
     /// How an arc is selected at a state.
     pub selector: S,

--- a/rustfst/src/algorithms/randgen/randgen_fst.rs
+++ b/rustfst/src/algorithms/randgen/randgen_fst.rs
@@ -1,0 +1,169 @@
+use std::borrow::Borrow;
+use std::fmt::{Debug, Formatter};
+use std::sync::Arc;
+
+use anyhow::Result;
+
+use crate::algorithms::lazy::{LazyFst2, SimpleHashMapCache};
+use crate::algorithms::randgen::randgen_fst_op::RandGenFstOp;
+use crate::algorithms::randgen::tr_sampler::TrSampler;
+use crate::fst_properties::FstProperties;
+use crate::fst_traits::{CoreFst, Fst, FstIterator, MutableFst, StateIterator};
+use crate::prelude::randgen::TrSelector;
+use crate::{Semiring, StateId, SymbolTable, TrsVec};
+
+pub struct RandGenFst<W: Semiring<Type = f32>, F: Fst<W>, B: Borrow<F>, S: TrSelector>(
+    LazyFst2<W, RandGenFstOp<W, F, B, S>, SimpleHashMapCache<W>>,
+);
+
+impl<'a, W, F, B, S> CoreFst<W> for RandGenFst<W, F, B, S>
+where
+    W: Semiring<Type = f32>,
+    F: Fst<W>,
+    B: Borrow<F>,
+    S: TrSelector,
+{
+    type TRS = TrsVec<W>;
+
+    fn start(&self) -> Option<StateId> {
+        self.0.start()
+    }
+
+    fn final_weight(&self, state: StateId) -> anyhow::Result<Option<W>> {
+        self.0.final_weight(state)
+    }
+
+    unsafe fn final_weight_unchecked(&self, state: StateId) -> Option<W> {
+        self.0.final_weight_unchecked(state)
+    }
+
+    fn num_trs(&self, s: StateId) -> anyhow::Result<usize> {
+        self.0.num_trs(s)
+    }
+
+    unsafe fn num_trs_unchecked(&self, state: StateId) -> usize {
+        self.0.num_trs_unchecked(state)
+    }
+
+    fn get_trs(&self, state_id: StateId) -> anyhow::Result<Self::TRS> {
+        self.0.get_trs(state_id)
+    }
+
+    unsafe fn get_trs_unchecked(&self, state: StateId) -> Self::TRS {
+        self.0.get_trs_unchecked(state)
+    }
+
+    fn properties(&self) -> FstProperties {
+        self.0.properties()
+    }
+
+    fn num_input_epsilons(&self, state: StateId) -> anyhow::Result<usize> {
+        self.0.num_input_epsilons(state)
+    }
+
+    fn num_output_epsilons(&self, state: StateId) -> anyhow::Result<usize> {
+        self.0.num_output_epsilons(state)
+    }
+}
+
+impl<'a, W, F, B, S> StateIterator<'a> for RandGenFst<W, F, B, S>
+where
+    W: Semiring<Type = f32>,
+    F: Fst<W> + 'a,
+    B: Borrow<F> + 'a,
+    S: TrSelector + 'a,
+{
+    type Iter =
+        <LazyFst2<W, RandGenFstOp<W, F, B, S>, SimpleHashMapCache<W>> as StateIterator<'a>>::Iter;
+
+    fn states_iter(&'a self) -> Self::Iter {
+        self.0.states_iter()
+    }
+}
+
+impl<'a, W, F, B, S> FstIterator<'a, W> for RandGenFst<W, F, B, S>
+where
+    W: Semiring<Type = f32>,
+    F: Fst<W> + 'a,
+    B: Borrow<F> + 'a,
+    S: TrSelector + 'a,
+{
+    type FstIter = <LazyFst2<W, RandGenFstOp<W, F, B, S>, SimpleHashMapCache<W>> as FstIterator<
+        'a,
+        W,
+    >>::FstIter;
+
+    fn fst_iter(&'a self) -> Self::FstIter {
+        self.0.fst_iter()
+    }
+}
+
+impl<W, F, B, S> Fst<W> for RandGenFst<W, F, B, S>
+where
+    W: Semiring<Type = f32>,
+    F: Fst<W> + 'static,
+    B: Borrow<F> + 'static,
+    S: TrSelector + 'static,
+{
+    fn input_symbols(&self) -> Option<&Arc<SymbolTable>> {
+        self.0.input_symbols()
+    }
+
+    fn output_symbols(&self) -> Option<&Arc<SymbolTable>> {
+        self.0.output_symbols()
+    }
+
+    fn set_input_symbols(&mut self, symt: Arc<SymbolTable>) {
+        self.0.set_input_symbols(symt)
+    }
+
+    fn set_output_symbols(&mut self, symt: Arc<SymbolTable>) {
+        self.0.set_output_symbols(symt)
+    }
+
+    fn take_input_symbols(&mut self) -> Option<Arc<SymbolTable>> {
+        self.0.take_input_symbols()
+    }
+
+    fn take_output_symbols(&mut self) -> Option<Arc<SymbolTable>> {
+        self.0.take_output_symbols()
+    }
+}
+
+impl<W, F, B, S> Debug for RandGenFst<W, F, B, S>
+where
+    W: Semiring<Type = f32>,
+    F: Fst<W> + 'static,
+    B: Borrow<F> + 'static,
+    S: TrSelector + 'static,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+impl<W, F, B, S> RandGenFst<W, F, B, S>
+where
+    W: Semiring<Type = f32>,
+    F: Fst<W>,
+    B: Borrow<F>,
+    S: TrSelector,
+{
+    pub fn new(
+        fst: B,
+        sampler: TrSampler<W, F, B, S>,
+        npath: usize,
+        weighted: bool,
+        remove_total_weight: bool,
+    ) -> Self {
+        let isymt = fst.borrow().input_symbols().cloned();
+        let osymt = fst.borrow().output_symbols().cloned();
+        let fst_op = RandGenFstOp::new(fst, sampler, npath, weighted, remove_total_weight);
+        let fst_cache = SimpleHashMapCache::default();
+        let lazy_fst = LazyFst2::from_op_and_cache(fst_op, fst_cache, isymt, osymt);
+        RandGenFst(lazy_fst)
+    }
+
+    pub fn compute<F2: MutableFst<W>>(&self) -> Result<F2> {
+        self.0.compute()
+    }
+}

--- a/rustfst/src/algorithms/randgen/randgen_fst.rs
+++ b/rustfst/src/algorithms/randgen/randgen_fst.rs
@@ -12,6 +12,7 @@ use crate::fst_traits::{CoreFst, Fst, FstIterator, MutableFst, StateIterator};
 use crate::prelude::randgen::TrSelector;
 use crate::{Semiring, StateId, SymbolTable, TrsVec};
 
+/// Delayed Fst sampling Fst paths through the input Fst.
 pub struct RandGenFst<W: Semiring<Type = f32>, F: Fst<W>, B: Borrow<F>, S: TrSelector>(
     LazyFst2<W, RandGenFstOp<W, F, B, S>, SimpleHashMapCache<W>>,
 );

--- a/rustfst/src/algorithms/randgen/randgen_fst_op.rs
+++ b/rustfst/src/algorithms/randgen/randgen_fst_op.rs
@@ -1,0 +1,167 @@
+use std::borrow::Borrow;
+use std::cell::RefCell;
+use std::fmt::{Debug, Formatter};
+use std::rc::Rc;
+use std::sync::Arc;
+
+use anyhow::Result;
+
+use crate::algorithms::lazy::FstOp2;
+use crate::algorithms::randgen::rand_state::RandState;
+use crate::algorithms::randgen::tr_sampler::TrSampler;
+use crate::algorithms::randgen::TrSelector;
+use crate::algorithms::weight_convert::WeightConverter;
+use crate::fst_properties::mutable_properties::rand_gen_properties;
+use crate::fst_properties::FstProperties;
+use crate::prelude::Fst;
+use crate::semirings::LogWeight;
+use crate::{Semiring, StateId, Tr, Trs, TrsVec, NO_STATE_ID};
+
+pub struct RandGenFstOp<W, F, B, S>
+where
+    W: Semiring<Type = f32>,
+    F: Fst<W>,
+    B: Borrow<F>,
+    S: TrSelector,
+{
+    fst: B,
+    sampler: RefCell<TrSampler<W, F, B, S>>,
+    npath: usize,
+    state_table: RefCell<Vec<Rc<RandState>>>,
+    weighted: bool,
+    remove_total_weight: bool,
+    superfinal: RefCell<StateId>,
+}
+
+impl<W, F, B, S> RandGenFstOp<W, F, B, S>
+where
+    W: Semiring<Type = f32>,
+    F: Fst<W>,
+    B: Borrow<F>,
+    S: TrSelector,
+{
+    pub fn new(
+        fst: B,
+        sampler: TrSampler<W, F, B, S>,
+        npath: usize,
+        weighted: bool,
+        remove_total_weight: bool,
+    ) -> Self {
+        Self {
+            fst,
+            sampler: RefCell::new(sampler),
+            npath,
+            state_table: RefCell::new(vec![]),
+            weighted,
+            remove_total_weight,
+            superfinal: RefCell::new(NO_STATE_ID),
+        }
+    }
+}
+
+impl<W, F, B, S> Debug for RandGenFstOp<W, F, B, S>
+where
+    W: Semiring<Type = f32>,
+    F: Fst<W>,
+    B: Borrow<F>,
+    S: TrSelector,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        todo!()
+    }
+}
+
+impl<W, F, B, S> FstOp2<W> for RandGenFstOp<W, F, B, S>
+where
+    W: Semiring<Type = f32>,
+    F: Fst<W>,
+    B: Borrow<F>,
+    S: TrSelector,
+{
+    fn compute_start(&self) -> Result<Option<StateId>> {
+        if let Some(s) = self.fst.borrow().start() {
+            let n = self.state_table.borrow().len();
+            self.state_table.borrow_mut().push(Rc::new(
+                RandState::new(s)
+                    .with_nsamples(self.npath)
+                    .with_length(0)
+                    .with_select(0)
+                    .with_parent(None),
+            ));
+            Ok(Some(n as StateId))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn compute_trs_and_final_weight(&self, s: StateId) -> Result<(TrsVec<W>, Option<W>)> {
+        if s == *self.superfinal.borrow() {
+            let result = Ok((TrsVec::default(), Some(W::one())));
+            return result;
+        }
+        let rstate = Rc::clone(self.state_table.borrow().get(s as usize).unwrap());
+        self.sampler.borrow_mut().sample(&rstate)?;
+
+        let aiter = self.fst.borrow().get_trs(rstate.state_id)?;
+        let trs = aiter.trs();
+        let num_trs = trs.len();
+
+        let mut output_trs: Vec<Tr<W>> = vec![];
+        let mut output_final_weight = None;
+
+        for (&pos, &count) in self.sampler.borrow().iter() {
+            let prob = (count as f32) / (rstate.nsamples as f32);
+            if pos < num_trs {
+                let tr = &trs[pos];
+                let weight = if self.weighted {
+                    W::new(-prob.ln())
+                } else {
+                    W::one()
+                };
+                output_trs.push(Tr::new(
+                    tr.ilabel,
+                    tr.olabel,
+                    weight,
+                    self.state_table.borrow().len() as StateId,
+                ));
+                let nrstate = RandState::new(tr.nextstate)
+                    .with_nsamples(count)
+                    .with_length(rstate.length + 1)
+                    .with_select(pos)
+                    .with_parent(Some(Rc::clone(&rstate)));
+                self.state_table.borrow_mut().push(Rc::new(nrstate));
+            } else {
+                // Super-final transition.
+                if self.weighted {
+                    let weight = if self.remove_total_weight {
+                        W::new(-prob.ln())
+                    } else {
+                        W::new(-(prob * self.npath as f32).ln())
+                    };
+                    output_final_weight = Some(weight);
+                } else {
+                    if *self.superfinal.borrow() == NO_STATE_ID {
+                        *self.superfinal.borrow_mut() = self.state_table.borrow().len() as StateId;
+                        self.state_table.borrow_mut().push(Rc::new(
+                            RandState::new(NO_STATE_ID)
+                                .with_nsamples(0)
+                                .with_length(0)
+                                .with_select(0)
+                                .with_parent(None),
+                        ));
+                    }
+                    for _ in 0..count {
+                        output_trs.push(Tr::new(0, 0, W::one(), *self.superfinal.borrow()));
+                    }
+                }
+            }
+        }
+
+        return Ok((TrsVec(Arc::new(output_trs)), output_final_weight));
+    }
+
+    fn properties(&self) -> FstProperties {
+        rand_gen_properties(self.fst.borrow().properties(), self.weighted)
+            & FstProperties::copy_properties()
+    }
+}

--- a/rustfst/src/algorithms/randgen/randgen_fst_op.rs
+++ b/rustfst/src/algorithms/randgen/randgen_fst_op.rs
@@ -10,11 +10,9 @@ use crate::algorithms::lazy::FstOp2;
 use crate::algorithms::randgen::rand_state::RandState;
 use crate::algorithms::randgen::tr_sampler::TrSampler;
 use crate::algorithms::randgen::TrSelector;
-use crate::algorithms::weight_convert::WeightConverter;
 use crate::fst_properties::mutable_properties::rand_gen_properties;
 use crate::fst_properties::FstProperties;
 use crate::prelude::Fst;
-use crate::semirings::LogWeight;
 use crate::{Semiring, StateId, Tr, Trs, TrsVec, NO_STATE_ID};
 
 pub struct RandGenFstOp<W, F, B, S>
@@ -67,7 +65,17 @@ where
     S: TrSelector,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        todo!()
+        write!(
+            f,
+            "RandGenFstOp {{ fst : {:?}, sampler : {:?}, npath : {:?}, state_table : {:?}, weighted : {:?}, remove_total_weight : {:?}, superfinal : {:?} }}",
+            self.fst.borrow(),
+            self.sampler.borrow(),
+            self.npath,
+            self.state_table.borrow(),
+            self.weighted,
+            self.remove_total_weight,
+            self.superfinal
+        )
     }
 }
 

--- a/rustfst/src/algorithms/randgen/randgen_visitor.rs
+++ b/rustfst/src/algorithms/randgen/randgen_visitor.rs
@@ -1,0 +1,85 @@
+use crate::algorithms::dfs_visit::Visitor;
+use crate::fst_impls::VectorFst;
+use crate::fst_traits::{CoreFst, MutableFst};
+use crate::prelude::Fst;
+use crate::{Semiring, StateId, Tr};
+use anyhow::Result;
+
+pub struct RandGenVisitor<'a, W: Semiring, FI: Fst<W>, FO: MutableFst<W>> {
+    ofst: FO,
+    ifst: Option<&'a FI>,
+    path: Vec<Tr<W>>,
+}
+
+impl<'a, W: Semiring, FI: Fst<W>, FO: MutableFst<W>> RandGenVisitor<'a, W, FI, FO> {
+    pub fn into_output_fst(self) -> FO {
+        self.ofst
+    }
+}
+
+impl<'a, W: Semiring, FI: Fst<W>, FO: MutableFst<W>> RandGenVisitor<'a, W, FI, FO> {
+    pub fn new() -> Self {
+        Self {
+            ifst: None,
+            ofst: FO::new(),
+            path: vec![],
+        }
+    }
+
+    fn output_path(&mut self) -> Result<()> {
+        if self.ofst.start().is_none() {
+            let start = self.ofst.add_state();
+            self.ofst.set_start(start)?;
+        }
+        let mut src = self.ofst.start().unwrap();
+        for i in 0..self.path.len() {
+            let dest = self.ofst.add_state();
+            let tr = Tr::new(self.path[i].ilabel, self.path[i].olabel, W::one(), dest);
+            self.ofst.add_tr(src, tr)?;
+            src = dest;
+        }
+        self.ofst.set_final(src, W::one())?;
+        Ok(())
+    }
+}
+
+impl<'a, W: Semiring, FI: Fst<W>, FO: MutableFst<W>> Visitor<'a, W, FI>
+    for RandGenVisitor<'a, W, FI, FO>
+{
+    fn init_visit(&mut self, fst: &'a FI) {
+        self.ifst = Some(fst);
+        self.ofst.del_all_states();
+        self.ofst.set_symts_from_fst(fst);
+        self.path.clear();
+    }
+
+    fn init_state(&mut self, _s: StateId, _root: StateId) -> bool {
+        return true;
+    }
+
+    fn tree_tr(&mut self, _s: StateId, tr: &Tr<W>) -> bool {
+        if !self.ifst.unwrap().is_final(tr.nextstate).unwrap() {
+            self.path.push(tr.clone());
+        } else {
+            self.output_path().unwrap();
+        }
+        return true;
+    }
+
+    fn back_tr(&mut self, _s: StateId, _tr: &Tr<W>) -> bool {
+        panic!("RandGenVisitor: cyclic input");
+    }
+
+    fn forward_or_cross_tr(&mut self, _s: StateId, _tr: &Tr<W>) -> bool {
+        self.output_path().unwrap();
+        return true;
+    }
+
+    fn finish_state(&mut self, s: StateId, parent: Option<StateId>, _tr: Option<&Tr<W>>) {
+        if parent.is_some() && !self.ifst.unwrap().is_final(s).unwrap() {
+            self.path.pop();
+        }
+    }
+
+    fn finish_visit(&mut self) {}
+}

--- a/rustfst/src/algorithms/randgen/randgen_visitor.rs
+++ b/rustfst/src/algorithms/randgen/randgen_visitor.rs
@@ -1,9 +1,8 @@
-use crate::algorithms::dfs_visit::Visitor;
-use crate::fst_impls::VectorFst;
-use crate::fst_traits::{CoreFst, MutableFst};
-use crate::prelude::Fst;
-use crate::{Semiring, StateId, Tr};
 use anyhow::Result;
+
+use crate::algorithms::dfs_visit::Visitor;
+use crate::fst_traits::{Fst, MutableFst};
+use crate::{Semiring, StateId, Tr};
 
 pub struct RandGenVisitor<'a, W: Semiring, FI: Fst<W>, FO: MutableFst<W>> {
     ofst: FO,

--- a/rustfst/src/algorithms/randgen/tr_sampler.rs
+++ b/rustfst/src/algorithms/randgen/tr_sampler.rs
@@ -1,5 +1,6 @@
 use std::borrow::Borrow;
 use std::collections::HashMap;
+use std::fmt::{Debug, Formatter};
 use std::marker::PhantomData;
 
 use anyhow::Result;
@@ -19,6 +20,25 @@ pub struct TrSampler<W: Semiring, F: Fst<W>, B: Borrow<F>, S: TrSelector> {
     fst: B,
     sample_map: HashMap<usize, usize>,
     ghost: PhantomData<(W, F)>,
+}
+
+impl<W, F, B, S> Debug for TrSampler<W, F, B, S>
+where
+    W: Semiring,
+    F: Fst<W>,
+    B: Borrow<F>,
+    S: TrSelector,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "TrSampler {{ max_length : {:?}, selector : {:?}, fst : {:?}, sample_map : {:?} }}",
+            self.max_length,
+            self.selector,
+            self.fst.borrow(),
+            self.sample_map
+        )
+    }
 }
 
 impl<W, F, B, S> TrSampler<W, F, B, S>

--- a/rustfst/src/algorithms/randgen/tr_sampler.rs
+++ b/rustfst/src/algorithms/randgen/tr_sampler.rs
@@ -1,0 +1,69 @@
+use std::borrow::Borrow;
+use std::collections::HashMap;
+use std::marker::PhantomData;
+
+use anyhow::Result;
+
+use crate::algorithms::randgen::rand_state::RandState;
+use crate::algorithms::randgen::TrSelector;
+use crate::prelude::Fst;
+use crate::Semiring;
+
+/// This class, given a TrSelector, samples, with replacement, multiple random
+/// transitions from an FST's state. This is a generic version with a
+/// straightforward use of the tr selector. Specializations may be defined for
+/// tr selectors for greater efficiency or special behavior.
+pub struct TrSampler<W: Semiring, F: Fst<W>, B: Borrow<F>, S: TrSelector> {
+    max_length: usize,
+    selector: S,
+    fst: B,
+    sample_map: HashMap<usize, usize>,
+    ghost: PhantomData<(W, F)>,
+}
+
+impl<W, F, B, S> TrSampler<W, F, B, S>
+where
+    W: Semiring,
+    F: Fst<W>,
+    B: Borrow<F>,
+    S: TrSelector,
+{
+    pub fn new(fst: B, selector: S, max_length: usize) -> Self {
+        Self {
+            fst,
+            selector,
+            max_length,
+            sample_map: HashMap::new(),
+            ghost: PhantomData,
+        }
+    }
+
+    /// Samples a fixed number of samples from the given state. The length argument
+    /// specifies the length of the path to the state. Returns true if the samples
+    /// were collected. No samples may be collected if either there are no
+    /// transitions leaving the state and the state is non-final, or if the path
+    /// length has been exceeded. Iterator members are provided to read the samples
+    /// in the order in which they were collected.
+    pub fn sample(&mut self, rstate: &RandState) -> Result<bool> {
+        self.sample_map.clear();
+        if (self.fst.borrow().num_trs(rstate.state_id)? == 0
+            && !self.fst.borrow().is_final(rstate.state_id)?)
+            || rstate.length == self.max_length
+        {
+            // self.reset();
+            return Ok(false);
+        }
+        for _ in 0..rstate.nsamples {
+            let selected = self
+                .selector
+                .select_tr(self.fst.borrow(), rstate.state_id)?;
+            *self.sample_map.entry(selected).or_insert(0) += 1;
+        }
+        // self.reset();
+        Ok(true)
+    }
+
+    pub fn iter(&self) -> std::collections::hash_map::Iter<usize, usize> {
+        self.sample_map.iter()
+    }
+}

--- a/rustfst/src/algorithms/randgen/tr_selector.rs
+++ b/rustfst/src/algorithms/randgen/tr_selector.rs
@@ -6,9 +6,9 @@ use rand_chacha::rand_core::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 use std::fmt::Debug;
 
-/// TrSelector implementors are used to select a random transition given an FST
-/// state s, returning a number N such that 0 <= N <= NumTrs(s). If N is
-/// NumArcs(s), then the final weight is selected; otherwise the N-th arc is
+/// `TrSelector` implementors are used to select a random transition given an Fst
+/// state `s`, returning a number `N` such that 0 <= `N` <= `fst.num_trs(s)`. If `N` is
+/// `fst.num_trs(s)`, then the final weight is selected; otherwise the `N`-th transition is
 /// selected. It is assumed these are not applied to any state which is neither
 /// final nor has any arcs leaving it.
 pub trait TrSelector: Debug {

--- a/rustfst/src/algorithms/randgen/tr_selector.rs
+++ b/rustfst/src/algorithms/randgen/tr_selector.rs
@@ -4,17 +4,19 @@ use anyhow::Result;
 use rand::distributions::{Distribution, Uniform};
 use rand_chacha::rand_core::SeedableRng;
 use rand_chacha::ChaCha8Rng;
+use std::fmt::Debug;
 
 /// TrSelector implementors are used to select a random transition given an FST
 /// state s, returning a number N such that 0 <= N <= NumTrs(s). If N is
 /// NumArcs(s), then the final weight is selected; otherwise the N-th arc is
 /// selected. It is assumed these are not applied to any state which is neither
 /// final nor has any arcs leaving it.
-pub trait TrSelector {
+pub trait TrSelector: Debug {
     fn select_tr<W: Semiring, F: Fst<W>>(&mut self, fst: &F, state: StateId) -> Result<usize>;
 }
 
 /// Randomly selects a transition using the uniform distribution.
+#[derive(Debug, Clone)]
 pub struct UniformTrSelector {
     rng: ChaCha8Rng,
 }

--- a/rustfst/src/algorithms/rm_epsilon/rm_epsilon_op.rs
+++ b/rustfst/src/algorithms/rm_epsilon/rm_epsilon_op.rs
@@ -27,7 +27,7 @@ impl<W: Semiring, F: MutableFst<W>, B: Borrow<F>> std::fmt::Debug for RmEpsilonO
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "RmEpsilonImpl {{ rmeps_state : {:?}}}",
+            "RmEpsilonOp {{ rmeps_state : {:?}}}",
             self.rmeps_state.borrow()
         )
     }

--- a/rustfst/src/fst_impls/vector_fst/test.rs
+++ b/rustfst/src/fst_impls/vector_fst/test.rs
@@ -11,6 +11,7 @@ mod tests {
     use crate::semirings::{ProbabilityWeight, Semiring, TropicalWeight};
     use crate::tr::Tr;
     use crate::{SymbolTable, Trs};
+    use rand::seq::SliceRandom;
     use std::sync::Arc;
 
     #[test]
@@ -141,7 +142,7 @@ mod tests {
 
         // Select randomly n_final_states
         let mut rg = StdRng::from_seed([53; 32]);
-        rg.shuffle(&mut states);
+        states.shuffle(&mut rg);
         let final_states: Vec<_> = states.into_iter().take(n_final_states).collect();
 
         // Set those as final with a weight equals to its position in the vector
@@ -239,7 +240,7 @@ mod tests {
 
         // Sample n_states_to_delete to remove from the FST
         let mut rg = StdRng::from_seed([53; 32]);
-        rg.shuffle(&mut states);
+        states.shuffle(&mut rg);
         let states_to_delete: Vec<_> = states.into_iter().take(n_states_to_delete).collect();
 
         fst.del_states(states_to_delete)?;

--- a/rustfst/src/fst_impls/vector_fst/test.rs
+++ b/rustfst/src/fst_impls/vector_fst/test.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use rand::{rngs::StdRng, Rng, SeedableRng};
+    use rand::{rngs::StdRng, SeedableRng};
 
     use anyhow::Result;
 

--- a/rustfst/src/lib.rs
+++ b/rustfst/src/lib.rs
@@ -137,13 +137,13 @@ pub const EPS_SYMBOL: &str = "<eps>";
 /// A few utilities to manipulate wFSTs.
 pub mod utils;
 
-/// Provides algorithms that are generic to all wFST.
+/// Provides algorithms that are generic to all Fst.
 pub mod algorithms;
 
 /// Provides the `FstProperties` struct and some utils functions around it.
 /// Useful to assert some properties on a Fst.
 pub mod fst_properties;
-/// Implementation of the transitions inside a wFST.
+/// Implementation of the transitions inside a Fst.
 mod tr;
 
 #[macro_use]

--- a/rustfst/src/lib.rs
+++ b/rustfst/src/lib.rs
@@ -91,8 +91,6 @@ extern crate counter;
 #[macro_use]
 extern crate anyhow;
 #[cfg(test)]
-extern crate rand;
-#[cfg(test)]
 extern crate serde;
 #[cfg(test)]
 extern crate serde_json;

--- a/rustfst/src/semirings/semiring.rs
+++ b/rustfst/src/semirings/semiring.rs
@@ -27,12 +27,13 @@ bitflags! {
     }
 }
 
-/// For some operations, the weight set associated to a wFST must have the structure of a semiring.
+/// The weight on an Fst must implement the `Semiring` trait.
+/// Indeed, the weight set associated to a Fst must have the structure of a semiring.
 /// `(S, +, *, 0, 1)` is a semiring if `(S, +, 0)` is a commutative monoid with identity element 0,
 /// `(S, *, 1)` is a monoid with identity element `1`, `*` distributes over `+`,
 /// `0` is an annihilator for `*`.
 /// Thus, a semiring is a ring that may lack negation.
-/// For more information : https://cs.nyu.edu/~mohri/pub/hwa.pdf
+/// For more information : <https://cs.nyu.edu/~mohri/pub/hwa.pdf>
 pub trait Semiring: Clone + PartialEq + PartialOrd + Debug + Hash + Eq + Sync + 'static {
     type Type: Clone + Debug;
     type ReverseWeight: Semiring + ReverseBack<Self>;


### PR DESCRIPTION
- Implement one missing operation in Rust : `randgen` (fix https://github.com/Garvys/rustfst/issues/187)
- Add python binding for `randgen`.
- Add __add__, __mul__ and __or__ operator to the VectorFst class.