### PR TITLE
Fix connect python

### DIFF
--- a/rustfst-python/rustfst/algorithms/connect.py
+++ b/rustfst-python/rustfst/algorithms/connect.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import ctypes
 from rustfst.ffi_utils import (
     lib,
     check_ffi_error,
@@ -27,9 +26,8 @@ def connect(fst: VectorFst) -> VectorFst:
 
     """
 
-    connectd_fst = ctypes.c_void_p()
-    ret_code = lib.fst_connect(fst.ptr, ctypes.byref(connectd_fst))
+    ret_code = lib.fst_connect(fst.ptr)
     err_msg = "Error during connect"
     check_ffi_error(ret_code, err_msg)
 
-    return VectorFst(ptr=connectd_fst)
+    return VectorFst(ptr=fst.ptr)

--- a/rustfst-python/rustfst/algorithms/connect.py
+++ b/rustfst-python/rustfst/algorithms/connect.py
@@ -30,4 +30,4 @@ def connect(fst: VectorFst) -> VectorFst:
     err_msg = "Error during connect"
     check_ffi_error(ret_code, err_msg)
 
-    return VectorFst(ptr=fst.ptr)
+    return fst

--- a/rustfst-python/tests/algorithms/test_connect.py
+++ b/rustfst-python/tests/algorithms/test_connect.py
@@ -48,6 +48,7 @@ def test_connect():
     tr_3 = Tr(7, 8, 5.0, s1)
     expected_fst.add_tr(s3, tr_3)
 
-    fst1.connect()
+    res = fst1.connect()
 
     assert expected_fst == fst1
+    assert expected_fst == res


### PR DESCRIPTION
The Python API of the `connect` algorithm was always returning an empty FST. This PR fixes that