### PR TITLE
Allow `str` when reading or writing an Fst in Python

### DIFF
--- a/rustfst-python/rustfst/fst/const_fst.py
+++ b/rustfst-python/rustfst/fst/const_fst.py
@@ -8,7 +8,7 @@ from rustfst.ffi_utils import (
 from rustfst.fst import Fst
 from rustfst.symbol_table import SymbolTable
 from rustfst.drawing_config import DrawingConfig
-from typing import Optional
+from typing import Optional, Union
 from pathlib import Path
 
 
@@ -90,7 +90,7 @@ class ConstFst(Fst):
         check_ffi_error(ret_code, err_msg)
 
     @classmethod
-    def read(cls, filename: Path) -> Fst:
+    def read(cls, filename: Union[str, Path]) -> Fst:
         """
         Read a Fst at a given path.
         Args:
@@ -109,7 +109,7 @@ class ConstFst(Fst):
 
         return cls(ptr=fst)
 
-    def write(self, filename: Path):
+    def write(self, filename: Union[str, Path]):
         """
         Serializes FST to a file.
         This method writes the FST to a file in binary format.

--- a/rustfst-python/rustfst/fst/vector_fst.py
+++ b/rustfst-python/rustfst/fst/vector_fst.py
@@ -13,7 +13,7 @@ from rustfst.drawing_config import DrawingConfig
 from rustfst.iterators import MutableTrsIterator, StateIterator
 from rustfst.tr import Tr
 from rustfst.weight import weight_one
-from typing import Optional
+from typing import Optional, Union
 from pathlib import Path
 
 from typing import List
@@ -230,7 +230,7 @@ class VectorFst(Fst):
         check_ffi_error(ret_code, err_msg)
 
     @classmethod
-    def read(cls, filename: Path) -> Fst:
+    def read(cls, filename: Union[str, Path]) -> Fst:
         """
         Read a Fst at a given path.
         Args:
@@ -249,7 +249,7 @@ class VectorFst(Fst):
 
         return cls(ptr=fst)
 
-    def write(self, filename: Path):
+    def write(self, filename: Union[str, Path]):
         """
         Serializes FST to a file.
         This method writes the FST to a file in vector binary format.


### PR DESCRIPTION
`Fst.read` and `Fst.write` now takes `Union[str, Path]` instead of only `Path`.