### PR TITLE
Make `Queue::dequeue` return the removed value

### DIFF
--- a/rustfst/src/algorithms/minimize.rs
+++ b/rustfst/src/algorithms/minimize.rs
@@ -532,9 +532,7 @@ fn cyclic_minimize<W: Semiring, F: MutableFst<W>>(fst: &mut F) -> Result<Rc<RefC
     });
 
     // Compute
-    while let Some(c) = queue.head() {
-        queue.dequeue();
-
+    while let Some(c) = queue.dequeue() {
         // Split
         for s in partition.borrow().iter(c as usize) {
             if tr.num_trs(s as StateId + 1)? > 0 {

--- a/rustfst/src/algorithms/queue.rs
+++ b/rustfst/src/algorithms/queue.rs
@@ -29,7 +29,7 @@ pub enum QueueType {
 pub trait Queue: Debug {
     fn head(&mut self) -> Option<StateId>;
     fn enqueue(&mut self, state: StateId);
-    fn dequeue(&mut self);
+    fn dequeue(&mut self) -> Option<StateId>;
     fn update(&mut self, state: StateId);
     fn is_empty(&self) -> bool;
     fn clear(&mut self);

--- a/rustfst/src/algorithms/queues/auto_queue.rs
+++ b/rustfst/src/algorithms/queues/auto_queue.rs
@@ -166,7 +166,7 @@ impl Queue for AutoQueue {
         self.queue.enqueue(state)
     }
 
-    fn dequeue(&mut self) {
+    fn dequeue(&mut self) -> Option<StateId> {
         self.queue.dequeue()
     }
 

--- a/rustfst/src/algorithms/queues/fifo_queue.rs
+++ b/rustfst/src/algorithms/queues/fifo_queue.rs
@@ -16,8 +16,8 @@ impl Queue for FifoQueue {
         self.0.push_back(state)
     }
 
-    fn dequeue(&mut self) {
-        self.0.pop_front();
+    fn dequeue(&mut self) -> Option<StateId> {
+        self.0.pop_front()
     }
 
     fn update(&mut self, _state: StateId) {}

--- a/rustfst/src/algorithms/queues/lifo_queue.rs
+++ b/rustfst/src/algorithms/queues/lifo_queue.rs
@@ -14,8 +14,8 @@ impl Queue for LifoQueue {
         self.0.push(state)
     }
 
-    fn dequeue(&mut self) {
-        self.0.pop();
+    fn dequeue(&mut self) -> Option<StateId> {
+        self.0.pop()
     }
 
     fn update(&mut self, _state: StateId) {}

--- a/rustfst/src/algorithms/queues/scc_queue.rs
+++ b/rustfst/src/algorithms/queues/scc_queue.rs
@@ -21,13 +21,17 @@ impl SccQueue {
             sccs,
         }
     }
+
+    fn update_front(&mut self) {
+        while self.front <= self.back && self.queues[self.front as usize].is_empty() {
+            self.front += 1;
+        }
+    }
 }
 
 impl Queue for SccQueue {
     fn head(&mut self) -> Option<StateId> {
-        while self.front <= self.back && self.queues[self.front as usize].is_empty() {
-            self.front += 1;
-        }
+        self.update_front();
         self.queues[self.front as usize].head()
     }
 
@@ -44,8 +48,13 @@ impl Queue for SccQueue {
         self.queues[self.sccs[u_state] as usize].enqueue(state);
     }
 
-    fn dequeue(&mut self) {
-        self.queues[self.front as usize].dequeue()
+    fn dequeue(&mut self) -> Option<StateId> {
+        if self.is_empty() {
+            None
+        } else {
+            self.update_front();
+            self.queues[self.front as usize].dequeue()
+        }
     }
 
     fn update(&mut self, state: StateId) {

--- a/rustfst/src/algorithms/queues/shortest_first_queue.rs
+++ b/rustfst/src/algorithms/queues/shortest_first_queue.rs
@@ -57,8 +57,8 @@ impl<C: Clone + FnMut(&StateId, &StateId) -> Ordering> Queue for ShortestFirstQu
         self.heap.push(state);
     }
 
-    fn dequeue(&mut self) {
-        self.heap.pop();
+    fn dequeue(&mut self) -> Option<StateId> {
+        self.heap.pop()
     }
 
     fn update(&mut self, _state: StateId) {
@@ -108,7 +108,7 @@ impl Queue for NaturalShortestFirstQueue {
         self.queue.enqueue(state)
     }
 
-    fn dequeue(&mut self) {
+    fn dequeue(&mut self) -> Option<StateId> {
         self.queue.dequeue()
     }
 

--- a/rustfst/src/algorithms/queues/state_order_queue.rs
+++ b/rustfst/src/algorithms/queues/state_order_queue.rs
@@ -30,13 +30,18 @@ impl Queue for StateOrderQueue {
         self.enqueued[state] = true;
     }
 
-    fn dequeue(&mut self) {
+    fn dequeue(&mut self) -> Option<StateId> {
+        if self.is_empty() {
+            return None;
+        }
+        let old_head = self.head();
         self.enqueued[self.front] = false;
         if let Some(back_) = self.back {
             while self.front <= back_ && !self.enqueued[self.front] {
                 self.front += 1;
             }
         }
+        old_head
     }
 
     fn update(&mut self, _state: StateId) {}

--- a/rustfst/src/algorithms/queues/top_order_queue.rs
+++ b/rustfst/src/algorithms/queues/top_order_queue.rs
@@ -55,13 +55,17 @@ impl Queue for TopOrderQueue {
         self.state[self.order[u_state] as usize] = Some(state);
     }
 
-    fn dequeue(&mut self) {
-        self.state[self.front as usize] = None;
+    fn dequeue(&mut self) -> Option<StateId> {
+        if self.is_empty() {
+            return None;
+        }
+        let old_head = self.state[self.front as usize].take();
         if self.back.is_some() {
             while self.front <= self.back.unwrap() && self.state[self.front as usize].is_none() {
                 self.front += 1;
             }
         }
+        old_head
     }
 
     fn update(&mut self, _state: StateId) {}

--- a/rustfst/src/algorithms/queues/trivial_queue.rs
+++ b/rustfst/src/algorithms/queues/trivial_queue.rs
@@ -18,8 +18,8 @@ impl Queue for TrivialQueue {
         self.state = Some(state);
     }
 
-    fn dequeue(&mut self) {
-        self.state = None;
+    fn dequeue(&mut self) -> Option<StateId> {
+        self.state.take()
     }
 
     fn update(&mut self, _state: StateId) {}

--- a/rustfst/src/algorithms/shortest_distance.rs
+++ b/rustfst/src/algorithms/shortest_distance.rs
@@ -185,9 +185,8 @@ impl<W: Semiring, Q: Queue, A: TrFilter<W>> ShortestDistanceState<W, Q, A> {
         self.radder[source] = W::one();
         self.enqueued[source] = true;
         self.state_queue.enqueue(source as StateId);
-        while !self.state_queue.is_empty() {
-            let state = self.state_queue.head().unwrap() as usize;
-            self.state_queue.dequeue();
+        while let Some(state) = self.state_queue.dequeue() {
+            let state = state as usize;
             //            self.ensure_distance_index_is_valid(state);
             if self.first_path && fst.borrow().is_final(state as StateId)? {
                 break;

--- a/rustfst/src/algorithms/shortest_path.rs
+++ b/rustfst/src/algorithms/shortest_path.rs
@@ -209,10 +209,7 @@ where
 
     queue.enqueue(source);
 
-    while !queue.is_empty() {
-        // Safe because non empty
-        let s = unsafe { queue.head().unsafe_unwrap() };
-        queue.dequeue();
+    while let Some(s) = queue.dequeue() {
         enqueued[s as usize] = false;
         let sd = distance[s as usize].clone();
 


### PR DESCRIPTION
Presumably the previous pattern was copied straight from the C++ version, which presumably does it that way because of the lack of sum types. But in Rust, it is more idiomatic to return a value, like `Vec::pop`.