### PR TITLE
Bump ordered-float to 3.0

### DIFF
--- a/rustfst/Cargo.toml
+++ b/rustfst/Cargo.toml
@@ -30,7 +30,7 @@ getrandom = { version = "0.2", features = ["js"] }
 itertools = '0.9'
 nom = '6'
 num-traits = '0.2'
-ordered-float = '1'
+ordered-float = '3.0'
 rand = '0.8'
 rand_chacha = '0.3'
 serde = { version = '1', features = ['derive'] }


### PR DESCRIPTION
Fix vulnerability issue in `ordered-float` : An issue was discovered in the ordered-float crate before 1.1.1 and 2.x before 2.0.1 for Rust. A NotNan value can contain a NaN.