### PR TITLE
Declare presence of types as per PEP561

### DIFF
--- a/rustfst-python/setup.py
+++ b/rustfst-python/setup.py
@@ -58,6 +58,7 @@ setup(
         "License :: OSI Approved :: Apache Software License",
     ],
     packages=packages,
+    package_data={"rustfst": ["py.typed"]},
     include_package_data=True,
     rust_extensions=[
         RustExtension(


### PR DESCRIPTION
rustfst-python has type declarations (yay!) but mypy does not use them because it has not declared them by including a `py.typed` file in its package (boo!) - see https://mypy.readthedocs.io/en/stable/installed_packages.html#installed-packages

luckily this is easy to do, just include a `py.typed` file in the package :)