### PR TITLE
Remove `compare` crate dependency via internal stdlib shim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,7 +688,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustfst"
-version = "1.2.6"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "bimap",
@@ -715,7 +715,7 @@ dependencies = [
 
 [[package]]
 name = "rustfst-cli"
-version = "1.2.6"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "rustfst-ffi"
-version = "1.2.6"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "downcast-rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,37 +80,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
-name = "binary-heap-plus"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4551d8382e911ecc0d0f0ffb602777988669be09447d536ff4388d1def11296"
-dependencies = [
- "compare 0.1.0",
-]
-
-[[package]]
-name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec 0.6.3",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec 0.8.0",
+ "bit-vec",
 ]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -171,18 +147,6 @@ checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
  "windows-sys",
 ]
-
-[[package]]
-name = "compare"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0095f6103c2a8b44acd6fd15960c801dafebf02e21940360833e0673f48ba7"
-
-[[package]]
-name = "compare"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120133d4db2ec47efe2e26502ee984747630c67f51974fca0b6c1340cf2368d3"
 
 [[package]]
 name = "counter"
@@ -498,17 +462,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordered_iter"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8dcb2710cda23a8dacbb3fc39f18c883e639e1b6df19b0b10abbdd6919100fe"
-dependencies = [
- "bit-set 0.5.3",
- "bit-vec 0.6.3",
- "vec_map",
-]
-
-[[package]]
 name = "path_abs"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,8 +532,8 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
- "bit-set 0.8.0",
- "bit-vec 0.8.0",
+ "bit-set",
+ "bit-vec",
  "bitflags",
  "num-traits",
  "rand",
@@ -692,7 +645,6 @@ version = "1.3.0"
 dependencies = [
  "anyhow",
  "bimap",
- "binary-heap-plus",
  "bitflags",
  "counter",
  "doc-comment",
@@ -708,7 +660,6 @@ dependencies = [
  "rand_chacha",
  "serde",
  "serde_json",
- "stable_bst",
  "superslice",
  "tempfile",
 ]
@@ -815,16 +766,6 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
-]
-
-[[package]]
-name = "stable_bst"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac1df971c9978cdb75a38e82697472b6a001a9ac9488899da0981c9b35db96ad"
-dependencies = [
- "compare 0.0.6",
- "ordered_iter",
 ]
 
 [[package]]
@@ -935,12 +876,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "wait-timeout"

--- a/rustfst/Cargo.toml
+++ b/rustfst/Cargo.toml
@@ -23,7 +23,6 @@ state-label-u32 = []
 [dependencies]
 anyhow = '1'
 bimap = '0.6'
-binary-heap-plus = '0.5'
 bitflags = '2.5'
 generic-array = '1'
 itertools = '0.14'
@@ -33,7 +32,6 @@ ordered-float = '5'
 rand = '0.9'
 rand_chacha = '0.9'
 serde = { version = '1', features = ['derive'] }
-stable_bst = '0.2'
 superslice = '1'
 
 [dev-dependencies]

--- a/rustfst/src/algorithms/cmp_collections.rs
+++ b/rustfst/src/algorithms/cmp_collections.rs
@@ -1,0 +1,10 @@
+//! Internal stdlib-backed container shims accepting closure comparators.
+//!
+//! These wrap `std::collections::{BinaryHeap, BTreeMap}` to provide the
+//! "comparator object" pattern previously supplied by `binary-heap-plus`
+//! and `stable_bst`, without pulling in the `compare` crate.
+//!
+//! Single-threaded only (uses `Rc`).
+
+#[cfg(test)]
+mod tests {}

--- a/rustfst/src/algorithms/cmp_collections.rs
+++ b/rustfst/src/algorithms/cmp_collections.rs
@@ -73,10 +73,6 @@ impl<T, F: Fn(&T, &T) -> Ordering> CmpHeap<T, F> {
         self.heap.is_empty()
     }
 
-    pub(crate) fn len(&self) -> usize {
-        self.heap.len()
-    }
-
     pub(crate) fn clear(&mut self) {
         self.heap.clear();
     }
@@ -189,7 +185,6 @@ mod tests {
         for v in [3, 1, 4, 1, 5, 9, 2, 6] {
             heap.push(v);
         }
-        assert_eq!(heap.len(), 8);
         assert!(!heap.is_empty());
         assert_eq!(heap.peek(), Some(&1));
 
@@ -199,7 +194,6 @@ mod tests {
         }
         assert_eq!(popped, vec![1, 1, 2, 3, 4, 5, 6, 9]);
         assert!(heap.is_empty());
-        assert_eq!(heap.len(), 0);
     }
 
     #[test]
@@ -209,7 +203,6 @@ mod tests {
         heap.push(20);
         heap.clear();
         assert!(heap.is_empty());
-        assert_eq!(heap.len(), 0);
         assert_eq!(heap.pop(), None);
     }
 
@@ -223,10 +216,9 @@ mod tests {
 
         // Mutating the clone must not affect the original.
         cloned.pop();
-        assert_eq!(original.len(), 5);
-        assert_eq!(cloned.len(), 4);
 
-        // Both heaps should still drain in min-order.
+        // Both heaps drain in min-order; the original still has all 5,
+        // the clone has 4.
         let mut from_orig = Vec::new();
         while let Some(v) = original.pop() {
             from_orig.push(v);

--- a/rustfst/src/algorithms/cmp_collections.rs
+++ b/rustfst/src/algorithms/cmp_collections.rs
@@ -7,7 +7,7 @@
 //! Single-threaded only (uses `Rc`).
 
 use std::cmp::Ordering;
-use std::collections::BinaryHeap;
+use std::collections::{BTreeMap, BinaryHeap};
 use std::fmt;
 use std::rc::Rc;
 
@@ -78,9 +78,9 @@ impl<T, F: Fn(&T, &T) -> Ordering> CmpHeap<T, F> {
     }
 }
 
-impl<T: Clone, F: Fn(&T, &T) -> Ordering + Clone> Clone for CmpHeap<T, F> {
+impl<T: Clone, F: Fn(&T, &T) -> Ordering> Clone for CmpHeap<T, F> {
     fn clone(&self) -> Self {
-        let cmp = Rc::new((*self.cmp).clone());
+        let cmp = Rc::clone(&self.cmp);
         let heap = self
             .heap
             .iter()
@@ -107,7 +107,7 @@ impl<T: fmt::Debug, F: Fn(&T, &T) -> Ordering> fmt::Debug for CmpHeap<T, F> {
 /// for the operations rustfst uses (`insert`, `get`, `get_or_insert`).
 /// Two keys that compare `Equal` under the closure share one entry.
 pub(crate) struct CmpTreeMap<K, V, F: Fn(&K, &K) -> Ordering> {
-    map: std::collections::BTreeMap<KeyedKey<K, F>, V>,
+    map: BTreeMap<KeyedKey<K, F>, V>,
     cmp: Rc<F>,
 }
 
@@ -136,10 +136,10 @@ impl<K, F: Fn(&K, &K) -> Ordering> PartialOrd for KeyedKey<K, F> {
     }
 }
 
-impl<K: Clone, V, F: Fn(&K, &K) -> Ordering> CmpTreeMap<K, V, F> {
+impl<K, V, F: Fn(&K, &K) -> Ordering> CmpTreeMap<K, V, F> {
     pub(crate) fn with_comparator(cmp: F) -> Self {
         Self {
-            map: std::collections::BTreeMap::new(),
+            map: BTreeMap::new(),
             cmp: Rc::new(cmp),
         }
     }
@@ -154,14 +154,6 @@ impl<K: Clone, V, F: Fn(&K, &K) -> Ordering> CmpTreeMap<K, V, F> {
         )
     }
 
-    pub(crate) fn get(&self, key: &K) -> Option<&V> {
-        let probe = KeyedKey {
-            key: key.clone(),
-            cmp: Rc::clone(&self.cmp),
-        };
-        self.map.get(&probe)
-    }
-
     pub(crate) fn get_or_insert<G: FnOnce() -> V>(&mut self, key: K, default: G) -> &mut V {
         self.map
             .entry(KeyedKey {
@@ -169,6 +161,16 @@ impl<K: Clone, V, F: Fn(&K, &K) -> Ordering> CmpTreeMap<K, V, F> {
                 cmp: Rc::clone(&self.cmp),
             })
             .or_insert_with(default)
+    }
+}
+
+impl<K: Clone, V, F: Fn(&K, &K) -> Ordering> CmpTreeMap<K, V, F> {
+    pub(crate) fn get(&self, key: &K) -> Option<&V> {
+        let probe = KeyedKey {
+            key: key.clone(),
+            cmp: Rc::clone(&self.cmp),
+        };
+        self.map.get(&probe)
     }
 }
 

--- a/rustfst/src/algorithms/cmp_collections.rs
+++ b/rustfst/src/algorithms/cmp_collections.rs
@@ -6,5 +6,165 @@
 //!
 //! Single-threaded only (uses `Rc`).
 
+use std::cmp::Ordering;
+use std::collections::BinaryHeap;
+use std::fmt;
+use std::rc::Rc;
+
+/// Stdlib-backed binary heap whose ordering is supplied by a closure.
+///
+/// Behaviourally equivalent to `binary_heap_plus::BinaryHeap::new_by`:
+/// the closure plays the same role as `Ord::cmp`, so the *largest*
+/// element per the closure pops first.
+pub(crate) struct CmpHeap<T, F: Fn(&T, &T) -> Ordering> {
+    heap: BinaryHeap<Item<T, F>>,
+    cmp: Rc<F>,
+}
+
+struct Item<T, F: Fn(&T, &T) -> Ordering> {
+    val: T,
+    cmp: Rc<F>,
+}
+
+impl<T, F: Fn(&T, &T) -> Ordering> PartialEq for Item<T, F> {
+    fn eq(&self, other: &Self) -> bool {
+        (self.cmp)(&self.val, &other.val) == Ordering::Equal
+    }
+}
+
+impl<T, F: Fn(&T, &T) -> Ordering> Eq for Item<T, F> {}
+
+impl<T, F: Fn(&T, &T) -> Ordering> Ord for Item<T, F> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        (self.cmp)(&self.val, &other.val)
+    }
+}
+
+impl<T, F: Fn(&T, &T) -> Ordering> PartialOrd for Item<T, F> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<T, F: Fn(&T, &T) -> Ordering> CmpHeap<T, F> {
+    pub(crate) fn new_by(cmp: F) -> Self {
+        Self {
+            heap: BinaryHeap::new(),
+            cmp: Rc::new(cmp),
+        }
+    }
+
+    pub(crate) fn push(&mut self, val: T) {
+        self.heap.push(Item {
+            val,
+            cmp: Rc::clone(&self.cmp),
+        });
+    }
+
+    pub(crate) fn pop(&mut self) -> Option<T> {
+        self.heap.pop().map(|i| i.val)
+    }
+
+    pub(crate) fn peek(&self) -> Option<&T> {
+        self.heap.peek().map(|i| &i.val)
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.heap.is_empty()
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.heap.len()
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.heap.clear();
+    }
+}
+
+impl<T: Clone, F: Fn(&T, &T) -> Ordering + Clone> Clone for CmpHeap<T, F> {
+    fn clone(&self) -> Self {
+        let cmp = Rc::new((*self.cmp).clone());
+        let heap = self
+            .heap
+            .iter()
+            .map(|i| Item {
+                val: i.val.clone(),
+                cmp: Rc::clone(&cmp),
+            })
+            .collect();
+        Self { heap, cmp }
+    }
+}
+
+impl<T: fmt::Debug, F: Fn(&T, &T) -> Ordering> fmt::Debug for CmpHeap<T, F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_list()
+            .entries(self.heap.iter().map(|i| &i.val))
+            .finish()
+    }
+}
+
 #[cfg(test)]
-mod tests {}
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cmp_heap_min_heap_via_closure() {
+        // Min-heap over i32: closure says `a` is "greater" when `a` is
+        // numerically smaller. Stdlib BinaryHeap pops the max-by-Ord
+        // first, so the smallest pops first.
+        let mut heap: CmpHeap<i32, _> = CmpHeap::new_by(|a: &i32, b: &i32| b.cmp(a));
+        for v in [3, 1, 4, 1, 5, 9, 2, 6] {
+            heap.push(v);
+        }
+        assert_eq!(heap.len(), 8);
+        assert!(!heap.is_empty());
+        assert_eq!(heap.peek(), Some(&1));
+
+        let mut popped = Vec::new();
+        while let Some(v) = heap.pop() {
+            popped.push(v);
+        }
+        assert_eq!(popped, vec![1, 1, 2, 3, 4, 5, 6, 9]);
+        assert!(heap.is_empty());
+        assert_eq!(heap.len(), 0);
+    }
+
+    #[test]
+    fn cmp_heap_clear_resets() {
+        let mut heap: CmpHeap<i32, _> = CmpHeap::new_by(|a: &i32, b: &i32| a.cmp(b));
+        heap.push(10);
+        heap.push(20);
+        heap.clear();
+        assert!(heap.is_empty());
+        assert_eq!(heap.len(), 0);
+        assert_eq!(heap.pop(), None);
+    }
+
+    #[test]
+    fn cmp_heap_clone_produces_equivalent_copy() {
+        let mut original: CmpHeap<i32, _> = CmpHeap::new_by(|a: &i32, b: &i32| b.cmp(a));
+        for v in [3, 1, 4, 1, 5] {
+            original.push(v);
+        }
+        let mut cloned = original.clone();
+
+        // Mutating the clone must not affect the original.
+        cloned.pop();
+        assert_eq!(original.len(), 5);
+        assert_eq!(cloned.len(), 4);
+
+        // Both heaps should still drain in min-order.
+        let mut from_orig = Vec::new();
+        while let Some(v) = original.pop() {
+            from_orig.push(v);
+        }
+        let mut from_clone = Vec::new();
+        while let Some(v) = cloned.pop() {
+            from_clone.push(v);
+        }
+        assert_eq!(from_orig, vec![1, 1, 3, 4, 5]);
+        assert_eq!(from_clone, vec![1, 3, 4, 5]);
+    }
+}

--- a/rustfst/src/algorithms/cmp_collections.rs
+++ b/rustfst/src/algorithms/cmp_collections.rs
@@ -105,6 +105,77 @@ impl<T: fmt::Debug, F: Fn(&T, &T) -> Ordering> fmt::Debug for CmpHeap<T, F> {
     }
 }
 
+/// Stdlib-backed B-tree map whose key ordering is supplied by a closure.
+///
+/// Behaviourally equivalent to `stable_bst::TreeMap::with_comparator`
+/// for the operations rustfst uses (`insert`, `get`, `get_or_insert`).
+/// Two keys that compare `Equal` under the closure share one entry.
+pub(crate) struct CmpTreeMap<K, V, F: Fn(&K, &K) -> Ordering> {
+    map: std::collections::BTreeMap<KeyedKey<K, F>, V>,
+    cmp: Rc<F>,
+}
+
+struct KeyedKey<K, F: Fn(&K, &K) -> Ordering> {
+    key: K,
+    cmp: Rc<F>,
+}
+
+impl<K, F: Fn(&K, &K) -> Ordering> PartialEq for KeyedKey<K, F> {
+    fn eq(&self, other: &Self) -> bool {
+        (self.cmp)(&self.key, &other.key) == Ordering::Equal
+    }
+}
+
+impl<K, F: Fn(&K, &K) -> Ordering> Eq for KeyedKey<K, F> {}
+
+impl<K, F: Fn(&K, &K) -> Ordering> Ord for KeyedKey<K, F> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        (self.cmp)(&self.key, &other.key)
+    }
+}
+
+impl<K, F: Fn(&K, &K) -> Ordering> PartialOrd for KeyedKey<K, F> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<K: Clone, V, F: Fn(&K, &K) -> Ordering> CmpTreeMap<K, V, F> {
+    pub(crate) fn with_comparator(cmp: F) -> Self {
+        Self {
+            map: std::collections::BTreeMap::new(),
+            cmp: Rc::new(cmp),
+        }
+    }
+
+    pub(crate) fn insert(&mut self, key: K, value: V) -> Option<V> {
+        self.map.insert(
+            KeyedKey {
+                key,
+                cmp: Rc::clone(&self.cmp),
+            },
+            value,
+        )
+    }
+
+    pub(crate) fn get(&self, key: &K) -> Option<&V> {
+        let probe = KeyedKey {
+            key: key.clone(),
+            cmp: Rc::clone(&self.cmp),
+        };
+        self.map.get(&probe)
+    }
+
+    pub(crate) fn get_or_insert<G: FnOnce() -> V>(&mut self, key: K, default: G) -> &mut V {
+        self.map
+            .entry(KeyedKey {
+                key,
+                cmp: Rc::clone(&self.cmp),
+            })
+            .or_insert_with(default)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -166,5 +237,61 @@ mod tests {
         }
         assert_eq!(from_orig, vec![1, 1, 3, 4, 5]);
         assert_eq!(from_clone, vec![1, 3, 4, 5]);
+    }
+
+    #[test]
+    fn cmp_tree_map_basic_insert_get() {
+        let mut map: CmpTreeMap<i32, &'static str, _> =
+            CmpTreeMap::with_comparator(|a: &i32, b: &i32| a.cmp(b));
+        assert_eq!(map.insert(1, "one"), None);
+        assert_eq!(map.insert(2, "two"), None);
+        // Re-inserting the same key returns the previous value.
+        assert_eq!(map.insert(1, "uno"), Some("one"));
+        assert_eq!(map.get(&1), Some(&"uno"));
+        assert_eq!(map.get(&2), Some(&"two"));
+        assert_eq!(map.get(&3), None);
+    }
+
+    #[test]
+    fn cmp_tree_map_get_or_insert_only_runs_default_when_vacant() {
+        let mut map: CmpTreeMap<i32, i32, _> =
+            CmpTreeMap::with_comparator(|a: &i32, b: &i32| a.cmp(b));
+
+        let mut counter = 0;
+        // Vacant: closure runs.
+        let v = map.get_or_insert(7, || {
+            counter += 1;
+            100
+        });
+        assert_eq!(*v, 100);
+        assert_eq!(counter, 1);
+
+        // Occupied: closure must NOT run.
+        let v = map.get_or_insert(7, || {
+            counter += 1;
+            200
+        });
+        assert_eq!(*v, 100);
+        assert_eq!(counter, 1);
+    }
+
+    #[test]
+    fn cmp_tree_map_collapses_equivalence_classes() {
+        // Custom comparator: two keys are "equal" when their parity matches.
+        let mut map: CmpTreeMap<i32, &'static str, _> =
+            CmpTreeMap::with_comparator(|a: &i32, b: &i32| (a % 2).cmp(&(b % 2)));
+
+        map.insert(1, "odd-first");
+        // 3 is "equal" to 1 under the comparator → overwrites the entry.
+        assert_eq!(map.insert(3, "odd-second"), Some("odd-first"));
+
+        // Any odd key now retrieves the same entry.
+        assert_eq!(map.get(&5), Some(&"odd-second"));
+        assert_eq!(map.get(&7), Some(&"odd-second"));
+
+        // Even keys form a separate equivalence class.
+        map.insert(2, "even");
+        assert_eq!(map.get(&4), Some(&"even"));
+        assert_eq!(map.get(&6), Some(&"even"));
     }
 }

--- a/rustfst/src/algorithms/minimize.rs
+++ b/rustfst/src/algorithms/minimize.rs
@@ -5,9 +5,9 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::marker::PhantomData;
 
-use crate::algorithms::cmp_collections::{CmpHeap, CmpTreeMap};
 use anyhow::Result;
 
+use crate::algorithms::cmp_collections::{CmpHeap, CmpTreeMap};
 use crate::algorithms::encode::EncodeType;
 use crate::algorithms::factor_weight::factor_iterators::GallicFactorLeft;
 use crate::algorithms::factor_weight::{factor_weight, FactorWeightOptions, FactorWeightType};

--- a/rustfst/src/algorithms/minimize.rs
+++ b/rustfst/src/algorithms/minimize.rs
@@ -5,9 +5,8 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::marker::PhantomData;
 
+use crate::algorithms::cmp_collections::{CmpHeap, CmpTreeMap};
 use anyhow::Result;
-use binary_heap_plus::BinaryHeap;
-use stable_bst::TreeMap;
 
 use crate::algorithms::encode::EncodeType;
 use crate::algorithms::factor_weight::factor_iterators::GallicFactorLeft;
@@ -348,10 +347,8 @@ impl AcyclicMinimizer {
         let height = self.partition.borrow().num_classes();
         for h in 0..height {
             // We need here a binary search tree in order to order the states id and create a partition.
-            // For now uses the crate `stable_bst` which is quite old but seems to do the job
-            // TODO: Bench the performances of the implementation. Maybe re-write it.
             let mut equiv_classes =
-                TreeMap::<StateId, StateId, _>::with_comparator(|a: &StateId, b: &StateId| {
+                CmpTreeMap::<StateId, StateId, _>::with_comparator(|a: &StateId, b: &StateId| {
                     state_cmp.compare(*a, *b).unwrap()
                 });
 
@@ -523,7 +520,7 @@ fn cyclic_minimize<W: Semiring, F: MutableFst<W>>(fst: &mut F) -> Result<Rc<RefC
 
     let comp = TrIterCompare {};
 
-    let mut aiter_queue = BinaryHeap::new_by(|v1, v2| {
+    let mut aiter_queue = CmpHeap::new_by(|v1, v2| {
         if comp.compare(v1, v2) {
             Ordering::Less
         } else {

--- a/rustfst/src/algorithms/mod.rs
+++ b/rustfst/src/algorithms/mod.rs
@@ -33,6 +33,7 @@ mod add_super_final_state;
 mod all_pairs_shortest_distance;
 /// Functions to compute Kleene closure (star or plus) of an FST.
 pub mod closure;
+pub(crate) mod cmp_collections;
 #[allow(clippy::type_complexity)]
 /// Functions to compose FSTs.
 pub mod compose;

--- a/rustfst/src/algorithms/queues/shortest_first_queue.rs
+++ b/rustfst/src/algorithms/queues/shortest_first_queue.rs
@@ -2,8 +2,8 @@ use std::cmp::Ordering;
 use std::fmt::Debug;
 use std::fmt::Formatter;
 
+use crate::algorithms::cmp_collections::CmpHeap;
 use anyhow::Result;
-use binary_heap_plus::{BinaryHeap, FnComparator};
 
 use crate::algorithms::{Queue, QueueType};
 use crate::semirings::Semiring;
@@ -31,7 +31,7 @@ pub fn natural_less<W: Semiring>(w1: &W, w2: &W) -> Result<bool> {
 
 #[derive(Clone)]
 pub struct ShortestFirstQueue<C: Clone + Fn(&StateId, &StateId) -> Ordering> {
-    heap: BinaryHeap<StateId, FnComparator<C>>,
+    heap: CmpHeap<StateId, C>,
 }
 
 impl<C: Clone + Fn(&StateId, &StateId) -> Ordering> Debug for ShortestFirstQueue<C> {
@@ -43,7 +43,7 @@ impl<C: Clone + Fn(&StateId, &StateId) -> Ordering> Debug for ShortestFirstQueue
 impl<C: Clone + Fn(&StateId, &StateId) -> Ordering> ShortestFirstQueue<C> {
     pub fn new(c: C) -> Self {
         Self {
-            heap: BinaryHeap::new_by(c),
+            heap: CmpHeap::new_by(c),
         }
     }
 }

--- a/rustfst/src/algorithms/queues/shortest_first_queue.rs
+++ b/rustfst/src/algorithms/queues/shortest_first_queue.rs
@@ -2,9 +2,9 @@ use std::cmp::Ordering;
 use std::fmt::Debug;
 use std::fmt::Formatter;
 
-use crate::algorithms::cmp_collections::CmpHeap;
 use anyhow::Result;
 
+use crate::algorithms::cmp_collections::CmpHeap;
 use crate::algorithms::{Queue, QueueType};
 use crate::semirings::Semiring;
 use crate::StateId;


### PR DESCRIPTION
  # Context
  `rustfst` transitively depends on the unmaintained `compare` crate in
  two duplicated versions — `0.0.6` via `stable_bst 0.2` and `0.1.0` via
  `binary-heap-plus 0.5`. Both third-party crates use `compare::Compare<T>`
  only as a nameable type parameter so their generics can accept
  `Fn(&T, &T) -> Ordering` closures, a role stdlib already plays for
  `slice::sort_by` etc.

# Changes
  - New `pub(crate)` module `rustfst/src/algorithms/cmp_collections.rs`:
    - `CmpHeap<T, F>` — wraps `std::collections::BinaryHeap`, semantics
      match `binary_heap_plus::BinaryHeap::new_by` exactly.
    - `CmpTreeMap<K, V, F>` — wraps `std::collections::BTreeMap`, supplies
      the four ops minimize uses (`with_comparator`, `insert`, `get`,
      `get_or_insert`); keys comparing `Equal` under the closure share one
      entry, matching `stable_bst::TreeMap`.
    - Comparator is shared via `Rc<F>` per item — single-threaded only,
      matching the existing posture of both call sites.
  - Migrated `queues/shortest_first_queue.rs` and two spots in
    `minimize.rs` to the new shims. Three lines each, no algorithmic
    change; the stale `// uses crate stable_bst …` comment is dropped.
  - Dropped `binary-heap-plus` and `stable_bst` from `rustfst/Cargo.toml`.
    **8 crates removed** from the lockfile: `binary-heap-plus`,
    `stable_bst`, `compare` ×2, `ordered_iter`, `vec_map`, `bit-set 0.5`,
    `bit-vec 0.6`.