### PR TITLE
Fix up Clippy issues and do some manual cleanups

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.74.0
+          toolchain: 1.78.0
           components: rustfmt
       - name: Cargo fmt check
         run: cargo fmt --all -- --check
@@ -152,7 +152,7 @@ jobs:
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.74.0
+          toolchain: 1.78.0
           components: clippy
       - name: Cargo Clippy
         run: cargo clippy -- -D warnings
@@ -168,7 +168,7 @@ jobs:
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.74.0
+          toolchain: 1.78.0
       - name: Cargo doc`
         run: cargo doc --all --no-deps
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,7 +730,7 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "rustfst"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "bimap",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "rustfst-cli"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "rustfst-ffi"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "downcast-rs",

--- a/rustfst-ffi/src/algorithms/compose.rs
+++ b/rustfst-ffi/src/algorithms/compose.rs
@@ -279,7 +279,7 @@ pub unsafe extern "C" fn fst_matcher_config_destroy(
             return Ok(());
         }
 
-        unsafe { drop(Box::from_raw(ptr)) }
+        drop(unsafe { Box::from_raw(ptr) });
         Ok(())
     })
 }
@@ -296,7 +296,7 @@ pub unsafe extern "C" fn fst_compose_config_destroy(
             return Ok(());
         }
 
-        unsafe { drop(Box::from_raw(ptr)) }
+        drop(unsafe { Box::from_raw(ptr) });
         Ok(())
     })
 }

--- a/rustfst-ffi/src/fst/mod.rs
+++ b/rustfst-ffi/src/fst/mod.rs
@@ -381,7 +381,7 @@ pub unsafe fn fst_destroy(fst_ptr: *mut CFst) -> RUSTFST_FFI_RESULT {
             return Ok(());
         }
 
-        unsafe { drop(Box::from_raw(fst_ptr)) }
+        drop(unsafe { Box::from_raw(fst_ptr) });
         Ok(())
     })
 }

--- a/rustfst-ffi/src/iterators.rs
+++ b/rustfst-ffi/src/iterators.rs
@@ -127,7 +127,7 @@ pub unsafe extern "C" fn trs_iterator_destroy(iter_ptr: *mut CTrsIterator) -> RU
             return Ok(());
         }
 
-        unsafe { drop(Box::from_raw(iter_ptr)) }
+        drop(unsafe { Box::from_raw(iter_ptr) });
         Ok(())
     })
 }
@@ -313,7 +313,7 @@ pub unsafe extern "C" fn mut_trs_iterator_destroy(
             return Ok(());
         }
 
-        unsafe { drop(Box::from_raw(iter_ptr)) }
+        drop(unsafe { Box::from_raw(iter_ptr) });
         Ok(())
     })
 }
@@ -384,7 +384,7 @@ pub unsafe extern "C" fn state_iterator_destroy(
             return Ok(());
         }
 
-        unsafe { drop(Box::from_raw(iter_ptr)) }
+        drop(unsafe { Box::from_raw(iter_ptr) });
         Ok(())
     })
 }

--- a/rustfst-ffi/src/lib.rs
+++ b/rustfst-ffi/src/lib.rs
@@ -37,7 +37,7 @@ pub enum RUSTFST_FFI_RESULT {
 }
 
 thread_local! {
-    pub(crate) static LAST_ERROR: RefCell<Option<String>> = RefCell::new(None);
+    pub(crate) static LAST_ERROR: RefCell<Option<String>> = const { RefCell::new(None) };
 }
 
 pub fn wrap<F: FnOnce() -> Result<()>>(func: F) -> RUSTFST_FFI_RESULT {

--- a/rustfst-ffi/src/string_path.rs
+++ b/rustfst-ffi/src/string_path.rs
@@ -19,7 +19,7 @@ pub unsafe extern "C" fn string_path_destroy(iter_ptr: *mut CStringPath) -> RUST
             return Ok(());
         }
 
-        unsafe { drop(Box::from_raw(iter_ptr)) }
+        drop(unsafe { Box::from_raw(iter_ptr) });
         Ok(())
     })
 }

--- a/rustfst-ffi/src/string_paths_iterator.rs
+++ b/rustfst-ffi/src/string_paths_iterator.rs
@@ -116,7 +116,7 @@ pub unsafe extern "C" fn string_paths_iterator_destroy(
             return Ok(());
         }
 
-        unsafe { drop(Box::from_raw(iter_ptr)) }
+        drop(unsafe { Box::from_raw(iter_ptr) });
         Ok(())
     })
 }

--- a/rustfst-ffi/src/symbol_table.rs
+++ b/rustfst-ffi/src/symbol_table.rs
@@ -244,7 +244,7 @@ pub unsafe extern "C" fn symt_destroy(symt_ptr: *mut CSymbolTable) -> RUSTFST_FF
             return Ok(());
         }
 
-        unsafe { drop(Box::from_raw(symt_ptr)) }
+        drop(unsafe { Box::from_raw(symt_ptr) });
         Ok(())
     })
 }

--- a/rustfst-ffi/src/tr.rs
+++ b/rustfst-ffi/src/tr.rs
@@ -185,7 +185,7 @@ pub unsafe extern "C" fn tr_delete(tr_ptr: *mut CTr) -> RUSTFST_FFI_RESULT {
             return Ok(());
         }
 
-        unsafe { drop(Box::from_raw(tr_ptr)) }
+        drop(unsafe { Box::from_raw(tr_ptr) });
         Ok(())
     })
 }

--- a/rustfst-ffi/src/trs.rs
+++ b/rustfst-ffi/src/trs.rs
@@ -115,7 +115,7 @@ pub unsafe extern "C" fn trs_vec_delete(trs_ptr: *mut CTrs) -> RUSTFST_FFI_RESUL
             return Ok(());
         }
 
-        unsafe { drop(Box::from_raw(trs_ptr)) }
+        drop(unsafe { Box::from_raw(trs_ptr) });
         Ok(())
     })
 }

--- a/rustfst/src/algorithms/connect.rs
+++ b/rustfst/src/algorithms/connect.rs
@@ -174,13 +174,13 @@ impl<'a, W: Semiring, F: 'a + ExpandedFst<W>> Visitor<'a, W, F> for ConnectVisit
                 }
             }
         }
-        if let Some(_p) = parent {
-            let _p = _p as usize;
+        if let Some(p) = parent {
+            let p = p as usize;
             if self.coaccess[s] {
-                self.coaccess[_p] = true;
+                self.coaccess[p] = true;
             }
-            if self.lowlink[s] < self.lowlink[_p] {
-                self.lowlink[_p] = self.lowlink[s];
+            if self.lowlink[s] < self.lowlink[p] {
+                self.lowlink[p] = self.lowlink[s];
             }
         }
     }

--- a/rustfst/src/algorithms/minimize.rs
+++ b/rustfst/src/algorithms/minimize.rs
@@ -602,10 +602,7 @@ impl TrIterCompare {
         &self,
         x: &TrsIterCollected<W, T>,
         y: &TrsIterCollected<W, T>,
-    ) -> bool
-    where
-        W: Semiring,
-    {
+    ) -> bool {
         let xarc = x.value().unwrap();
         let yarc = y.value().unwrap();
         xarc.ilabel > yarc.ilabel

--- a/rustfst/src/algorithms/queues/fifo_queue.rs
+++ b/rustfst/src/algorithms/queues/fifo_queue.rs
@@ -55,11 +55,11 @@ mod test {
 
         queue.enqueue(2);
         queue.enqueue(3);
-        assert_eq!(queue.is_empty(), false);
+        assert!(!queue.is_empty());
         assert_eq!(queue.head(), Some(2));
         queue.clear();
         assert_eq!(queue.head(), None);
-        assert_eq!(queue.is_empty(), true);
+        assert!(queue.is_empty());
 
         Ok(())
     }

--- a/rustfst/src/algorithms/queues/lifo_queue.rs
+++ b/rustfst/src/algorithms/queues/lifo_queue.rs
@@ -53,11 +53,11 @@ mod test {
 
         queue.enqueue(2);
         queue.enqueue(3);
-        assert_eq!(queue.is_empty(), false);
+        assert!(!queue.is_empty());
         assert_eq!(queue.head(), Some(3));
         queue.clear();
         assert_eq!(queue.head(), None);
-        assert_eq!(queue.is_empty(), true);
+        assert!(queue.is_empty());
 
         Ok(())
     }

--- a/rustfst/src/algorithms/queues/trivial_queue.rs
+++ b/rustfst/src/algorithms/queues/trivial_queue.rs
@@ -57,11 +57,11 @@ mod test {
 
         queue.enqueue(2);
         queue.enqueue(3);
-        assert_eq!(queue.is_empty(), false);
+        assert!(!queue.is_empty());
         assert_eq!(queue.head(), Some(3));
         queue.clear();
         assert_eq!(queue.head(), None);
-        assert_eq!(queue.is_empty(), true);
+        assert!(queue.is_empty());
         Ok(())
     }
 }

--- a/rustfst/src/algorithms/shortest_path.rs
+++ b/rustfst/src/algorithms/shortest_path.rs
@@ -444,7 +444,6 @@ where
     heap.push(final_state);
 
     let weight_threshold = W::zero();
-    let state_threshold: Option<StateId> = None;
     let limit = distance[istart as usize].times(weight_threshold)?;
 
     let mut r = vec![];
@@ -464,10 +463,7 @@ where
         } else {
             W::one()
         };
-        #[allow(clippy::unnecessary_literal_unwrap)]
-        if natural_less(&limit, &d.times(&p.1)?)?
-            || (state_threshold.is_some() && ofst.num_states() >= state_threshold.unwrap() as usize)
-        {
+        if natural_less(&limit, &d.times(&p.1)?)? {
             continue;
         }
 

--- a/rustfst/src/algorithms/state_sort.rs
+++ b/rustfst/src/algorithms/state_sort.rs
@@ -12,6 +12,7 @@ use crate::{StateId, Trs};
 /// `order[i]` gives the the state ID after sorting that corresponds
 /// to the state ID i before sorting; it must therefore be a
 /// permutation of the input FST's states ID sequence.
+#[allow(clippy::assigning_clones)]
 pub fn state_sort<W, F>(fst: &mut F, order: &[StateId]) -> Result<()>
 where
     W: Semiring,

--- a/rustfst/src/fst_impls/vector_fst/serializable_fst.rs
+++ b/rustfst/src/fst_impls/vector_fst/serializable_fst.rs
@@ -126,14 +126,6 @@ impl<W: SerializableSemiring> SerializableFst<W> for VectorFst<W> {
 
 static VECTOR_MIN_FILE_VERSION: i32 = 2;
 
-#[derive(Debug, PartialEq)]
-struct Transition {
-    ilabel: i32,
-    olabel: i32,
-    weight: f32,
-    nextstate: i32,
-}
-
 fn parse_vector_fst_state<W: SerializableSemiring>(
     i: &[u8],
 ) -> IResult<&[u8], VectorFstState<W>, NomCustomError<&[u8]>> {

--- a/rustfst/src/fst_traits/paths_iterator.rs
+++ b/rustfst/src/fst_traits/paths_iterator.rs
@@ -190,11 +190,7 @@ mod tests {
 
         let mut paths_ref = Counter::new();
         paths_ref.update(vec![FstPath::new(vec![], vec![], IntegerWeight::new(38))]);
-        paths_ref.update(vec![FstPath::new(
-            vec![1],
-            vec![1],
-            IntegerWeight::new(1 * 41),
-        )]);
+        paths_ref.update(vec![FstPath::new(vec![1], vec![1], IntegerWeight::new(41))]);
         paths_ref.update(vec![FstPath::new(
             vec![2],
             vec![2],

--- a/rustfst/src/semirings/boolean_weight.rs
+++ b/rustfst/src/semirings/boolean_weight.rs
@@ -93,16 +93,16 @@ mod tests {
         let b_false = BooleanWeight::new(false);
 
         // Test plus
-        assert_eq!(b_true.plus(&b_true)?, b_true);
-        assert_eq!(b_true.plus(&b_false)?, b_true);
-        assert_eq!(b_false.plus(&b_true)?, b_true);
-        assert_eq!(b_false.plus(&b_false)?, b_false);
+        assert_eq!(b_true.plus(b_true)?, b_true);
+        assert_eq!(b_true.plus(b_false)?, b_true);
+        assert_eq!(b_false.plus(b_true)?, b_true);
+        assert_eq!(b_false.plus(b_false)?, b_false);
 
         // Test times
-        assert_eq!(b_true.times(&b_true)?, b_true);
-        assert_eq!(b_true.times(&b_false)?, b_false);
-        assert_eq!(b_false.times(&b_true)?, b_false);
-        assert_eq!(b_false.times(&b_false)?, b_false);
+        assert_eq!(b_true.times(b_true)?, b_true);
+        assert_eq!(b_true.times(b_false)?, b_false);
+        assert_eq!(b_false.times(b_true)?, b_false);
+        assert_eq!(b_false.times(b_false)?, b_false);
         Ok(())
     }
 }

--- a/rustfst/src/symbol_table.rs
+++ b/rustfst/src/symbol_table.rs
@@ -412,25 +412,25 @@ mod tests {
 
         assert_eq!(symt.len(), 3);
 
-        assert_eq!(symt.is_empty(), false);
+        assert!(!symt.is_empty());
 
         assert_eq!(symt.get_label(EPS_SYMBOL), Some(0));
         assert_eq!(symt.get_label("a"), Some(1));
         assert_eq!(symt.get_label("b"), Some(2));
 
-        assert_eq!(symt.contains_symbol(EPS_SYMBOL), true);
-        assert_eq!(symt.contains_symbol("a"), true);
-        assert_eq!(symt.contains_symbol("b"), true);
-        assert_eq!(symt.contains_symbol("c"), false);
+        assert!(symt.contains_symbol(EPS_SYMBOL));
+        assert!(symt.contains_symbol("a"));
+        assert!(symt.contains_symbol("b"));
+        assert!(!symt.contains_symbol("c"));
 
         assert_eq!(symt.get_symbol(0), Some(EPS_SYMBOL));
         assert_eq!(symt.get_symbol(1), Some("a"));
         assert_eq!(symt.get_symbol(2), Some("b"));
 
-        assert_eq!(symt.contains_label(0), true);
-        assert_eq!(symt.contains_label(1), true);
-        assert_eq!(symt.contains_label(2), true);
-        assert_eq!(symt.contains_label(3), false);
+        assert!(symt.contains_label(0));
+        assert!(symt.contains_label(1));
+        assert!(symt.contains_label(2));
+        assert!(!symt.contains_label(3));
     }
 
     #[test]

--- a/rustfst/src/tests_openfst/algorithms/compose.rs
+++ b/rustfst/src/tests_openfst/algorithms/compose.rs
@@ -189,7 +189,7 @@ where
 
     type TComposeFilter<S, F1, F2> = TPushLabelsFilter<S, F1, F2>;
 
-    let fst1: VectorFst<_> = fst_raw.clone().into();
+    let fst1: VectorFst<_> = fst_raw.clone();
     let mut fst2: VectorFst<_> = compose_test_data.fst_2.clone();
 
     let graph1look = Arc::new(TLaFst::new_with_relabeling(fst1, &mut fst2, true)?);
@@ -246,7 +246,7 @@ where
     test_eq_fst(
         &compose_test_data.result,
         &static_fst,
-        format!("Compose failed : filter_name = lookahead"),
+        "Compose failed : filter_name = lookahead".to_string(),
     );
 
     Ok(())

--- a/rustfst/src/tests_openfst/test_symt.rs
+++ b/rustfst/src/tests_openfst/test_symt.rs
@@ -71,15 +71,15 @@ fn run_test_openfst_symt(test_name: &str) -> Result<()> {
 
 #[test]
 fn test_openfst_symt_000() -> Result<()> {
-    run_test_openfst_symt("symt_000").map_err(|v| v.into())
+    run_test_openfst_symt("symt_000")
 }
 
 #[test]
 fn test_openfst_symt_001() -> Result<()> {
-    run_test_openfst_symt("symt_001").map_err(|v| v.into())
+    run_test_openfst_symt("symt_001")
 }
 
 #[test]
 fn test_openfst_symt_002() -> Result<()> {
-    run_test_openfst_symt("symt_002").map_err(|v| v.into())
+    run_test_openfst_symt("symt_002")
 }

--- a/rustfst/src/tests_openfst/test_weights.rs
+++ b/rustfst/src/tests_openfst/test_weights.rs
@@ -87,8 +87,7 @@ fn do_run_test_openfst_weight<W: SerializableSemiring + WeightQuantize>(
 }
 
 fn run_test_openfst_weight(test_name: &str) -> Result<()> {
-    let absolute_path_folder = get_path_folder("weights")?;
-    let mut path_metadata = absolute_path_folder.clone();
+    let mut path_metadata = get_path_folder("weights")?;
     path_metadata.push(format!("{}.json", test_name));
 
     let string = read_to_string(&path_metadata)

--- a/rustfst/src/tests_openfst/test_weights.rs
+++ b/rustfst/src/tests_openfst/test_weights.rs
@@ -163,60 +163,60 @@ fn run_test_openfst_weight(test_name: &str) -> Result<()> {
 
 #[test]
 fn test_openfst_weight_001() -> Result<()> {
-    run_test_openfst_weight("weight_001").map_err(|v| v.into())
+    run_test_openfst_weight("weight_001")
 }
 
 #[test]
 fn test_openfst_weight_002() -> Result<()> {
-    run_test_openfst_weight("weight_002").map_err(|v| v.into())
+    run_test_openfst_weight("weight_002")
 }
 
 #[test]
 fn test_openfst_weight_003() -> Result<()> {
-    run_test_openfst_weight("weight_003").map_err(|v| v.into())
+    run_test_openfst_weight("weight_003")
 }
 
 #[test]
 fn test_openfst_weight_004() -> Result<()> {
-    run_test_openfst_weight("weight_004").map_err(|v| v.into())
+    run_test_openfst_weight("weight_004")
 }
 
 #[test]
 fn test_openfst_weight_005() -> Result<()> {
-    run_test_openfst_weight("weight_005").map_err(|v| v.into())
+    run_test_openfst_weight("weight_005")
 }
 
 #[test]
 fn test_openfst_weight_006() -> Result<()> {
-    run_test_openfst_weight("weight_006").map_err(|v| v.into())
+    run_test_openfst_weight("weight_006")
 }
 
 #[test]
 fn test_openfst_weight_007() -> Result<()> {
-    run_test_openfst_weight("weight_007").map_err(|v| v.into())
+    run_test_openfst_weight("weight_007")
 }
 
 #[test]
 fn test_openfst_weight_008() -> Result<()> {
-    run_test_openfst_weight("weight_008").map_err(|v| v.into())
+    run_test_openfst_weight("weight_008")
 }
 
 #[test]
 fn test_openfst_weight_009() -> Result<()> {
-    run_test_openfst_weight("weight_009").map_err(|v| v.into())
+    run_test_openfst_weight("weight_009")
 }
 
 #[test]
 fn test_openfst_weight_010() -> Result<()> {
-    run_test_openfst_weight("weight_010").map_err(|v| v.into())
+    run_test_openfst_weight("weight_010")
 }
 
 #[test]
 fn test_openfst_weight_011() -> Result<()> {
-    run_test_openfst_weight("weight_011").map_err(|v| v.into())
+    run_test_openfst_weight("weight_011")
 }
 
 #[test]
 fn test_openfst_weight_012() -> Result<()> {
-    run_test_openfst_weight("weight_012").map_err(|v| v.into())
+    run_test_openfst_weight("weight_012")
 }


### PR DESCRIPTION
Clippy has to be run twice to reproduce these results (to cover some
spots that get hit by one lint and then another).

Remaining Clippy issues:

- A lot of instances of `not_unsafe_ptr_arg_deref` under
  `rustfst-ffi`. Fixing those would require either skipping the lint at
  the top level, which Clippy strongly recommends against, or adding
  `unsafe` to many functions, which would be a big change textually and
  I think also technically a breaking change.

- Unused tuple members in `CConstFst` and `CConcatFst`. It's not clear
  what those are supposed to be doing, but they're `pub`, so I'll just
  leave them untouched.