### PR TITLE
serialize_integer_weight - allow parsing from/to text of IntegerWeight

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "rustfst"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "bimap",
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "rustfst-cli"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -700,7 +700,7 @@ dependencies = [
 
 [[package]]
 name = "rustfst-ffi"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "downcast-rs",

--- a/rustfst/src/semirings/tropical_weight.rs
+++ b/rustfst/src/semirings/tropical_weight.rs
@@ -4,6 +4,9 @@ use std::hash::{Hash, Hasher};
 use std::io::Write;
 
 use anyhow::Result;
+use nom::branch::alt;
+use nom::bytes::complete::tag_no_case;
+use nom::combinator::map;
 use nom::number::complete::float;
 use nom::IResult;
 use ordered_float::OrderedFloat;
@@ -147,7 +150,10 @@ impl SerializableSemiring for TropicalWeight {
     }
 
     fn parse_text(i: &str) -> IResult<&str, Self> {
-        let (i, f) = float(i)?;
+        // FIXME: nom 7 does not fully parse "infinity", therefore it is done manually
+        // even after https://github.com/rust-bakery/nom/pull/1673 wass merged this issue persisted
+        // https://github.com/Garvys/rustfst/pull/253#discussion_r1494208294
+        let (i, f) = alt((map(tag_no_case("infinity"), |_| f32::INFINITY), float))(i)?;
         Ok((i, Self::new(f)))
     }
 }

--- a/rustfst/src/semirings/tropical_weight.rs
+++ b/rustfst/src/semirings/tropical_weight.rs
@@ -4,9 +4,6 @@ use std::hash::{Hash, Hasher};
 use std::io::Write;
 
 use anyhow::Result;
-use nom::branch::alt;
-use nom::bytes::complete::tag_no_case;
-use nom::combinator::map;
 use nom::number::complete::float;
 use nom::IResult;
 use ordered_float::OrderedFloat;
@@ -150,9 +147,7 @@ impl SerializableSemiring for TropicalWeight {
     }
 
     fn parse_text(i: &str) -> IResult<&str, Self> {
-        // FIXME: nom 7 does not fully parse "infinity", therefore it is done manually here until
-        // the PR https://github.com/rust-bakery/nom/pull/1673 is merged.
-        let (i, f) = alt((map(tag_no_case("infinity"), |_| f32::INFINITY), float))(i)?;
+        let (i, f) = float(i)?;
         Ok((i, Self::new(f)))
     }
 }


### PR DESCRIPTION
Resolving https://github.com/Garvys/rustfst/issues/252 so that FSTs using `IntegerWeight` can be serialized properly.