### PR TITLE
Fix types and implementation of SymbolTableIterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `TrivialWeight`
 - Implement `WeaklyDivisibleSemiring` for `BooleanWeight`
 
+## Changed
+- Correct implementation of `SymbolTableIterator` in Python
+
 ## [0.8.0] - 2020-16-10
 
 ## Added

--- a/rustfst-python/rustfst/symbol_table.py
+++ b/rustfst-python/rustfst/symbol_table.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-from typing import Union, Tuple, List
+from typing import Union, Tuple, List, Iterable, Iterator, overload
 
 from rustfst.ffi_utils import lib, check_ffi_error
 import ctypes
 from pathlib import Path
 
 
-class SymbolTable:
+class SymbolTable(Iterable[tuple[int, str]]):
     """
     `SymbolTable` class. This class wraps the `SymbolTable` struct.
     """
@@ -35,13 +35,8 @@ class SymbolTable:
         Returns:
           The integer key of the new symbol.
         """
-        try:
-            symbol = symbol.encode("utf-8")
-        except UnicodeDecodeError:
-            symbol = ctypes.c_char_p(symbol)
-
         integer_key = ctypes.c_size_t()
-        ret_code = lib.symt_add_symbol(self.ptr, symbol, ctypes.byref(integer_key))
+        ret_code = lib.symt_add_symbol(self.ptr, symbol.encode("utf-8"), ctypes.byref(integer_key))
         err_msg = "`add_symbol` failed"
         check_ffi_error(ret_code, err_msg)
 
@@ -71,6 +66,12 @@ class SymbolTable:
 
         return SymbolTable(ptr=clone)
 
+    @overload
+    def find(self, key: int) -> str: ...
+
+    @overload
+    def find(self, key: str) -> int: ...
+
     def find(self, key: Union[int, str]) -> Union[int, str]:
         """
         Given a symbol or index, finds the other one.
@@ -91,18 +92,16 @@ class SymbolTable:
         raise f"key can only be a string or integer. Not {type(key)}"
 
     def _find_index(self, key: int) -> str:
-        key = ctypes.c_size_t(key)
         symbol = ctypes.c_void_p()
-        ret_code = lib.symt_find_index(self.ptr, key, ctypes.byref(symbol))
+        ret_code = lib.symt_find_index(self.ptr, ctypes.c_size_t(key), ctypes.byref(symbol))
         err_msg = "`find` failed"
         check_ffi_error(ret_code, err_msg)
 
         return ctypes.string_at(symbol).decode("utf8")
 
     def _find_symbol(self, symbol: str) -> int:
-        symbol = symbol.encode("utf-8")
         index = ctypes.c_size_t()
-        ret_code = lib.symt_find_symbol(self.ptr, symbol, ctypes.byref(index))
+        ret_code = lib.symt_find_symbol(self.ptr, symbol.encode("utf-8"), ctypes.byref(index))
         err_msg = "`find` failed"
         check_ffi_error(ret_code, err_msg)
 
@@ -243,7 +242,7 @@ class SymbolTable:
 
         return bool(is_equal.value)
 
-    def __eq__(self, other: SymbolTable) -> bool:
+    def __eq__(self, other: object) -> bool:
         """
         Check if this `SymbolTable` is equal to the other
 
@@ -252,6 +251,8 @@ class SymbolTable:
         Returns:
              bool
         """
+        if not isinstance(other, SymbolTable):
+            return NotImplemented
         return self.equals(other)
 
     def __iter__(self) -> SymbolTableIterator:
@@ -284,7 +285,7 @@ class SymbolTable:
         lib.symt_destroy(self.ptr)
 
 
-class SymbolTableIterator:
+class SymbolTableIterator(Iterator[tuple[int, str]]):
     """
     Iterator on a SymbolTable. Allows retrieving all the symbols along with their corresponding labels.
     """
@@ -298,6 +299,9 @@ class SymbolTableIterator:
         self._symt = symbol_table
         self._idx = 0
         self._len = self._symt.num_symbols()
+
+    def __iter__(self) -> SymbolTableIterator:
+        return self
 
     def __next__(self) -> Tuple[int, str]:
         """

--- a/rustfst-python/tests/test_symt.py
+++ b/rustfst-python/tests/test_symt.py
@@ -75,6 +75,7 @@ def test_symt_iterator():
     symt.add_symbol("b")
 
     assert list(symt) == [(0, "<eps>"), (1, "a"), (2, "b")]
+    assert list(symt) == [(idx, sym) for idx, sym in symt]
 
 
 def test_symt_copy_add():


### PR DESCRIPTION
Fixes: #297 

Also corrects the type annotations (there is a separate PR to correct all the other ones) and related bugs.

Notably, you can't just create a `c_char_p` from an arbitrary object, I don't know why you would want to do that.  If you can't encode a `str` as UTF-8 then there is something incredibly wrong with it, and you probably *should* get an exception.