### PR TITLE
Freeze rust version for clippy to 1.61.0 + sleep between cargo publish

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -147,17 +147,12 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    strategy:
-      fail-fast: false
-      matrix:
-        rust: [1.49.0, 1.61.0]
-
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ matrix.rust }}
+          toolchain: 1.61.0
           default: true
           components: clippy
       - name: Cargo Clippy
@@ -336,6 +331,7 @@ jobs:
         run: |
           cd rustfst
           cargo publish
+          sleep 30
           cd ..
       - name: Publish rustfst-ffi
         env:

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -150,7 +150,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [1.49.0, stable]
+        rust: [1.49.0, 1.61.0]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
- Run clippy only on rust version : `1.61.0`
- Add `sleep 30` between `cargo publish`