### PR TITLE
chore: upgrade nom 6 -> 7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,12 +27,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15af2628f6890fe2609a3b91bef4c83450512802e59489f9c1cb1fa5df064a61"
 
 [[package]]
-name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -90,18 +84,6 @@ name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-
-[[package]]
-name = "bitvec"
-version = "0.19.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8942c8d352ae1838c9dda0b0ca2ab657696ef2232a20147cf1b30ae1a9cb4321"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
 
 [[package]]
 name = "bumpalo"
@@ -265,12 +247,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
-name = "funty"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
-
-[[package]]
 name = "generic-array"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -341,19 +317,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "lexical-core"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
-dependencies = [
- "arrayvec",
- "bitflags",
- "cfg-if 1.0.0",
- "ryu",
- "static_assertions",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,16 +338,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
-name = "nom"
-version = "6.2.1"
+name = "minimal-lexical"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c5c51b9083a3c620fa67a2a635d1ce7d95b897e957d6b28ff9a5da960a103a6"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
- "bitvec",
- "funty",
- "lexical-core",
  "memchr",
- "version_check",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -497,12 +463,6 @@ checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "radium"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
 name = "rand"
@@ -809,12 +769,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "std_prelude"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -852,12 +806,6 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -940,12 +888,6 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
-name = "version_check"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "wait-timeout"
@@ -1046,9 +988,3 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "wyz"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"

--- a/rustfst/Cargo.toml
+++ b/rustfst/Cargo.toml
@@ -28,7 +28,7 @@ bitflags = '1'
 generic-array = '0.12'
 getrandom = { version = "0.2", features = ["js"] }
 itertools = '0.9'
-nom = '6'
+nom = '7'
 num-traits = '0.2'
 ordered-float = '3.0'
 rand = '0.8'

--- a/rustfst/src/algorithms/lazy/cache/simple_hash_map_cache.rs
+++ b/rustfst/src/algorithms/lazy/cache/simple_hash_map_cache.rs
@@ -279,7 +279,7 @@ pub fn parse_simple_hashmap_cache<W: SerializableSemiring>(
         num_computed_states as usize,
         num_computed_states as usize,
         parse_hashmap_cache_trs::<W>,
-        HashMap::<StateId, CacheTrs<W>>::new(),
+        HashMap::<StateId, CacheTrs<W>>::new,
         |mut acc: HashMap<StateId, CacheTrs<W>>,
          item: (StateId, CacheTrs<W>)|
          -> HashMap<StateId, CacheTrs<W>> {
@@ -295,7 +295,7 @@ pub fn parse_simple_hashmap_cache<W: SerializableSemiring>(
         num_computed_final_weights as usize,
         num_computed_final_weights as usize,
         parse_hashmap_cache_final_weight::<W>,
-        HashMap::<StateId, Option<W>>::new(),
+        HashMap::<StateId, Option<W>>::new,
         |mut acc: HashMap<StateId, Option<W>>,
          item: (StateId, Option<W>)|
          -> HashMap<StateId, Option<W>> {

--- a/rustfst/src/algorithms/lazy/state_table.rs
+++ b/rustfst/src/algorithms/lazy/state_table.rs
@@ -132,7 +132,7 @@ impl<T: SerializeBinary + Hash + Eq + Clone> SerializeBinary for StateTable<T> {
             tuple_to_id_len as usize,
             tuple_to_id_len as usize,
             parse_tuple_to_id,
-            HashMap::<T, StateId>::new(),
+            HashMap::<T, StateId>::new,
             |mut acc, item| {
                 acc.insert(item.0, item.1);
                 acc

--- a/rustfst/src/semirings/log_weight.rs
+++ b/rustfst/src/semirings/log_weight.rs
@@ -4,6 +4,9 @@ use std::hash::{Hash, Hasher};
 use std::io::Write;
 
 use anyhow::Result;
+use nom::branch::alt;
+use nom::bytes::complete::tag_no_case;
+use nom::combinator::map;
 use nom::number::complete::float;
 use nom::IResult;
 use ordered_float::OrderedFloat;
@@ -155,7 +158,9 @@ impl SerializableSemiring for LogWeight {
     }
 
     fn parse_text(i: &str) -> IResult<&str, Self> {
-        let (i, f) = float(i)?;
+        // FIXME: nom 7 does not fully parse "infinity", therefore it is done manually here until
+        // the PR https://github.com/rust-bakery/nom/pull/1673 is merged.
+        let (i, f) = alt((map(tag_no_case("infinity"), |_| f32::INFINITY), float))(i)?;
         Ok((i, Self::new(f)))
     }
 }

--- a/rustfst/src/semirings/tropical_weight.rs
+++ b/rustfst/src/semirings/tropical_weight.rs
@@ -4,6 +4,9 @@ use std::hash::{Hash, Hasher};
 use std::io::Write;
 
 use anyhow::Result;
+use nom::branch::alt;
+use nom::bytes::complete::tag_no_case;
+use nom::combinator::map;
 use nom::number::complete::float;
 use nom::IResult;
 use ordered_float::OrderedFloat;
@@ -147,7 +150,9 @@ impl SerializableSemiring for TropicalWeight {
     }
 
     fn parse_text(i: &str) -> IResult<&str, Self> {
-        let (i, f) = float(i)?;
+        // FIXME: nom 7 does not fully parse "infinity", therefore it is done manually here until
+        // the PR https://github.com/rust-bakery/nom/pull/1673 is merged.
+        let (i, f) = alt((map(tag_no_case("infinity"), |_| f32::INFINITY), float))(i)?;
         Ok((i, Self::new(f)))
     }
 }


### PR DESCRIPTION
In particular, this fixes the following warning:

```
warning: the following packages contain code that will be rejected by a future version of Rust: nom v6.1.2
```