### PR TITLE
feat: Support compilation as `wasm32-unknown-unknown`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,20 +234,26 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ffi-convert"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d96fa39640e119d4bc9898672ab63d9c575810dbad8806683a993fa8de0a8b"
+version = "0.7.0"
 dependencies = [
- "ffi-convert-derive",
- "libc",
+ "ffi-convert-derive 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
 ]
 
 [[package]]
 name = "ffi-convert-derive"
-version = "0.6.2"
+version = "0.7.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ffi-convert-derive"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "480d55e4c9442832b168701bcc7f2e3282608f841791224ea1ed6ae35d450175"
+checksum = "6137314991d3d201a27d9805429094fc51a11bb41c4f259498b0cc656d538da8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -683,7 +689,6 @@ dependencies = [
  "anyhow",
  "downcast-rs",
  "ffi-convert",
- "libc",
  "rustfst",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,9 +454,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "ordered-float"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0218004a4aae742209bee9c3cef05672f6b2708be36a50add8eb613b1f2a4008"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
 ]
@@ -641,7 +641,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustfst"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bimap",
@@ -651,7 +651,6 @@ dependencies = [
  "generic-array",
  "itertools",
  "nom",
- "num-traits",
  "ordered-float",
  "path_abs",
  "pretty_assertions",
@@ -666,7 +665,7 @@ dependencies = [
 
 [[package]]
 name = "rustfst-cli"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -679,7 +678,7 @@ dependencies = [
 
 [[package]]
 name = "rustfst-ffi"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "downcast-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,11 @@
 [workspace]
+resolver = "2"
 members = [
     "rustfst",
     "rustfst-cli",
     "rustfst-ffi",
+    "ffi-convert",
+    "ffi-convert-derive",
 ]
 
 [profile.release]

--- a/ffi-convert-derive/Cargo.toml
+++ b/ffi-convert-derive/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "ffi-convert-derive"
+version = "0.7.0"
+authors = ["Sonos"]
+edition = "2018"
+license = "MIT OR Apache-2.0"
+description = "Macros implementations of CReprOf, AsRust, CDrop traits from ffi-convert"
+repository = "https://github.com/sonos/ffi-convert-rs"
+readme = "../README.md"
+keywords = ["ffi"]
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "1.0.2"
+proc-macro2 = "1.0.6"
+
+[dependencies.syn]
+version = "1.0.16"
+features = ["extra-traits", "full"]

--- a/ffi-convert-derive/src/asrust.rs
+++ b/ffi-convert-derive/src/asrust.rs
@@ -1,0 +1,163 @@
+use proc_macro::TokenStream;
+
+use quote::quote;
+use syn::parse::{Parse, ParseBuffer};
+
+use crate::utils::{
+    parse_enum_variants, parse_struct_fields, parse_target_type, Field, TypeArrayOrTypePath,
+};
+
+pub fn impl_asrust_macro(input: &syn::DeriveInput) -> TokenStream {
+    let name = &input.ident;
+    let target_type = parse_target_type(&input.attrs);
+
+    match &input.data {
+        syn::Data::Struct(data_struct) => {
+            impl_asrust_struct(name, &target_type, data_struct, input)
+        }
+        syn::Data::Enum(data_enum) => impl_asrust_enum(name, &target_type, data_enum),
+        _ => panic!("AsRust can only be derived for structs and unit enums"),
+    }
+}
+
+fn impl_asrust_struct(
+    struct_name: &syn::Ident,
+    target_type: &syn::Path,
+    data: &syn::DataStruct,
+    input: &syn::DeriveInput,
+) -> TokenStream {
+    let fields = parse_struct_fields(data)
+        .iter()
+        .filter_map(|field| {
+            let Field {
+                name: field_name,
+                target_name: target_field_name,
+                ref field_type,
+                ..
+            } = field;
+
+            if field.levels_of_indirection > 1 && !field.is_nullable {
+                panic!(
+                    "The CReprOf, AsRust, and CDrop traits cannot be derived automatically: \
+                    The field {} is a pointer field has too many levels of indirection \
+                    ({} in this case). Please implements those traits manually.",
+                    field_name, field.levels_of_indirection
+                )
+            }
+
+            let mut conversion = if field.is_string {
+                quote!( {
+                    use ffi_convert::RawBorrow;
+                    unsafe { std::ffi::CStr::raw_borrow(self.#field_name) }?.as_rust()?
+                })
+            } else if field.is_pointer {
+                match field_type {
+                    TypeArrayOrTypePath::TypeArray(type_array) => {
+                        quote!( {
+                        let ref_to_array = unsafe { <#type_array>::raw_borrow(self.#field_name)? };
+                        let converted_array = ref_to_struct.as_rust()?;
+                        converted_array
+                    })
+                    }
+                    TypeArrayOrTypePath::TypePath(type_path) => {
+                        quote!( {
+                        let ref_to_struct = unsafe { #type_path::raw_borrow(self.#field_name)? };
+                        let converted_struct = ref_to_struct.as_rust()?;
+                        converted_struct
+                    })
+                    }
+                }
+
+            } else {
+                quote!(self.#field_name.as_rust()?)
+            };
+
+            conversion = if field.is_nullable {
+                quote!(
+                    #target_field_name: if !self.#field_name.is_null() {
+                        Some(#conversion)
+                    } else {
+                        None
+                    }
+                )
+            } else {
+                quote!(
+                    #target_field_name: #conversion
+                )
+            };
+            if field.c_repr_of_convert.is_some() {
+                // ignore field for as_rust if it has a special c_repr_of handling
+                None
+            } else {
+                Some(conversion)
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let extra_fields = &input
+        .attrs
+        .iter()
+        .filter(|attribute| {
+            attribute.path.get_ident().map(|it| it.to_string())
+                == Some("as_rust_extra_field".into())
+        })
+        .map(|it| {
+            let ExtraFieldsArgs { field_name, init } = it
+                .parse_args()
+                .expect("Could not parse args for as_rust_extra_field");
+            quote! {#field_name: #init}
+        })
+        .collect::<Vec<_>>();
+
+    quote!(
+        impl AsRust<#target_type> for #struct_name {
+            fn as_rust(&self) -> Result<#target_type, ffi_convert::AsRustError> {
+                Ok(#target_type {
+                    #(#fields, )*
+                    #(#extra_fields, )*
+                })
+            }
+        }
+    )
+    .into()
+}
+
+fn impl_asrust_enum(
+    enum_name: &syn::Ident,
+    target_type: &syn::Path,
+    data: &syn::DataEnum,
+) -> TokenStream {
+    let variants = parse_enum_variants(data);
+
+    let match_arms = variants
+        .iter()
+        .map(|variant| quote!(#enum_name::#variant => Ok(#target_type::#variant)));
+
+    quote!(
+        impl AsRust<#target_type> for #enum_name {
+            fn as_rust(&self) -> Result<#target_type, ffi_convert::AsRustError> {
+                match self {
+                    #(#match_arms,)*
+                }
+            }
+        }
+    )
+    .into()
+}
+
+struct ExtraFieldsArgs {
+    field_name: syn::Ident,
+    init: syn::Expr,
+}
+
+impl Parse for ExtraFieldsArgs {
+    fn parse(input: &ParseBuffer) -> Result<Self, syn::parse::Error> {
+        let field_name = input.parse()?;
+
+        input.parse::<syn::Token![=]>()?;
+
+        let init = input.parse()?;
+
+        Ok(ExtraFieldsArgs { field_name, init })
+    }
+}

--- a/ffi-convert-derive/src/cdrop.rs
+++ b/ffi-convert-derive/src/cdrop.rs
@@ -1,0 +1,112 @@
+use crate::utils::{parse_no_drop_impl_flag, parse_struct_fields, Field, TypeArrayOrTypePath};
+use proc_macro::TokenStream;
+use quote::quote;
+
+pub fn impl_cdrop_macro(input: &syn::DeriveInput) -> TokenStream {
+    let name = &input.ident;
+    let disable_drop_impl = parse_no_drop_impl_flag(&input.attrs);
+
+    match &input.data {
+        syn::Data::Struct(data_struct) => impl_cdrop_struct(name, disable_drop_impl, data_struct),
+        syn::Data::Enum(_) => impl_cdrop_enum(name, disable_drop_impl),
+        _ => panic!("CDrop can only be derived for structs and unit enums"),
+    }
+}
+
+fn impl_cdrop_struct(
+    struct_name: &syn::Ident,
+    disable_drop_impl: bool,
+    data: &syn::DataStruct,
+) -> TokenStream {
+    let fields = parse_struct_fields(data);
+
+    let do_drop_fields = fields
+        .iter()
+        .map(|field| {
+            let Field {
+                name: field_name,
+                ref field_type,
+                ..
+            } = field;
+
+            let drop_field = if field.is_string {
+                quote!({
+                    use ffi_convert::RawPointerConverter;
+                    unsafe { std::ffi::CString::drop_raw_pointer(self.#field_name) }?
+                })
+            } else if field.is_pointer {
+                match field_type {
+                    TypeArrayOrTypePath::TypeArray(type_array) => {
+                        quote!( unsafe { <#type_array>::drop_raw_pointer(self.#field_name) }? )
+                    }
+                    TypeArrayOrTypePath::TypePath(type_path) => {
+                        quote!( unsafe { #type_path::drop_raw_pointer(self.#field_name) }? )
+                    }
+                }
+            } else {
+                // the other cases will be handled automatically by rust
+                quote!()
+            };
+
+            if field.is_nullable {
+                quote!(
+                    if !self.#field_name.is_null() {
+                       # drop_field
+                    }
+                )
+            } else {
+                drop_field
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let c_drop_impl = quote!(
+        impl CDrop for #struct_name {
+            fn do_drop(&mut self) -> Result<(), ffi_convert::CDropError> {
+                use ffi_convert::RawPointerConverter;
+                #(#do_drop_fields;)*
+                Ok(())
+            }
+        }
+    );
+
+    let drop_impl = quote!(
+        impl Drop for #struct_name {
+            fn drop(&mut self) {
+                let _ = self.do_drop();
+            }
+        }
+    );
+
+    if disable_drop_impl {
+        quote!(#c_drop_impl)
+    } else {
+        quote!(#c_drop_impl #drop_impl)
+    }
+    .into()
+}
+
+fn impl_cdrop_enum(enum_name: &syn::Ident, disable_drop_impl: bool) -> TokenStream {
+    let c_drop_impl = quote!(
+        impl CDrop for #enum_name {
+            fn do_drop(&mut self) -> Result<(), ffi_convert::CDropError> {
+                Ok(())
+            }
+        }
+    );
+
+    let drop_impl = quote!(
+        impl Drop for #enum_name {
+            fn drop(&mut self) {
+                let _ = self.do_drop();
+            }
+        }
+    );
+
+    if disable_drop_impl {
+        quote!(#c_drop_impl)
+    } else {
+        quote!(#c_drop_impl #drop_impl)
+    }
+    .into()
+}

--- a/ffi-convert-derive/src/creprof.rs
+++ b/ffi-convert-derive/src/creprof.rs
@@ -1,0 +1,108 @@
+use proc_macro::TokenStream;
+
+use quote::quote;
+
+use crate::utils::{
+    parse_enum_variants, parse_struct_fields, parse_target_type, Field, TypeArrayOrTypePath,
+};
+
+pub fn impl_creprof_macro(input: &syn::DeriveInput) -> TokenStream {
+    let name = &input.ident;
+    let target_type = parse_target_type(&input.attrs);
+
+    match &input.data {
+        syn::Data::Struct(data_struct) => impl_creprof_struct(name, &target_type, data_struct),
+        syn::Data::Enum(data_enum) => impl_creprof_enum(name, &target_type, data_enum),
+        _ => panic!("CReprOf can only be derived for structs and unit enums"),
+    }
+}
+
+fn impl_creprof_struct(
+    struct_name: &syn::Ident,
+    target_type: &syn::Path,
+    data: &syn::DataStruct,
+) -> TokenStream {
+    let fields = parse_struct_fields(data);
+    let c_repr_of_fields = fields
+        .iter()
+        .map(|field| {
+            let Field {
+                name: field_name,
+                target_name: target_field_name,
+                ref field_type,
+                ..
+            } = field;
+
+            let mut conversion = if field.is_string {
+                quote!(std::ffi::CString::c_repr_of(field)?)
+            } else {
+                match field_type {
+                    TypeArrayOrTypePath::TypeArray(type_array) => {
+                        quote!(<#type_array>::c_repr_of(field)?)
+                    }
+                    TypeArrayOrTypePath::TypePath(type_path) => {
+                        quote!(#type_path::c_repr_of(field)?)
+                    }
+                }
+            };
+
+            if field.is_pointer {
+                for _ in 0..field.levels_of_indirection {
+                    conversion = quote!(#conversion.into_raw_pointer())
+                }
+            }
+
+            conversion = if field.is_nullable {
+                quote!(
+                    #field_name: if let Some(field) = input.#target_field_name {
+                        #conversion
+                    } else {
+                        std::ptr::null() as _
+                    }
+                )
+            } else {
+                quote!(#field_name: { let field = input.#target_field_name ; #conversion })
+            };
+            if let Some(convert) = &field.c_repr_of_convert {
+                quote!(#field_name: #convert)
+            } else {
+                conversion
+            }
+        })
+        .collect::<Vec<_>>();
+
+    quote!(
+        impl CReprOf<#target_type> for #struct_name {
+            fn c_repr_of(input: #target_type) -> Result<Self, ffi_convert::CReprOfError> {
+                use ffi_convert::RawPointerConverter;
+                Ok(Self {
+                    #(#c_repr_of_fields,)*
+                })
+            }
+        }
+    )
+    .into()
+}
+
+fn impl_creprof_enum(
+    enum_name: &syn::Ident,
+    target_type: &syn::Path,
+    data: &syn::DataEnum,
+) -> TokenStream {
+    let variants = parse_enum_variants(data);
+
+    let match_arms = variants
+        .iter()
+        .map(|variant| quote!(#target_type::#variant => Ok(#enum_name::#variant)));
+
+    quote!(
+        impl CReprOf<#target_type> for #enum_name {
+            fn c_repr_of(input: #target_type) -> Result<Self, ffi_convert::CReprOfError> {
+                match input {
+                    #(#match_arms,)*
+                }
+            }
+        }
+    )
+    .into()
+}

--- a/ffi-convert-derive/src/lib.rs
+++ b/ffi-convert-derive/src/lib.rs
@@ -1,0 +1,51 @@
+//! This crate provides ffi_convert derive macros for CReprOf, AsRust and CDrop traits.
+
+extern crate proc_macro;
+
+mod asrust;
+mod cdrop;
+mod creprof;
+mod rawpointerconverter;
+mod utils;
+
+use asrust::impl_asrust_macro;
+use cdrop::impl_cdrop_macro;
+use creprof::impl_creprof_macro;
+use proc_macro::TokenStream;
+use rawpointerconverter::impl_rawpointerconverter_macro;
+
+#[proc_macro_derive(
+    CReprOf,
+    attributes(target_type, nullable, c_repr_of_convert, target_name)
+)]
+pub fn creprof_derive(token_stream: TokenStream) -> TokenStream {
+    let ast = syn::parse(token_stream).unwrap();
+    impl_creprof_macro(&ast)
+}
+
+#[proc_macro_derive(
+    AsRust,
+    attributes(
+        target_type,
+        nullable,
+        as_rust_extra_field,
+        as_rust_ignore,
+        target_name
+    )
+)]
+pub fn asrust_derive(token_stream: TokenStream) -> TokenStream {
+    let ast = syn::parse(token_stream).unwrap();
+    impl_asrust_macro(&ast)
+}
+
+#[proc_macro_derive(CDrop, attributes(no_drop_impl, nullable))]
+pub fn cdrop_derive(token_stream: TokenStream) -> TokenStream {
+    let ast = syn::parse(token_stream).unwrap();
+    impl_cdrop_macro(&ast)
+}
+
+#[proc_macro_derive(RawPointerConverter)]
+pub fn rawpointerconverter_derive(token_stream: TokenStream) -> TokenStream {
+    let ast = syn::parse(token_stream).unwrap();
+    impl_rawpointerconverter_macro(&ast)
+}

--- a/ffi-convert-derive/src/rawpointerconverter.rs
+++ b/ffi-convert-derive/src/rawpointerconverter.rs
@@ -1,0 +1,27 @@
+use proc_macro::TokenStream;
+use quote::quote;
+
+pub fn impl_rawpointerconverter_macro(input: &syn::DeriveInput) -> TokenStream {
+    let struct_name = &input.ident;
+
+    quote!(
+        impl RawPointerConverter<# struct_name> for # struct_name {
+            fn into_raw_pointer(self) -> *const # struct_name {
+                ffi_convert::convert_into_raw_pointer(self)
+            }
+
+            fn into_raw_pointer_mut(self) -> *mut # struct_name {
+                ffi_convert::convert_into_raw_pointer_mut(self)
+            }
+
+            unsafe fn from_raw_pointer_mut(input: *mut # struct_name) -> Result<# struct_name, ffi_convert::UnexpectedNullPointerError> {
+                ffi_convert::take_back_from_raw_pointer_mut(input)
+            }
+
+            unsafe fn from_raw_pointer(input: *const # struct_name) -> Result<# struct_name, ffi_convert::UnexpectedNullPointerError> {
+                ffi_convert::take_back_from_raw_pointer(input)
+            }
+
+        }
+    ).into()
+}

--- a/ffi-convert-derive/src/utils.rs
+++ b/ffi-convert-derive/src/utils.rs
@@ -1,0 +1,325 @@
+pub fn parse_target_type(attrs: &[syn::Attribute]) -> syn::Path {
+    let target_type_attribute = attrs
+        .iter()
+        .find(|attribute| {
+            attribute.path.get_ident().map(|it| it.to_string()) == Some("target_type".into())
+        })
+        .expect("Can't derive CReprOf without target_type helper attribute.");
+
+    target_type_attribute.parse_args().unwrap()
+}
+
+pub fn parse_no_drop_impl_flag(attrs: &[syn::Attribute]) -> bool {
+    attrs.iter().any(|attribute| {
+        attribute.path.get_ident().map(|it| it.to_string()) == Some("no_drop_impl".to_string())
+    })
+}
+
+pub fn parse_struct_fields(data: &syn::DataStruct) -> Vec<Field<'_>> {
+    data.fields.iter().map(parse_field).collect::<Vec<Field>>()
+}
+
+pub fn parse_enum_variants(data: &syn::DataEnum) -> Vec<&syn::Ident> {
+    data.variants
+        .iter()
+        .map(|variant| {
+            if !variant.fields.is_empty() {
+                panic!(
+                    "CReprOf, AsRust, and CDrop derive for enums only supports unit variants \
+                     (no fields). Variant `{}` has fields.",
+                    variant.ident
+                );
+            }
+            &variant.ident
+        })
+        .collect()
+}
+
+#[derive(PartialEq, Eq, Debug)]
+pub enum TypeArrayOrTypePath {
+    TypeArray(syn::TypeArray),
+    TypePath(syn::TypePath),
+}
+
+pub struct Field<'a> {
+    pub name: &'a syn::Ident,
+    pub target_name: syn::Ident,
+    pub field_type: TypeArrayOrTypePath,
+    #[allow(unused)]
+    pub type_params: Option<syn::AngleBracketedGenericArguments>,
+    pub is_nullable: bool,
+    pub is_string: bool,
+    pub is_pointer: bool,
+    pub c_repr_of_convert: Option<syn::Expr>,
+    pub levels_of_indirection: u32,
+}
+
+pub fn parse_field(field: &syn::Field) -> Field<'_> {
+    let name = field.ident.as_ref().expect("Field should have an ident");
+
+    let target_name = field
+        .attrs
+        .iter()
+        .find(|attr| attr.path.get_ident().map(|it| it.to_string()) == Some("target_name".into()))
+        .map(|attr| {
+            attr.parse_args()
+                .expect("Could not parse attributes of c_repr_of_convert")
+        })
+        .unwrap_or_else(|| name.clone());
+
+    let mut inner_field_type: syn::Type = field.ty.clone();
+    let mut levels_of_indirection: u32 = 0;
+
+    while let syn::Type::Ptr(ptr_t) = inner_field_type {
+        inner_field_type = *ptr_t.elem;
+        levels_of_indirection += 1;
+    }
+
+    let (field_type, type_params) = match inner_field_type {
+        syn::Type::Path(type_path) => generic_path_to_concrete_type_path(type_path),
+        syn::Type::Array(type_array) => (TypeArrayOrTypePath::TypeArray(type_array), None),
+        _ => panic!("Field type used in this struct is not supported by the proc macro"),
+    };
+
+    let is_nullable = field
+        .attrs
+        .iter()
+        .any(|attr| attr.path.get_ident().map(|it| it.to_string()) == Some("nullable".into()));
+
+    let c_repr_of_convert = field
+        .attrs
+        .iter()
+        .find(|attr| {
+            attr.path.get_ident().map(|it| it.to_string()) == Some("c_repr_of_convert".into())
+        })
+        .map(|attr| {
+            attr.parse_args()
+                .expect("Could not parse attributes of c_repr_of_convert")
+        });
+
+    let is_string = match &field.ty {
+        syn::Type::Ptr(ptr_t) => {
+            match &*ptr_t.elem {
+                syn::Type::Path(path_t) => {
+                    // We are trying to detect the c_char identifier in the last segment
+                    if let Some(segment) = path_t.path.segments.last() {
+                        &segment.ident.to_string() == "c_char"
+                    } else {
+                        false
+                    }
+                }
+                _ => false,
+            }
+        }
+        _ => false,
+    };
+
+    let is_pointer = matches!(&field.ty, syn::Type::Ptr(_));
+
+    Field {
+        name,
+        target_name,
+        field_type,
+        is_nullable,
+        is_string,
+        is_pointer,
+        c_repr_of_convert,
+        levels_of_indirection,
+        type_params,
+    }
+}
+
+/// A helper function that extracts type parameters from type definitions of fields.  
+///
+/// Some procedural macros need to extract type parameters from the definitions of a struct's fields.
+/// For instance, if a struct has a field, with the following type :
+///  `std::module1::module2::Vec<Hello>`, the goal of this function is to transform this in :
+/// `(std::module1::module2::Vec`, `Hello`)`
+///
+pub fn generic_path_to_concrete_type_path(
+    mut path: syn::TypePath,
+) -> (
+    TypeArrayOrTypePath,
+    Option<syn::AngleBracketedGenericArguments>,
+) {
+    let last_seg: Option<&mut syn::PathSegment> = path.path.segments.last_mut();
+
+    if let Some(last_segment) = last_seg {
+        if let syn::PathArguments::AngleBracketed(ref bracketed_type_params) =
+            last_segment.arguments
+        {
+            let extracted_type_params = (*bracketed_type_params).clone();
+            last_segment.arguments = syn::PathArguments::None;
+            (
+                TypeArrayOrTypePath::TypePath(path),
+                Some(extracted_type_params),
+            )
+        } else {
+            (TypeArrayOrTypePath::TypePath(path), None)
+        }
+    } else {
+        panic!("Invalid type path: no segments on the TypePath")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use syn::TypePath;
+
+    use super::*;
+
+    #[test]
+    fn test_type_parameter_extraction() {
+        let type_path = syn::parse_str::<TypePath>("std::mod1::mod2::Foo<Bar>").unwrap();
+
+        let (transformed_type_path, extracted_type_param) =
+            generic_path_to_concrete_type_path(type_path);
+
+        assert_eq!(extracted_type_param.unwrap().args.len(), 1);
+        assert_eq!(
+            transformed_type_path,
+            TypeArrayOrTypePath::TypePath(
+                syn::parse_str::<TypePath>("std::mod1::mod2::Foo").unwrap()
+            )
+        );
+    }
+
+    #[test]
+    fn test_type_parameters_extraction() {
+        let type_path = syn::parse_str::<TypePath>("std::mod1::mod2::Foo<Bar, Baz>").unwrap();
+
+        let (transformed_type_path, extracted_type_param) =
+            generic_path_to_concrete_type_path(type_path);
+
+        assert_eq!(
+            transformed_type_path,
+            TypeArrayOrTypePath::TypePath(
+                syn::parse_str::<TypePath>("std::mod1::mod2::Foo").unwrap()
+            )
+        );
+        assert_eq!(extracted_type_param.unwrap().args.len(), 2)
+    }
+
+    #[test]
+    fn test_type_parameter_extraction_works_without_params() {
+        let original_path = syn::parse_str::<TypePath>("std::module1::module2::Hello")
+            .expect("Could not parse str into syn::Path");
+        let (transformed_path, extracted_type_params) =
+            generic_path_to_concrete_type_path(original_path);
+
+        assert!(extracted_type_params.is_none());
+        assert_eq!(
+            transformed_path,
+            TypeArrayOrTypePath::TypePath(
+                syn::parse_str::<TypePath>("std::module1::module2::Hello").unwrap()
+            )
+        )
+    }
+
+    #[test]
+    fn test_field_parsing_1() {
+        let fields = syn::parse_str::<syn::FieldsNamed>("{ field : *const mod1::CDummy }").unwrap();
+
+        let parsed_fields = fields.named.iter().map(parse_field).collect::<Vec<Field>>();
+
+        assert_eq!(parsed_fields[0].is_string, false);
+        assert_eq!(parsed_fields[0].is_pointer, true);
+        assert_eq!(parsed_fields[0].is_nullable, false);
+
+        if let TypeArrayOrTypePath::TypePath(type_path) = &parsed_fields[0].field_type {
+            assert_eq!(type_path.path.segments.len(), 2);
+        } else {
+            panic!("Unexpected type")
+        }
+    }
+
+    #[test]
+    fn test_field_parsing_2() {
+        let fields = syn::parse_str::<syn::FieldsNamed>(
+            "{\
+                field1: *const mod1::CDummy, \
+                field2: *const CDummy\
+            }",
+        )
+        .unwrap();
+
+        let parsed_fields = fields
+            .named
+            .iter()
+            .map(|f| {
+                println!("f : {:?}", f);
+                f
+            })
+            .map(parse_field)
+            .collect::<Vec<Field>>();
+
+        assert_eq!(parsed_fields[0].is_pointer, true);
+        assert_eq!(parsed_fields[1].is_pointer, true);
+        assert_eq!(parsed_fields[0].is_string, false);
+        assert_eq!(parsed_fields[1].is_string, false);
+
+        let field_type0 =
+            if let TypeArrayOrTypePath::TypePath(type_path) = &parsed_fields[0].field_type {
+                type_path
+            } else {
+                panic!("unexpected type")
+            };
+        let field_type1 =
+            if let TypeArrayOrTypePath::TypePath(type_path) = &parsed_fields[1].field_type {
+                type_path
+            } else {
+                panic!("unexpected type")
+            };
+
+        let parsed_path_0 = field_type0.path.clone();
+        let parsed_path_1 = field_type1.path.clone();
+
+        assert_eq!(parsed_path_0.segments.len(), 2);
+        assert_eq!(parsed_path_1.segments.len(), 1);
+    }
+
+    #[test]
+    fn test_field_parsing_3() {
+        let fields = syn::parse_str::<syn::FieldsNamed>(
+            "{\
+                field1: *const mod1::CFoo<CBar>, \
+                field2: *const CFoo<CBar>\
+            }",
+        )
+        .unwrap();
+
+        let parsed_fields = fields
+            .named
+            .iter()
+            .map(|f| {
+                println!("f : {:?}", f);
+                f
+            })
+            .map(parse_field)
+            .collect::<Vec<Field>>();
+
+        assert_eq!(parsed_fields[0].is_pointer, true);
+        assert_eq!(parsed_fields[1].is_pointer, true);
+        assert_eq!(parsed_fields[0].is_string, false);
+        assert_eq!(parsed_fields[1].is_string, false);
+
+        let field_type0 =
+            if let TypeArrayOrTypePath::TypePath(type_path) = &parsed_fields[0].field_type {
+                type_path
+            } else {
+                panic!("unexpected type")
+            };
+        let field_type1 =
+            if let TypeArrayOrTypePath::TypePath(type_path) = &parsed_fields[1].field_type {
+                type_path
+            } else {
+                panic!("unexpected type")
+            };
+
+        let parsed_path_0 = field_type0.path.clone();
+        let parsed_path_1 = field_type1.path.clone();
+
+        assert_eq!(parsed_path_0.segments.len(), 2);
+        assert_eq!(parsed_path_1.segments.len(), 1);
+    }
+}

--- a/ffi-convert/Cargo.toml
+++ b/ffi-convert/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "ffi-convert"
+version = "0.7.0"
+authors = ["Sonos"]
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "A collection of utilities to ease conversion between Rust and C-compatible data structures."
+repository = "https://github.com/sonos/ffi-convert-rs"
+readme = "../README.md"
+keywords = ["ffi"]
+
+[dependencies]
+ffi-convert-derive = "0.7.0"
+thiserror = "2.0.12"

--- a/ffi-convert/src/conversions.rs
+++ b/ffi-convert/src/conversions.rs
@@ -1,0 +1,416 @@
+use std::ffi::NulError;
+use std::str::Utf8Error;
+
+use thiserror::Error;
+
+macro_rules! impl_c_repr_of_for {
+    ($typ:ty) => {
+        impl CReprOf<$typ> for $typ {
+            fn c_repr_of(input: $typ) -> Result<$typ, CReprOfError> {
+                Ok(input)
+            }
+        }
+    };
+
+    ($from_typ:ty, $to_typ:ty) => {
+        impl CReprOf<$from_typ> for $to_typ {
+            fn c_repr_of(input: $from_typ) -> Result<$to_typ, CReprOfError> {
+                Ok(input as $to_typ)
+            }
+        }
+    };
+}
+
+/// implements a noop implementation of the CDrop trait for a given type.
+macro_rules! impl_c_drop_for {
+    ($typ:ty) => {
+        impl CDrop for $typ {
+            fn do_drop(&mut self) -> Result<(), CDropError> {
+                Ok(())
+            }
+        }
+    };
+}
+
+macro_rules! impl_as_rust_for {
+    ($typ:ty) => {
+        impl AsRust<$typ> for $typ {
+            fn as_rust(&self) -> Result<$typ, AsRustError> {
+                Ok(*self)
+            }
+        }
+    };
+
+    ($from_typ:ty, $to_typ:ty) => {
+        impl AsRust<$to_typ> for $from_typ {
+            fn as_rust(&self) -> Result<$to_typ, AsRustError> {
+                Ok(*self as $to_typ)
+            }
+        }
+    };
+}
+
+macro_rules! impl_rawpointerconverter_for {
+    ($typ:ty) => {
+        impl RawPointerConverter<$typ> for $typ {
+            fn into_raw_pointer(self) -> *const $typ {
+                convert_into_raw_pointer(self)
+            }
+            fn into_raw_pointer_mut(self) -> *mut $typ {
+                convert_into_raw_pointer_mut(self)
+            }
+            unsafe fn from_raw_pointer(
+                input: *const $typ,
+            ) -> Result<Self, UnexpectedNullPointerError> {
+                take_back_from_raw_pointer(input)
+            }
+            unsafe fn from_raw_pointer_mut(
+                input: *mut $typ,
+            ) -> Result<Self, UnexpectedNullPointerError> {
+                take_back_from_raw_pointer_mut(input)
+            }
+        }
+    };
+}
+
+#[derive(Error, Debug)]
+pub enum CReprOfError {
+    #[error("A string contains a nul bit")]
+    StringContainsNullBit(#[from] NulError),
+    #[error("An error occurred during conversion to C repr; {}", .0)]
+    Other(#[from] Box<dyn std::error::Error + Send + Sync>),
+}
+
+/// Trait showing that the struct implementing it is a `repr(C)` compatible view of the parametrized
+/// type that can be created from an value of this type.
+pub trait CReprOf<T>: Sized + CDrop {
+    fn c_repr_of(input: T) -> Result<Self, CReprOfError>;
+}
+
+#[derive(Error, Debug)]
+pub enum CDropError {
+    #[error("unexpected null pointer")]
+    NullPointer(#[from] UnexpectedNullPointerError),
+    #[error("An error occurred while dropping C struct: {}", .0)]
+    Other(#[from] Box<dyn std::error::Error + Send + Sync>),
+}
+
+/// Trait showing that the C-like struct implementing it can free up its part of memory that are not
+/// managed by Rust.
+pub trait CDrop {
+    fn do_drop(&mut self) -> Result<(), CDropError>;
+}
+
+#[derive(Error, Debug)]
+pub enum AsRustError {
+    #[error("unexpected null pointer")]
+    NullPointer(#[from] UnexpectedNullPointerError),
+
+    #[error("could not convert string as it is not UTF-8: {}", .0)]
+    Utf8Error(#[from] Utf8Error),
+    #[error("An error occurred during conversion to Rust: {}", .0)]
+    Other(#[from] Box<dyn std::error::Error + Send + Sync>),
+}
+
+/// Trait showing that the struct implementing it is a `repr(C)` compatible view of the parametrized
+/// type and that an instance of the parametrized type can be created form this struct
+pub trait AsRust<T> {
+    fn as_rust(&self) -> Result<T, AsRustError>;
+}
+
+#[derive(Error, Debug)]
+#[error("Could not use raw pointer: unexpected null pointer")]
+pub struct UnexpectedNullPointerError;
+
+/// Trait representing the creation of a raw pointer from a struct and the recovery of said pointer.
+///
+/// The `from_raw_pointer` function should be used only on pointers obtained through the
+/// `into_raw_pointer` method (and is thus unsafe as we don't have any way to get insurance of that
+/// from the compiler).
+///
+/// The `from_raw_pointer` effectively takes back ownership of the pointer. If you didn't create the
+/// pointer yourself, please use the `as_ref` method on the raw pointer to borrow it
+pub trait RawPointerConverter<T>: Sized {
+    /// Creates a raw pointer from the value and leaks it, you should use [`Self::from_raw_pointer`]
+    /// or [`Self::drop_raw_pointer`] to free the value when you're done with it.
+    fn into_raw_pointer(self) -> *const T;
+    /// Creates a mutable raw pointer from the value and leaks it, you should use
+    /// [`Self::from_raw_pointer_mut`] or [`Self::drop_raw_pointer_mut`] to free the value when
+    /// you're done with it.
+    fn into_raw_pointer_mut(self) -> *mut T;
+    /// Takes back control of a raw pointer created by [`Self::into_raw_pointer`].
+    /// # Safety
+    /// This method is unsafe because passing it a pointer that was not created by
+    /// [`Self::into_raw_pointer`] can lead to memory problems. Also note that passing the same pointer
+    /// twice to this function will probably result in a double free
+    unsafe fn from_raw_pointer(input: *const T) -> Result<Self, UnexpectedNullPointerError>;
+    /// Takes back control of a raw pointer created by [`Self::into_raw_pointer_mut`].
+    /// # Safety
+    /// This method is unsafe because passing it a pointer that was not created by
+    /// [`Self::into_raw_pointer_mut`] can lead to memory problems. Also note that passing the same
+    /// pointer twice to this function will probably result in a double free
+    unsafe fn from_raw_pointer_mut(input: *mut T) -> Result<Self, UnexpectedNullPointerError>;
+
+    /// Takes back control of a raw pointer created by [`Self::into_raw_pointer`] and drop it.
+    /// # Safety
+    /// This method is unsafe for the same reasons as [`Self::from_raw_pointer`]
+    unsafe fn drop_raw_pointer(input: *const T) -> Result<(), UnexpectedNullPointerError> {
+        Self::from_raw_pointer(input).map(|_| ())
+    }
+
+    /// Takes back control of a raw pointer created by [`Self::into_raw_pointer_mut`] and drops it.
+    /// # Safety
+    /// This method is unsafe for the same reasons a [`Self::from_raw_pointer_mut`]
+    unsafe fn drop_raw_pointer_mut(input: *mut T) -> Result<(), UnexpectedNullPointerError> {
+        Self::from_raw_pointer_mut(input).map(|_| ())
+    }
+}
+
+#[doc(hidden)]
+pub fn convert_into_raw_pointer<T>(pointee: T) -> *const T {
+    Box::into_raw(Box::new(pointee)) as _
+}
+
+#[doc(hidden)]
+pub fn convert_into_raw_pointer_mut<T>(pointee: T) -> *mut T {
+    Box::into_raw(Box::new(pointee))
+}
+
+#[doc(hidden)]
+pub unsafe fn take_back_from_raw_pointer<T>(
+    input: *const T,
+) -> Result<T, UnexpectedNullPointerError> {
+    take_back_from_raw_pointer_mut(input as _)
+}
+
+#[doc(hidden)]
+pub unsafe fn take_back_from_raw_pointer_mut<T>(
+    input: *mut T,
+) -> Result<T, UnexpectedNullPointerError> {
+    if input.is_null() {
+        Err(UnexpectedNullPointerError)
+    } else {
+        Ok(*Box::from_raw(input))
+    }
+}
+
+/// Trait to create borrowed references to type T, from a raw pointer to a T. Note that this is
+/// implemented for all types.
+pub trait RawBorrow<T> {
+    /// Get a reference on the value behind the pointer or return an error if the pointer is `null`.
+    /// # Safety
+    /// As this is using `*const T::as_ref()` this is unsafe for exactly the same reasons.
+    unsafe fn raw_borrow<'a>(input: *const T) -> Result<&'a Self, UnexpectedNullPointerError>;
+}
+
+/// Trait to create mutable borrowed references to type T, from a raw pointer to a T. Note that this
+/// is implemented for all types.
+pub trait RawBorrowMut<T> {
+    /// Get a mutable reference on the value behind the pointer or return an error if the pointer is
+    /// `null`.
+    /// # Safety
+    /// As this is using `*mut T:as_ref()` this is unsafe for exactly the same reasons.
+    unsafe fn raw_borrow_mut<'a>(input: *mut T)
+        -> Result<&'a mut Self, UnexpectedNullPointerError>;
+}
+
+/// Trait that allows obtaining a borrowed reference to a type T from a raw pointer to T
+impl<T> RawBorrow<T> for T {
+    unsafe fn raw_borrow<'a>(input: *const T) -> Result<&'a Self, UnexpectedNullPointerError> {
+        input.as_ref().ok_or(UnexpectedNullPointerError)
+    }
+}
+
+/// Trait that allows obtaining a mutable borrowed reference to a type T from a raw pointer to T
+impl<T> RawBorrowMut<T> for T {
+    unsafe fn raw_borrow_mut<'a>(
+        input: *mut T,
+    ) -> Result<&'a mut Self, UnexpectedNullPointerError> {
+        input.as_mut().ok_or(UnexpectedNullPointerError)
+    }
+}
+
+impl RawPointerConverter<std::ffi::c_void> for std::ffi::CString {
+    fn into_raw_pointer(self) -> *const std::ffi::c_void {
+        self.into_raw() as _
+    }
+
+    fn into_raw_pointer_mut(self) -> *mut std::ffi::c_void {
+        self.into_raw() as _
+    }
+
+    unsafe fn from_raw_pointer(
+        input: *const std::ffi::c_void,
+    ) -> Result<Self, UnexpectedNullPointerError> {
+        Self::from_raw_pointer_mut(input as *mut std::ffi::c_void)
+    }
+
+    unsafe fn from_raw_pointer_mut(
+        input: *mut std::ffi::c_void,
+    ) -> Result<Self, UnexpectedNullPointerError> {
+        if input.is_null() {
+            Err(UnexpectedNullPointerError)
+        } else {
+            Ok(std::ffi::CString::from_raw(input as *mut core::ffi::c_char))
+        }
+    }
+}
+
+impl RawPointerConverter<core::ffi::c_char> for std::ffi::CString {
+    fn into_raw_pointer(self) -> *const core::ffi::c_char {
+        self.into_raw() as _
+    }
+
+    fn into_raw_pointer_mut(self) -> *mut core::ffi::c_char {
+        self.into_raw()
+    }
+
+    unsafe fn from_raw_pointer(
+        input: *const core::ffi::c_char,
+    ) -> Result<Self, UnexpectedNullPointerError> {
+        Self::from_raw_pointer_mut(input as *mut core::ffi::c_char)
+    }
+
+    unsafe fn from_raw_pointer_mut(
+        input: *mut core::ffi::c_char,
+    ) -> Result<Self, UnexpectedNullPointerError> {
+        if input.is_null() {
+            Err(UnexpectedNullPointerError)
+        } else {
+            Ok(std::ffi::CString::from_raw(input as *mut core::ffi::c_char))
+        }
+    }
+}
+
+impl RawBorrow<core::ffi::c_char> for std::ffi::CStr {
+    unsafe fn raw_borrow<'a>(
+        input: *const core::ffi::c_char,
+    ) -> Result<&'a Self, UnexpectedNullPointerError> {
+        if input.is_null() {
+            Err(UnexpectedNullPointerError)
+        } else {
+            Ok(Self::from_ptr(input))
+        }
+    }
+}
+
+impl_c_drop_for!(usize);
+impl_c_drop_for!(i8);
+impl_c_drop_for!(u8);
+impl_c_drop_for!(i16);
+impl_c_drop_for!(u16);
+impl_c_drop_for!(i32);
+impl_c_drop_for!(u32);
+impl_c_drop_for!(i64);
+impl_c_drop_for!(u64);
+impl_c_drop_for!(f32);
+impl_c_drop_for!(f64);
+impl_c_drop_for!(bool);
+impl_c_drop_for!(std::ffi::CString);
+
+impl_c_repr_of_for!(usize);
+impl_c_repr_of_for!(i8);
+impl_c_repr_of_for!(u8);
+impl_c_repr_of_for!(i16);
+impl_c_repr_of_for!(u16);
+impl_c_repr_of_for!(i32);
+impl_c_repr_of_for!(u32);
+impl_c_repr_of_for!(i64);
+impl_c_repr_of_for!(u64);
+impl_c_repr_of_for!(f32);
+impl_c_repr_of_for!(f64);
+impl_c_repr_of_for!(bool);
+
+impl_c_repr_of_for!(usize, i32);
+
+impl CReprOf<String> for std::ffi::CString {
+    fn c_repr_of(input: String) -> Result<Self, CReprOfError> {
+        Ok(std::ffi::CString::new(input)?)
+    }
+}
+
+impl_as_rust_for!(usize);
+impl_as_rust_for!(i8);
+impl_as_rust_for!(u8);
+impl_as_rust_for!(i16);
+impl_as_rust_for!(u16);
+impl_as_rust_for!(i32);
+impl_as_rust_for!(u32);
+impl_as_rust_for!(i64);
+impl_as_rust_for!(u64);
+impl_as_rust_for!(f32);
+impl_as_rust_for!(f64);
+impl_as_rust_for!(bool);
+
+impl_as_rust_for!(i32, usize);
+
+impl AsRust<String> for std::ffi::CStr {
+    fn as_rust(&self) -> Result<String, AsRustError> {
+        self.to_str().map(|s| s.to_owned()).map_err(|e| e.into())
+    }
+}
+
+impl_rawpointerconverter_for!(usize);
+impl_rawpointerconverter_for!(i16);
+impl_rawpointerconverter_for!(u16);
+impl_rawpointerconverter_for!(i32);
+impl_rawpointerconverter_for!(u32);
+impl_rawpointerconverter_for!(i64);
+impl_rawpointerconverter_for!(u64);
+impl_rawpointerconverter_for!(f32);
+impl_rawpointerconverter_for!(f64);
+impl_rawpointerconverter_for!(bool);
+
+impl<U, T: CReprOf<U>, const N: usize> CReprOf<[U; N]> for [T; N]
+where
+    [T; N]: CDrop,
+{
+    fn c_repr_of(input: [U; N]) -> Result<[T; N], CReprOfError> {
+        // TODO passing through a Vec here is a bit ugly, but as the conversion call may fail,
+        // TODO we don't want tobe in the case where we're in the middle of the conversion of the
+        // TODO array and we encounter an error, hence leaving the array partially uninitialised for
+        // TODO rust to try to cleanup. the try_map unstable method on array would be nice here
+        let result_vec: Result<Vec<T>, CReprOfError> =
+            input.into_iter().map(T::c_repr_of).collect();
+        let vec = result_vec?;
+
+        assert_eq!(vec.len(), N);
+
+        let mut result: [T; N] = unsafe { std::mem::zeroed() }; // we'll replace everything so "should" be good
+
+        for (i, t) in vec.into_iter().enumerate() {
+            result[i] = t;
+        }
+
+        Ok(result)
+    }
+}
+
+impl<T: CDrop, const N: usize> CDrop for [T; N] {
+    fn do_drop(&mut self) -> Result<(), CDropError> {
+        let result: Result<Vec<()>, CDropError> = self.iter_mut().map(T::do_drop).collect();
+        result?;
+        Ok(())
+    }
+}
+
+impl<U: AsRust<T>, T, const N: usize> AsRust<[T; N]> for [U; N] {
+    fn as_rust(&self) -> Result<[T; N], AsRustError> {
+        // TODO passing through a Vec here is a bit ugly, but as the conversion call may fail,
+        // TODO we don't want tobe in the case where we're in the middle of the conversion of the
+        // TODO array and we encounter an error, hence leaving the array partially uninitialised for
+        // TODO rust to try to cleanup. the try_map unstable method on array would be nice here
+        let result_vec: Result<Vec<T>, AsRustError> = self.iter().map(U::as_rust).collect();
+        let vec = result_vec?;
+
+        assert_eq!(vec.len(), N);
+
+        let mut result: [T; N] = unsafe { std::mem::zeroed() }; // we'll replace everything so "should" be good
+
+        for (i, t) in vec.into_iter().enumerate() {
+            result[i] = t;
+        }
+
+        Ok(result)
+    }
+}

--- a/ffi-convert/src/lib.rs
+++ b/ffi-convert/src/lib.rs
@@ -1,0 +1,209 @@
+//! A collection of utilities (traits, data structures, conversion functions, etc ...) to ease conversion between Rust and C-compatible data structures.
+//!
+//! Through two **conversion traits**, [`CReprOf`] and [`AsRust`], this crate provides a framework to convert idiomatic Rust structs to C-compatible structs that can pass through an FFI boundary, and conversely.
+//! They ensure that the developer uses best practices when performing the conversion in both directions (ownership-wise).
+//!
+//! The crate also provides a collection of useful utility functions and traits to perform conversions of types.
+//! It goes hand in hand with the `ffi-convert-derive` crate as it provides an **automatic derivation** of the [`CReprOf`] and [`AsRust`] trait.
+//!
+//! # Usage
+//! When dealing with an FFI frontier, the general philosophy of the crate is :  
+//! - When receiving pointers to structs created by C code, the struct is immediately converted to an owned (via a copy), idiomatic Rust struct through the use of the [`AsRust`] trait.
+//! - To send an idiomatic, owned Rust struct to C code, the struct is converted to C-compatible representation using the [`CReprOf`] trait.
+//!
+//! ## Example
+//!
+//! We want to be able to convert a **`Pizza`** Rust struct that has an idiomatic representation to a **`CPizza`** Rust struct that has a C-compatible representation in memory.
+//! We start by defining the fields of the `Pizza` struct :
+//! ```
+//! # struct Topping {};
+//! # struct Sauce {};
+//! pub struct Pizza {
+//!     pub name: String,
+//!     pub toppings: Vec<Topping>,
+//!     pub base: Option<Sauce>,
+//!     pub weight: f32,
+//! }
+//!```
+//!
+//! We then create the C-compatible struct by [mapping](#types-representations-mapping) idiomatic Rust types to C-compatible types :
+//! ```
+//! # use ffi_convert::CArray;
+//! # struct CTopping {};
+//! # struct CSauce {};
+//! #[repr(C)]
+//! pub struct CPizza {
+//!     pub name: *const core::ffi::c_char,
+//!     pub toppings: *const CArray<CTopping>,
+//!     pub base: *const CSauce,
+//!     pub weight: core::ffi::c_float,
+//! }
+//! ```
+//!
+//! This crate provides two traits that are useful for converting between Pizza to CPizza and conversely.
+//!
+//! ```ignore
+//!    CPizza::c_repr_of(pizza)
+//!      <=================|
+//!
+//! CPizza                   Pizza
+//!
+//!      |=================>
+//!       cpizza.as_rust()
+//!
+//! ```
+//! Instead of manually writing the body of the conversion traits, we can derive them :
+//!
+//! ```
+//! # use ffi_convert::{CReprOf, AsRust, CDrop, RawPointerConverter};
+//! # use ffi_convert::CArray;
+//! # use ffi_convert::RawBorrow;
+//! # struct Topping {};
+//! # #[derive(CReprOf, AsRust, CDrop)]
+//! # #[target_type(Topping)]
+//! # struct CTopping {};
+//! #
+//! # struct Pizza {
+//! #     name: String,
+//! #     toppings: Vec<Topping>,
+//! #     base: Option<Sauce>,
+//! #     weight: f32
+//! # };
+//! use core::ffi::{c_char, c_float};
+//!
+//! struct Sauce {};
+//! #[derive(CReprOf, AsRust, CDrop, RawPointerConverter)]
+//! #[target_type(Sauce)]
+//! struct CSauce {};
+//!
+//! #[repr(C)]
+//! #[derive(CReprOf, AsRust, CDrop)]
+//! #[target_type(Pizza)]
+//! pub struct CPizza {
+//!     pub name: *const c_char,
+//!     pub toppings: *const CArray<CTopping>,
+//!     #[nullable]
+//!     pub base: *const CSauce,
+//!     pub weight: c_float,
+//! }
+//! ```
+//!
+//! You may have noticed that you have to derive two traits : the CDrop trait and the RawPointerConverter trait.
+//!
+//! The CDrop trait needs to be implemented on every C-compatible struct that require manual resource management.
+//! The release of those resources should be done in the drop method of the CDrop trait.
+//!
+//! The RawPointerConverter trait is implemented to perform the conversion of a C-like struct to a raw-pointer to this C-like structure (and conversely).
+//! Here, it is used behind the scene to convert a `CSauce` struct to a pointer to a raw pointer to CSause struct : `*const CSauce`
+//! (needed behind the scenes when the [`CReprOf`] trait is derived for `CPizza`).
+//!
+//! You can now pass the `CPizza` struct through your FFI boundary !
+//!
+
+//! ## Types representations mapping
+//!
+//! `T : CReprOf<U> + AsRust<U>`
+//! <table>
+//!     <thead>
+//!         <tr>
+//!             <th>C type</th>
+//!             <th>Rust type</th>
+//!             <th>C-compatible Rust type</th>
+//!         </tr>
+//!     </thead>
+//!     <tbody>
+//!         <tr>
+//!             <td><code>const char*</code></td>
+//!             <td><code>String</code></td>
+//!             <td><code>*const core::ffi::c_char</code></td>
+//!         </tr>
+//!         <tr>
+//!             <td><code>const T*</code></td>
+//!             <td><code>U</code></td>
+//!             <td><code>*const T</code></td>
+//!         </tr>
+//!         <tr>
+//!             <td><code>T*</code></td>
+//!             <td><code>U</code></td>
+//!             <td><code>*mut T</code></td>
+//!         </tr>
+//!         <tr>
+//!             <td><code>T</code></td>
+//!             <td><code>U</code></td>
+//!             <td><code>T</code></td>
+//!         </tr>
+//!         <tr>
+//!             <td><code>const T*</code></td>
+//!             <td><code>Option&lt;U&gt;</code></td>
+//!             <td><code>*const T</code> (with <code>#[nullable]</code> field annotation)</td>
+//!         </tr>
+//!         <tr>
+//!             <td><code>CArrayT</code></td>
+//!             <td><code>Vec&lt;U&gt;</code></td>
+//!             <td><code>CArray&lt;T&gt;</code></td>
+//!         </tr>
+//!         <tr>
+//!             <td><code>CStringArray</code></td>
+//!             <td><code>Vec&lt;String&gt;</code></td>
+//!             <td><code>CStringArray</code></td>
+//!         </tr>
+//!         <tr>
+//!             <td><code>CRangeT</code></td>
+//!             <td><code>Range&lt;U&gt;</code></td>
+//!             <td><code>CRange&lt;T&gt;</code></td>
+//!         </tr>
+//!     </tbody>
+//! </table>
+//!
+
+//! ## The CReprOf trait
+
+//! The `CReprOf` trait allows to create a C-compatible representation of the reciprocal idiomatic Rust struct by consuming the latter.
+
+//! ```
+//! # use ffi_convert::{CReprOfError, CDrop};
+//! pub trait CReprOf<T>: Sized + CDrop {
+//!     fn c_repr_of(input: T) -> Result<Self, CReprOfError>;
+//! }
+//! ```
+
+//! This shows that the struct implementing it is a `repr(C)` compatible view of the parametrized
+//! type and can be created from an object of this type.
+
+//! ## The AsRust trait
+
+//! > When trying to convert a `repr(C)` struct that originated from C, the philosophy is to immediately convert
+//! > the struct to an **owned** idiomatic representation of the struct via the AsRust trait.
+
+//!
+//! The [`AsRust`] trait allows to create an idiomatic Rust struct from a C-compatible struct :
+
+//! ```
+//! # use ffi_convert::{AsRustError, CDrop};
+//! pub trait AsRust<T> {
+//!     fn as_rust(&self) -> Result<T, AsRustError>;
+//! }
+//! ```
+
+//! This shows that the struct implementing it is a `repr(C)` compatible view of the parametrized
+//! type and that an instance of the parametrized type can be created from this struct.
+
+//! ## The CDrop trait
+
+//! A Trait showing that the `repr(C)` compatible view implementing it can free up its part of memory that are not
+//! managed by Rust drop mechanism.
+
+//! ## The RawPointerConverter trait
+
+//! This trait completes the conversion traits toolbox provided by this crate : It expresses the
+//! conversion of a C-like struct to a raw pointer to this struct and conversely.
+//!
+//! This conversion trait comes in handy for C-like struct that have fields that points to other structs.
+
+pub use ffi_convert_derive::*;
+
+mod conversions;
+mod types;
+
+pub use conversions::*;
+pub use types::*;

--- a/ffi-convert/src/types.rs
+++ b/ffi-convert/src/types.rs
@@ -1,0 +1,302 @@
+//! This module contains definitions of utility types that implement the [`CReprOf`], [`AsRust`], and [`CDrop`] traits.
+//!
+
+use ffi_convert_derive::RawPointerConverter;
+
+use std::any::TypeId;
+use std::ffi::{CStr, CString};
+use std::ops::Range;
+use std::ptr;
+
+use crate as ffi_convert;
+use crate::conversions::*;
+
+/// A utility type to represent arrays of string
+/// # Example
+///
+/// ```
+/// use ffi_convert::{CReprOf, CStringArray};
+/// let pizza_names = vec!["Diavola".to_string(), "Margarita".to_string(), "Regina".to_string()];
+/// let c_pizza_names = CStringArray::c_repr_of(pizza_names).expect("could not convert !");
+///
+/// ```
+#[repr(C)]
+#[derive(Debug, RawPointerConverter)]
+pub struct CStringArray {
+    /// Pointer to the first element of the array
+    pub data: *const *const core::ffi::c_char,
+    /// Number of elements in the array
+    pub size: usize,
+}
+
+unsafe impl Sync for CStringArray {}
+
+impl AsRust<Vec<String>> for CStringArray {
+    fn as_rust(&self) -> Result<Vec<String>, AsRustError> {
+        let mut result = vec![];
+
+        let strings = unsafe {
+            std::slice::from_raw_parts_mut(self.data as *mut *mut core::ffi::c_char, self.size)
+        };
+
+        for s in strings {
+            result.push(unsafe { CStr::raw_borrow(*s) }?.as_rust()?)
+        }
+
+        Ok(result)
+    }
+}
+
+impl CReprOf<Vec<String>> for CStringArray {
+    fn c_repr_of(input: Vec<String>) -> Result<Self, CReprOfError> {
+        Ok(Self {
+            size: input.len(),
+            data: Box::into_raw(
+                input
+                    .into_iter()
+                    .map::<Result<*const core::ffi::c_char, CReprOfError>, _>(|s| {
+                        Ok(CString::c_repr_of(s)?.into_raw_pointer())
+                    })
+                    .collect::<Result<Vec<_>, _>>()?
+                    .into_boxed_slice(),
+            ) as *const *const core::ffi::c_char,
+        })
+    }
+}
+
+impl CDrop for CStringArray {
+    fn do_drop(&mut self) -> Result<(), CDropError> {
+        unsafe {
+            let y = Box::from_raw(std::ptr::slice_from_raw_parts_mut(
+                self.data as *mut *mut core::ffi::c_char,
+                self.size,
+            ));
+            for p in y.iter() {
+                let _ = CString::from_raw_pointer(*p)?; // let's not panic if we fail here
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Drop for CStringArray {
+    fn drop(&mut self) {
+        let _ = self.do_drop();
+    }
+}
+
+/// A utility type to represent arrays of the parametrized type.
+/// Note that the parametrized type should have a C-compatible representation.
+///
+/// # Example
+///
+/// ```
+/// use ffi_convert::{CReprOf, AsRust, CDrop, CArray};
+/// use core::ffi::c_char;
+///
+/// pub struct PizzaTopping {
+///     pub ingredient: String,
+/// }
+///
+/// #[derive(CDrop, CReprOf, AsRust)]
+/// #[target_type(PizzaTopping)]
+/// pub struct CPizzaTopping {
+///     pub ingredient: *const c_char
+/// }
+///
+/// let toppings = vec![
+///         PizzaTopping { ingredient: "Cheese".to_string() },
+///         PizzaTopping { ingredient: "Ham".to_string() } ];
+///
+/// let ctoppings = CArray::<CPizzaTopping>::c_repr_of(toppings);
+///
+/// ```
+#[repr(C)]
+#[derive(Debug)]
+pub struct CArray<T> {
+    /// Pointer to the first element of the array
+    pub data_ptr: *const T,
+    /// Number of elements in the array
+    pub size: usize,
+}
+
+impl<U: AsRust<V> + 'static, V> AsRust<Vec<V>> for CArray<U> {
+    fn as_rust(&self) -> Result<Vec<V>, AsRustError> {
+        let mut vec = Vec::with_capacity(self.size);
+
+        if self.size > 0 {
+            let values =
+                unsafe { std::slice::from_raw_parts_mut(self.data_ptr as *mut U, self.size) };
+
+            if is_primitive(TypeId::of::<U>()) {
+                unsafe {
+                    ptr::copy(values.as_ptr() as *const V, vec.as_mut_ptr(), self.size);
+                    vec.set_len(self.size);
+                }
+            } else {
+                for value in values {
+                    vec.push(value.as_rust()?);
+                }
+            }
+        }
+        Ok(vec)
+    }
+}
+
+impl<U: CReprOf<V> + CDrop, V: 'static> CReprOf<Vec<V>> for CArray<U> {
+    fn c_repr_of(input: Vec<V>) -> Result<Self, CReprOfError> {
+        let input_size = input.len();
+        let mut output: CArray<U> = CArray {
+            data_ptr: ptr::null(),
+            size: input_size,
+        };
+
+        if input_size > 0 {
+            if is_primitive(TypeId::of::<V>()) {
+                output.data_ptr = Box::into_raw(input.into_boxed_slice()) as *const U;
+            } else {
+                output.data_ptr = Box::into_raw(
+                    input
+                        .into_iter()
+                        .map(U::c_repr_of)
+                        .collect::<Result<Vec<_>, CReprOfError>>()
+                        .expect("Could not convert to C representation")
+                        .into_boxed_slice(),
+                ) as *const U;
+            }
+        } else {
+            output.data_ptr = ptr::null();
+        }
+        Ok(output)
+    }
+}
+
+impl<T> CDrop for CArray<T> {
+    fn do_drop(&mut self) -> Result<(), CDropError> {
+        if !self.data_ptr.is_null() {
+            let _ = unsafe {
+                Box::from_raw(std::ptr::slice_from_raw_parts_mut(
+                    self.data_ptr as *mut T,
+                    self.size,
+                ))
+            };
+        }
+        Ok(())
+    }
+}
+
+impl<T> Drop for CArray<T> {
+    fn drop(&mut self) {
+        let _ = self.do_drop();
+    }
+}
+
+impl<T> RawPointerConverter<CArray<T>> for CArray<T> {
+    fn into_raw_pointer(self) -> *const CArray<T> {
+        convert_into_raw_pointer(self)
+    }
+
+    fn into_raw_pointer_mut(self) -> *mut CArray<T> {
+        convert_into_raw_pointer_mut(self)
+    }
+
+    unsafe fn from_raw_pointer(
+        input: *const CArray<T>,
+    ) -> Result<Self, UnexpectedNullPointerError> {
+        take_back_from_raw_pointer(input)
+    }
+
+    unsafe fn from_raw_pointer_mut(
+        input: *mut CArray<T>,
+    ) -> Result<Self, UnexpectedNullPointerError> {
+        take_back_from_raw_pointer_mut(input)
+    }
+}
+
+fn is_primitive(id: TypeId) -> bool {
+    id == TypeId::of::<u8>()
+        || id == TypeId::of::<i8>()
+        || id == TypeId::of::<u16>()
+        || id == TypeId::of::<i16>()
+        || id == TypeId::of::<u32>()
+        || id == TypeId::of::<i32>()
+        || id == TypeId::of::<f32>()
+        || id == TypeId::of::<f64>()
+}
+
+/// A utility type to represent range.
+/// Note that the parametrized type T should have have `CReprOf` and `AsRust` trait implementated.
+///
+/// # Example
+///
+/// ```
+/// use ffi_convert::{CReprOf, AsRust, CDrop, CRange};
+/// use std::ops::Range;
+///
+/// #[derive(Clone, Debug, PartialEq)]
+/// pub struct Foo {
+///     pub range: Range<i32>
+/// }
+///
+/// #[derive(AsRust, CDrop, CReprOf, Debug, PartialEq)]
+/// #[target_type(Foo)]
+/// pub struct CFoo {
+///     pub range: CRange<i32>
+/// }
+///
+/// let foo = Foo {
+///     range: Range {
+///         start: 20,
+///         end: 30,
+///     }
+/// };
+///
+/// let c_foo = CFoo {
+///     range: CRange {
+///         start: 20,
+///         end: 30,
+///     }
+/// };
+///
+/// let c_foo_converted = CFoo::c_repr_of(foo.clone()).unwrap();
+/// assert_eq!(c_foo, c_foo_converted);
+///
+/// let foo_converted = c_foo.as_rust().unwrap();
+/// assert_eq!(foo_converted, foo);
+/// ```
+#[repr(C)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CRange<T> {
+    pub start: T,
+    pub end: T,
+}
+
+impl<U: AsRust<V>, V: PartialOrd + PartialEq> AsRust<Range<V>> for CRange<U> {
+    fn as_rust(&self) -> Result<Range<V>, AsRustError> {
+        Ok(Range {
+            start: self.start.as_rust()?,
+            end: self.end.as_rust()?,
+        })
+    }
+}
+
+impl<U: CReprOf<V> + CDrop, V: PartialOrd + PartialEq> CReprOf<Range<V>> for CRange<U> {
+    fn c_repr_of(input: Range<V>) -> Result<Self, CReprOfError> {
+        Ok(Self {
+            start: U::c_repr_of(input.start)?,
+            end: U::c_repr_of(input.end)?,
+        })
+    }
+}
+
+impl<T> CDrop for CRange<T> {
+    fn do_drop(&mut self) -> Result<(), CDropError> {
+        Ok(())
+    }
+}
+
+impl<T> Drop for CRange<T> {
+    fn drop(&mut self) {
+        let _ = self.do_drop();
+    }
+}

--- a/rustfst-ffi/Cargo.toml
+++ b/rustfst-ffi/Cargo.toml
@@ -22,8 +22,9 @@ keywords = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["rustfst-state-label-u32"]
-rustfst-state-label-u32 = ["rustfst/state-label-u32"]
+default = ["state-label-u32"]
+state-label-u32 = ["rustfst/state-label-u32"]
+std = ["rustfst/std"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/rustfst-ffi/Cargo.toml
+++ b/rustfst-ffi/Cargo.toml
@@ -22,8 +22,8 @@ keywords = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["state-label-u32"]
-state-label-u32 = ["rustfst/state-label-u32"]
+default = ["std", "rustfst-state-label-u32"]
+rustfst-state-label-u32 = ["rustfst/state-label-u32"]
 std = ["rustfst/std"]
 
 [lib]
@@ -31,8 +31,8 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 anyhow = "1.0"
-libc = "0.2"
-ffi-convert = "0.6"
+# Vendored local version to remove libc dependency
+ffi-convert = { path = "../ffi-convert" }
 # Used locally when developping and used the one from crates.io when publishing
-rustfst = { path = "../rustfst", version = "=1.3.1" }
+rustfst = { path = "../rustfst", version = "=1.3.1", default-features = false }
 downcast-rs = "2"

--- a/rustfst-ffi/src/algorithms/compose.rs
+++ b/rustfst-ffi/src/algorithms/compose.rs
@@ -190,8 +190,8 @@ impl From<&[u32]> for CIntArray {
 /// The pointers should be valid.
 #[no_mangle]
 pub unsafe extern "C" fn fst_matcher_config_new(
-    sigma_label: libc::size_t,
-    rewrite_mode: libc::size_t,
+    sigma_label: usize,
+    rewrite_mode: usize,
     sigma_allowed_matches: CIntArray,
     config: *mut *const CMatcherConfig,
 ) -> RUSTFST_FFI_RESULT {
@@ -227,7 +227,7 @@ pub unsafe extern "C" fn fst_matcher_config_new(
 /// The pointers should be valid.
 #[no_mangle]
 pub unsafe extern "C" fn fst_compose_config_new(
-    compose_filter: libc::size_t,
+    compose_filter: usize,
     connect: bool,
     matcher1_config: *const CMatcherConfig,
     matcher2_config: *const CMatcherConfig,

--- a/rustfst-ffi/src/algorithms/determinize.rs
+++ b/rustfst-ffi/src/algorithms/determinize.rs
@@ -54,8 +54,8 @@ pub struct CDeterminizeConfig {
 /// The pointers should be valid.
 #[no_mangle]
 pub unsafe extern "C" fn fst_determinize_config_new(
-    delta: libc::c_float,
-    det_type: libc::size_t,
+    delta: core::ffi::c_float,
+    det_type: usize,
     config: *mut *const CDeterminizeConfig,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {

--- a/rustfst-ffi/src/algorithms/isomorphic.rs
+++ b/rustfst-ffi/src/algorithms/isomorphic.rs
@@ -14,7 +14,7 @@ use rustfst::semirings::TropicalWeight;
 pub unsafe fn fst_isomorphic(
     fst: *const CFst,
     other_fst: *const CFst,
-    is_isomorphic: *mut libc::size_t,
+    is_isomorphic: *mut usize,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let fst = get!(CFst, fst);

--- a/rustfst-ffi/src/algorithms/minimize.rs
+++ b/rustfst-ffi/src/algorithms/minimize.rs
@@ -21,7 +21,7 @@ pub struct CMinimizeConfig {
 /// The pointers should be valid.
 #[no_mangle]
 pub unsafe extern "C" fn fst_minimize_config_new(
-    delta: libc::c_float,
+    delta: core::ffi::c_float,
     allow_nondet: bool,
     ptr: *mut *const CMinimizeConfig,
 ) -> RUSTFST_FFI_RESULT {

--- a/rustfst-ffi/src/algorithms/mod.rs
+++ b/rustfst-ffi/src/algorithms/mod.rs
@@ -7,7 +7,6 @@ pub mod isomorphic;
 mod minimize;
 pub mod optimize;
 pub mod project;
-#[cfg(feature = "std")]
 pub mod randgen;
 pub mod replace;
 pub mod reverse;

--- a/rustfst-ffi/src/algorithms/mod.rs
+++ b/rustfst-ffi/src/algorithms/mod.rs
@@ -7,6 +7,7 @@ pub mod isomorphic;
 mod minimize;
 pub mod optimize;
 pub mod project;
+#[cfg(feature = "std")]
 pub mod randgen;
 pub mod replace;
 pub mod reverse;

--- a/rustfst-ffi/src/algorithms/project.rs
+++ b/rustfst-ffi/src/algorithms/project.rs
@@ -43,7 +43,7 @@ impl CReprOf<ProjectType> for CProjectType {
 /// The pointers should be valid.
 #[no_mangle]
 pub unsafe extern "C" fn fst_project_type_new(
-    project_type: libc::size_t,
+    project_type: usize,
     ptr: *mut *const CProjectType,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {

--- a/rustfst-ffi/src/algorithms/randgen.rs
+++ b/rustfst-ffi/src/algorithms/randgen.rs
@@ -15,9 +15,9 @@ use crate::{wrap, RUSTFST_FFI_RESULT};
 #[no_mangle]
 pub unsafe extern "C" fn fst_randgen(
     ptr: *const CFst,
-    npath: libc::size_t,
-    seed: libc::size_t,
-    max_length: libc::size_t,
+    npath: usize,
+    seed: usize,
+    max_length: usize,
     weight: bool,
     remove_total_weight: bool,
     res_fst: *mut *const CFst,

--- a/rustfst-ffi/src/algorithms/replace.rs
+++ b/rustfst-ffi/src/algorithms/replace.rs
@@ -22,7 +22,7 @@ pub struct CLabelFstPair {
 pub unsafe extern "C" fn fst_replace(
     root: CLabel,
     fst_list_ptr: *mut CLabelFstPair,
-    fst_list_ptr_len: libc::size_t,
+    fst_list_ptr_len: usize,
     epsilon_on_replace: bool,
     replaced_fst: *mut *const CFst,
 ) -> RUSTFST_FFI_RESULT {

--- a/rustfst-ffi/src/algorithms/shortest_path.rs
+++ b/rustfst-ffi/src/algorithms/shortest_path.rs
@@ -21,8 +21,8 @@ pub struct CShortestPathConfig {
 /// The pointers should be valid.
 #[no_mangle]
 pub unsafe extern "C" fn fst_shortest_path_config_new(
-    delta: libc::c_float,
-    nshortest: libc::size_t,
+    delta: core::ffi::c_float,
+    nshortest: usize,
     unique: bool,
     ptr: *mut *const CShortestPathConfig,
 ) -> RUSTFST_FFI_RESULT {

--- a/rustfst-ffi/src/fst/const_fst.rs
+++ b/rustfst-ffi/src/fst/const_fst.rs
@@ -6,6 +6,7 @@ use std::ffi::CString;
 /// # Safety
 ///
 /// The pointers should be valid.
+#[cfg(feature = "std")]
 #[no_mangle]
 pub unsafe fn const_fst_from_path(
     ptr: *mut *const CFst,
@@ -23,6 +24,7 @@ pub unsafe fn const_fst_from_path(
 /// # Safety
 ///
 /// The pointers should be valid.
+#[cfg(feature = "std")]
 #[no_mangle]
 pub unsafe fn const_fst_write_file(
     fst: *const CFst,

--- a/rustfst-ffi/src/fst/const_fst.rs
+++ b/rustfst-ffi/src/fst/const_fst.rs
@@ -10,7 +10,7 @@ use std::ffi::CString;
 #[no_mangle]
 pub unsafe fn const_fst_from_path(
     ptr: *mut *const CFst,
-    path: *const libc::c_char,
+    path: *const core::ffi::c_char,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let path = unsafe { CStr::from_ptr(path) }.as_rust()?;
@@ -28,7 +28,7 @@ pub unsafe fn const_fst_from_path(
 #[no_mangle]
 pub unsafe fn const_fst_write_file(
     fst: *const CFst,
-    path: *const libc::c_char,
+    path: *const core::ffi::c_char,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let fst = get!(CFst, fst);
@@ -46,7 +46,7 @@ pub unsafe fn const_fst_write_file(
 pub unsafe fn const_fst_equals(
     fst: *const CFst,
     other_fst: *const CFst,
-    is_equal: *mut libc::size_t,
+    is_equal: *mut usize,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let fst = get!(CFst, fst);
@@ -85,18 +85,18 @@ pub unsafe fn const_fst_draw(
     fst_ptr: *mut CFst,
     isyms: *const CSymbolTable,
     osyms: *const CSymbolTable,
-    fname: *const libc::c_char,
-    title: *const libc::c_char,
-    acceptor: libc::size_t,
-    width: libc::c_float,
-    height: libc::c_float,
-    portrait: libc::size_t,
-    vertical: libc::size_t,
-    ranksep: libc::c_float,
-    nodesep: libc::c_float,
-    fontsize: libc::size_t,
-    show_weight_one: libc::size_t,
-    print_weight: libc::size_t,
+    fname: *const core::ffi::c_char,
+    title: *const core::ffi::c_char,
+    acceptor: usize,
+    width: core::ffi::c_float,
+    height: core::ffi::c_float,
+    portrait: usize,
+    vertical: usize,
+    ranksep: core::ffi::c_float,
+    nodesep: core::ffi::c_float,
+    fontsize: usize,
+    show_weight_one: usize,
+    print_weight: usize,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let fst = get_mut!(CFst, fst_ptr);
@@ -141,13 +141,13 @@ pub unsafe fn const_fst_draw(
 #[no_mangle]
 pub unsafe extern "C" fn const_fst_display(
     fst_ptr: *const CFst,
-    s: *mut *const libc::c_char,
+    s: *mut *const core::ffi::c_char,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let fst = get!(CFst, fst_ptr);
         let vec_fst = as_fst!(ConstFst<TropicalWeight>, fst);
         let res = format!("{}", vec_fst);
-        unsafe { *s = CString::c_repr_of(res)?.into_raw_pointer() as *const libc::c_char };
+        unsafe { *s = CString::c_repr_of(res)?.into_raw_pointer() as *const core::ffi::c_char };
         Ok(())
     })
 }

--- a/rustfst-ffi/src/fst/mod.rs
+++ b/rustfst-ffi/src/fst/mod.rs
@@ -143,7 +143,7 @@ pub unsafe fn fst_start(fst: *const CFst, mut state: *mut CStateId) -> RUSTFST_F
 pub unsafe fn fst_final_weight(
     fst: *const CFst,
     state_id: CStateId,
-    mut final_weight: *mut libc::c_float,
+    mut final_weight: *mut core::ffi::c_float,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let fst = get!(CFst, fst);
@@ -162,7 +162,7 @@ pub unsafe fn fst_final_weight(
 pub unsafe fn fst_num_trs(
     fst: *const CFst,
     state: CStateId,
-    num_trs: *mut libc::size_t,
+    num_trs: *mut usize,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let fst = get!(CFst, fst);
@@ -198,7 +198,7 @@ pub unsafe fn fst_get_trs(
 pub unsafe fn fst_is_final(
     fst: *const CFst,
     state: CStateId,
-    is_final: *mut libc::size_t,
+    is_final: *mut usize,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let fst = get!(CFst, fst);
@@ -216,7 +216,7 @@ pub unsafe fn fst_is_final(
 pub unsafe fn fst_is_start(
     fst: *const CFst,
     state: CStateId,
-    is_start: *mut libc::size_t,
+    is_start: *mut usize,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let fst = get!(CFst, fst);
@@ -348,7 +348,7 @@ pub unsafe fn fst_unset_output_symbols(fst: *mut CFst) -> RUSTFST_FFI_RESULT {
 ///
 /// The pointers should be valid.
 #[no_mangle]
-pub unsafe extern "C" fn fst_weight_one(weight_one: *mut libc::c_float) -> RUSTFST_FFI_RESULT {
+pub unsafe extern "C" fn fst_weight_one(weight_one: *mut core::ffi::c_float) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let weight = TropicalWeight::one();
         unsafe { *weight_one = *weight.value() };
@@ -360,7 +360,7 @@ pub unsafe extern "C" fn fst_weight_one(weight_one: *mut libc::c_float) -> RUSTF
 ///
 /// The pointers should be valid.
 #[no_mangle]
-pub unsafe extern "C" fn fst_weight_zero(weight_zero: *mut libc::c_float) -> RUSTFST_FFI_RESULT {
+pub unsafe extern "C" fn fst_weight_zero(weight_zero: *mut core::ffi::c_float) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let weight = TropicalWeight::zero();
         unsafe { *weight_zero = *weight.value() };

--- a/rustfst-ffi/src/fst/mod.rs
+++ b/rustfst-ffi/src/fst/mod.rs
@@ -360,7 +360,9 @@ pub unsafe extern "C" fn fst_weight_one(weight_one: *mut core::ffi::c_float) -> 
 ///
 /// The pointers should be valid.
 #[no_mangle]
-pub unsafe extern "C" fn fst_weight_zero(weight_zero: *mut core::ffi::c_float) -> RUSTFST_FFI_RESULT {
+pub unsafe extern "C" fn fst_weight_zero(
+    weight_zero: *mut core::ffi::c_float,
+) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let weight = TropicalWeight::zero();
         unsafe { *weight_zero = *weight.value() };

--- a/rustfst-ffi/src/fst/utils.rs
+++ b/rustfst-ffi/src/fst/utils.rs
@@ -12,9 +12,9 @@ use std::ffi::CStr;
 /// The pointers should be valid.
 #[no_mangle]
 pub unsafe extern "C" fn utils_string_to_acceptor(
-    astring: *const libc::c_char,
+    astring: *const core::ffi::c_char,
     symbol_table: *mut CSymbolTable,
-    weight: libc::c_float,
+    weight: core::ffi::c_float,
     fst_ptr: *mut *const CFst,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {
@@ -39,11 +39,11 @@ pub unsafe extern "C" fn utils_string_to_acceptor(
 /// The pointers should be valid.
 #[no_mangle]
 pub unsafe extern "C" fn utils_string_to_transducer(
-    istring: *const libc::c_char,
-    ostring: *const libc::c_char,
+    istring: *const core::ffi::c_char,
+    ostring: *const core::ffi::c_char,
     isymt: *mut CSymbolTable,
     osymt: *mut CSymbolTable,
-    weight: libc::c_float,
+    weight: core::ffi::c_float,
     fst_ptr: *mut *const CFst,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {

--- a/rustfst-ffi/src/fst/vector_fst.rs
+++ b/rustfst-ffi/src/fst/vector_fst.rs
@@ -246,10 +246,7 @@ pub unsafe fn vec_fst_draw(
 ///
 /// The pointers should be valid.
 #[no_mangle]
-pub unsafe fn vec_fst_num_states(
-    fst: *const CFst,
-    num_states: *mut usize,
-) -> RUSTFST_FFI_RESULT {
+pub unsafe fn vec_fst_num_states(fst: *const CFst, num_states: *mut usize) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let fst = get!(CFst, fst);
         let vec_fst = as_fst!(VectorFst<TropicalWeight>, fst);

--- a/rustfst-ffi/src/fst/vector_fst.rs
+++ b/rustfst-ffi/src/fst/vector_fst.rs
@@ -111,6 +111,7 @@ pub unsafe fn vec_fst_del_final_weight(fst: *mut CFst, state: CStateId) -> RUSTF
 /// # Safety
 ///
 /// The pointers should be valid.
+#[cfg(feature = "std")]
 #[no_mangle]
 pub unsafe fn vec_fst_from_path(
     ptr: *mut *const CFst,
@@ -128,6 +129,7 @@ pub unsafe fn vec_fst_from_path(
 /// # Safety
 ///
 /// The pointers should be valid.
+#[cfg(feature = "std")]
 #[no_mangle]
 pub unsafe fn vec_fst_write_file(
     fst: *const CFst,

--- a/rustfst-ffi/src/fst/vector_fst.rs
+++ b/rustfst-ffi/src/fst/vector_fst.rs
@@ -1,7 +1,6 @@
 use super::*;
 use crate::get_symt;
 use anyhow::{anyhow, format_err};
-use ffi_convert::CArray;
 use rustfst::fst_traits::ExpandedFst;
 use rustfst::DrawingConfig;
 use std::ffi::CString;
@@ -39,7 +38,7 @@ pub unsafe fn vec_fst_set_start(fst: *mut CFst, state: CStateId) -> RUSTFST_FFI_
 pub unsafe fn vec_fst_set_final(
     fst: *mut CFst,
     state: CStateId,
-    weight: libc::c_float,
+    weight: core::ffi::c_float,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let fst = get_mut!(CFst, fst);
@@ -115,7 +114,7 @@ pub unsafe fn vec_fst_del_final_weight(fst: *mut CFst, state: CStateId) -> RUSTF
 #[no_mangle]
 pub unsafe fn vec_fst_from_path(
     ptr: *mut *const CFst,
-    path: *const libc::c_char,
+    path: *const core::ffi::c_char,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let path = unsafe { CStr::from_ptr(path) }.as_rust()?;
@@ -133,7 +132,7 @@ pub unsafe fn vec_fst_from_path(
 #[no_mangle]
 pub unsafe fn vec_fst_write_file(
     fst: *const CFst,
-    path: *const libc::c_char,
+    path: *const core::ffi::c_char,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let fst = get!(CFst, fst);
@@ -152,10 +151,10 @@ pub unsafe fn vec_fst_relabel_tables(
     fst: *mut CFst,
     old_isymbols: *const CSymbolTable,
     new_isymbols: *const CSymbolTable,
-    attach_new_isymbols: libc::size_t,
+    attach_new_isymbols: usize,
     old_osymbols: *const CSymbolTable,
     new_osymbols: *const CSymbolTable,
-    attach_new_osymbols: libc::size_t,
+    attach_new_osymbols: usize,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let fst = get_mut!(CFst, fst);
@@ -193,18 +192,18 @@ pub unsafe fn vec_fst_draw(
     fst_ptr: *mut CFst,
     isyms: *const CSymbolTable,
     osyms: *const CSymbolTable,
-    fname: *const libc::c_char,
-    title: *const libc::c_char,
-    acceptor: libc::size_t,
-    width: libc::c_float,
-    height: libc::c_float,
-    portrait: libc::size_t,
-    vertical: libc::size_t,
-    ranksep: libc::c_float,
-    nodesep: libc::c_float,
-    fontsize: libc::size_t,
-    show_weight_one: libc::size_t,
-    print_weight: libc::size_t,
+    fname: *const core::ffi::c_char,
+    title: *const core::ffi::c_char,
+    acceptor: usize,
+    width: core::ffi::c_float,
+    height: core::ffi::c_float,
+    portrait: usize,
+    vertical: usize,
+    ranksep: core::ffi::c_float,
+    nodesep: core::ffi::c_float,
+    fontsize: usize,
+    show_weight_one: usize,
+    print_weight: usize,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let fst = get_mut!(CFst, fst_ptr);
@@ -249,7 +248,7 @@ pub unsafe fn vec_fst_draw(
 #[no_mangle]
 pub unsafe fn vec_fst_num_states(
     fst: *const CFst,
-    num_states: *mut libc::size_t,
+    num_states: *mut usize,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let fst = get!(CFst, fst);
@@ -267,7 +266,7 @@ pub unsafe fn vec_fst_num_states(
 pub unsafe fn vec_fst_equals(
     fst: *const CFst,
     other_fst: *const CFst,
-    is_equal: *mut libc::size_t,
+    is_equal: *mut usize,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let fst = get!(CFst, fst);
@@ -303,13 +302,13 @@ pub unsafe extern "C" fn vec_fst_copy(
 #[no_mangle]
 pub unsafe extern "C" fn vec_fst_display(
     fst_ptr: *const CFst,
-    s: *mut *const libc::c_char,
+    s: *mut *const core::ffi::c_char,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let fst = get!(CFst, fst_ptr);
         let vec_fst = as_fst!(VectorFst<TropicalWeight>, fst);
         let res = format!("{}", vec_fst);
-        unsafe { *s = CString::c_repr_of(res)?.into_raw_pointer() as *const libc::c_char };
+        unsafe { *s = CString::c_repr_of(res)?.into_raw_pointer() as *const core::ffi::c_char };
         Ok(())
     })
 }

--- a/rustfst-ffi/src/iterators.rs
+++ b/rustfst-ffi/src/iterators.rs
@@ -95,12 +95,12 @@ pub unsafe extern "C" fn trs_iterator_next(
 #[no_mangle]
 pub unsafe extern "C" fn trs_iterator_done(
     iter_ptr: *const CTrsIterator,
-    done: *mut libc::size_t,
+    done: *mut usize,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let trs_iter = get!(CTrsIterator, iter_ptr);
         let res = trs_iter.done();
-        unsafe { *done = res as libc::size_t };
+        unsafe { *done = res as usize };
         Ok(())
     })
 }
@@ -277,12 +277,12 @@ pub unsafe extern "C" fn mut_trs_iterator_set_value(
 #[no_mangle]
 pub unsafe extern "C" fn mut_trs_iterator_done(
     iter_ptr: *const CMutTrsIterator,
-    done: *mut libc::size_t,
+    done: *mut usize,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let trs_iter = get!(CMutTrsIterator, iter_ptr);
         let res = trs_iter.done();
-        unsafe { *done = res as libc::size_t };
+        unsafe { *done = res as usize };
         Ok(())
     })
 }
@@ -362,12 +362,12 @@ pub unsafe extern "C" fn state_iterator_next(
 #[no_mangle]
 pub unsafe extern "C" fn state_iterator_done(
     iter_ptr: *mut CStateIterator,
-    done: *mut libc::size_t,
+    done: *mut usize,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let trs_iter = get_mut!(CStateIterator, iter_ptr);
         let res = trs_iter.peek().is_none();
-        unsafe { *done = res as libc::size_t };
+        unsafe { *done = res as usize };
         Ok(())
     })
 }

--- a/rustfst-ffi/src/lib.rs
+++ b/rustfst-ffi/src/lib.rs
@@ -79,7 +79,9 @@ pub unsafe extern "C" fn rustfst_ffi_get_last_error(
 
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-pub unsafe extern "C" fn rustfst_destroy_string(string: *mut core::ffi::c_char) -> RUSTFST_FFI_RESULT {
+pub unsafe extern "C" fn rustfst_destroy_string(
+    string: *mut core::ffi::c_char,
+) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         CString::drop_raw_pointer(string)?;
         Ok(())

--- a/rustfst-ffi/src/lib.rs
+++ b/rustfst-ffi/src/lib.rs
@@ -45,8 +45,10 @@ pub fn wrap<F: FnOnce() -> Result<()>>(func: F) -> RUSTFST_FFI_RESULT {
         Ok(_) => RUSTFST_FFI_RESULT::RUSTFST_FFI_RESULT_OK,
         Err(e) => {
             let msg = format!("{:#?}", e);
-            if std::env::var("AMSTRAM_FFI_ERROR_STDERR").is_ok() {
-                eprintln!("{}", msg);
+            if cfg!(feature = "std") {
+                if std::env::var("AMSTRAM_FFI_ERROR_STDERR").is_ok() {
+                    eprintln!("{}", msg);
+                }
             }
             LAST_ERROR.with(|p| *p.borrow_mut() = Some(msg));
             RUSTFST_FFI_RESULT::RUSTFST_FFI_RESULT_KO

--- a/rustfst-ffi/src/lib.rs
+++ b/rustfst-ffi/src/lib.rs
@@ -17,14 +17,14 @@ use anyhow::Result;
 use ffi_convert::{CReprOf, RawPointerConverter};
 
 #[cfg(feature = "rustfst-state-label-u32")]
-pub type CLabel = libc::c_uint;
+pub type CLabel = core::ffi::c_uint;
 #[cfg(not(feature = "rustfst-state-label-u32"))]
-pub type CLabel = libc::size_t;
+pub type CLabel = core::ffi::size_t;
 
 #[cfg(feature = "rustfst-state-label-u32")]
-pub type CStateId = libc::c_uint;
+pub type CStateId = core::ffi::c_uint;
 #[cfg(not(feature = "rustfst-state-label-u32"))]
-pub type CStateId = libc::size_t;
+pub type CStateId = core::ffi::size_t;
 
 #[repr(C)]
 #[allow(non_camel_case_types)]
@@ -61,7 +61,7 @@ pub fn wrap<F: FnOnce() -> Result<()>>(func: F) -> RUSTFST_FFI_RESULT {
 /// Should never happen
 #[no_mangle]
 pub unsafe extern "C" fn rustfst_ffi_get_last_error(
-    error: *mut *mut ::libc::c_char,
+    error: *mut *mut ::core::ffi::c_char,
 ) -> RUSTFST_FFI_RESULT {
     wrap(move || {
         LAST_ERROR.with(|msg| {
@@ -69,7 +69,7 @@ pub unsafe extern "C" fn rustfst_ffi_get_last_error(
                 .borrow_mut()
                 .take()
                 .unwrap_or_else(|| "No error message".to_string());
-            let result: *const ::libc::c_char =
+            let result: *const ::core::ffi::c_char =
                 std::ffi::CString::c_repr_of(string)?.into_raw_pointer();
             unsafe { *error = result as _ }
             Ok(())
@@ -79,7 +79,7 @@ pub unsafe extern "C" fn rustfst_ffi_get_last_error(
 
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-pub unsafe extern "C" fn rustfst_destroy_string(string: *mut libc::c_char) -> RUSTFST_FFI_RESULT {
+pub unsafe extern "C" fn rustfst_destroy_string(string: *mut core::ffi::c_char) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         CString::drop_raw_pointer(string)?;
         Ok(())

--- a/rustfst-ffi/src/lib.rs
+++ b/rustfst-ffi/src/lib.rs
@@ -19,12 +19,12 @@ use ffi_convert::{CReprOf, RawPointerConverter};
 #[cfg(feature = "rustfst-state-label-u32")]
 pub type CLabel = core::ffi::c_uint;
 #[cfg(not(feature = "rustfst-state-label-u32"))]
-pub type CLabel = core::ffi::size_t;
+pub type CLabel = usize;
 
 #[cfg(feature = "rustfst-state-label-u32")]
 pub type CStateId = core::ffi::c_uint;
 #[cfg(not(feature = "rustfst-state-label-u32"))]
-pub type CStateId = core::ffi::size_t;
+pub type CStateId = usize;
 
 #[repr(C)]
 #[allow(non_camel_case_types)]

--- a/rustfst-ffi/src/string_path.rs
+++ b/rustfst-ffi/src/string_path.rs
@@ -30,7 +30,7 @@ pub unsafe extern "C" fn string_path_destroy(iter_ptr: *mut CStringPath) -> RUST
 #[no_mangle]
 pub unsafe extern "C" fn string_path_weight(
     c_string_path: *const CStringPath,
-    weight: *mut libc::c_float,
+    weight: *mut core::ffi::c_float,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let string_path = get!(CStringPath, c_string_path);
@@ -46,13 +46,13 @@ pub unsafe extern "C" fn string_path_weight(
 #[no_mangle]
 pub unsafe extern "C" fn string_path_istring(
     c_string_path: *const CStringPath,
-    c_istring: *mut *const libc::c_char,
+    c_istring: *mut *const core::ffi::c_char,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let string_path = get!(CStringPath, c_string_path);
         let istring = string_path.istring()?;
         unsafe {
-            *c_istring = CString::c_repr_of(istring)?.into_raw_pointer() as *const libc::c_char
+            *c_istring = CString::c_repr_of(istring)?.into_raw_pointer() as *const core::ffi::c_char
         }
 
         Ok(())
@@ -65,13 +65,13 @@ pub unsafe extern "C" fn string_path_istring(
 #[no_mangle]
 pub unsafe extern "C" fn string_path_ostring(
     c_string_path: *const CStringPath,
-    c_ostring: *mut *const libc::c_char,
+    c_ostring: *mut *const core::ffi::c_char,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let string_path = get!(CStringPath, c_string_path);
         let ostring = string_path.ostring()?;
         unsafe {
-            *c_ostring = CString::c_repr_of(ostring)?.into_raw_pointer() as *const libc::c_char
+            *c_ostring = CString::c_repr_of(ostring)?.into_raw_pointer() as *const core::ffi::c_char
         }
 
         Ok(())

--- a/rustfst-ffi/src/string_paths_iterator.rs
+++ b/rustfst-ffi/src/string_paths_iterator.rs
@@ -94,12 +94,12 @@ pub unsafe extern "C" fn string_paths_iterator_next(
 #[no_mangle]
 pub unsafe extern "C" fn string_paths_iterator_done(
     iter_ptr: *mut CStringPathsIterator,
-    done: *mut libc::size_t,
+    done: *mut usize,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let string_paths_iter = get_mut!(CStringPathsIterator, iter_ptr);
         let res = string_paths_iter.peek().is_none();
-        unsafe { *done = res as libc::size_t };
+        unsafe { *done = res as usize };
         Ok(())
     })
 }

--- a/rustfst-ffi/src/symbol_table.rs
+++ b/rustfst-ffi/src/symbol_table.rs
@@ -105,6 +105,7 @@ pub unsafe extern "C" fn symt_find_symbol(
 /// # Safety
 ///
 /// The pointers should be valid.
+#[cfg(feature = "std")]
 #[no_mangle]
 pub unsafe extern "C" fn symt_from_path(
     table_ptr: *mut *const CSymbolTable,
@@ -128,6 +129,7 @@ pub unsafe extern "C" fn symt_from_path(
 /// # Safety
 ///
 /// The pointers should be valid.
+#[cfg(feature = "std")]
 #[no_mangle]
 pub unsafe extern "C" fn symt_write_file(
     symt: *const CSymbolTable,

--- a/rustfst-ffi/src/symbol_table.rs
+++ b/rustfst-ffi/src/symbol_table.rs
@@ -28,8 +28,8 @@ pub unsafe extern "C" fn symt_new(new_struct: *mut *const CSymbolTable) -> RUSTF
 #[no_mangle]
 pub unsafe extern "C" fn symt_add_symbol(
     symt: *mut CSymbolTable,
-    symbol: *const libc::c_char,
-    integer_key: *mut libc::size_t,
+    symbol: *const core::ffi::c_char,
+    integer_key: *mut usize,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let symt = get_mut!(CSymbolTable, symt);
@@ -37,7 +37,7 @@ pub unsafe extern "C" fn symt_add_symbol(
         let res = Arc::get_mut(symt)
             .ok_or_else(|| anyhow!("Could not get a mutable reference to the symbol table"))?
             .add_symbol(&symbol);
-        unsafe { *integer_key = res as libc::size_t };
+        unsafe { *integer_key = res as usize };
         Ok(())
     })
 }
@@ -67,7 +67,7 @@ pub unsafe extern "C" fn symt_add_table(
 pub unsafe extern "C" fn symt_find_index(
     symt: *const CSymbolTable,
     key: CStateId,
-    symbol: *mut *const libc::c_char,
+    symbol: *mut *const core::ffi::c_char,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let symt = get!(CSymbolTable, symt);
@@ -76,7 +76,7 @@ pub unsafe extern "C" fn symt_find_index(
             .ok_or_else(|| format_err!("No symbol found at index:{}", key as i32))?;
         unsafe {
             *symbol = CString::c_repr_of(found_symbol.to_string())?.into_raw_pointer()
-                as *const libc::c_char
+                as *const core::ffi::c_char
         };
         Ok(())
     })
@@ -88,8 +88,8 @@ pub unsafe extern "C" fn symt_find_index(
 #[no_mangle]
 pub unsafe extern "C" fn symt_find_symbol(
     symt: *const CSymbolTable,
-    symbol: *const libc::c_char,
-    key: *mut libc::size_t,
+    symbol: *const core::ffi::c_char,
+    key: *mut usize,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let symt = get!(CSymbolTable, symt);
@@ -97,7 +97,7 @@ pub unsafe extern "C" fn symt_find_symbol(
         let res = symt
             .get_label(&symbol)
             .ok_or_else(|| format_err!("No symbol `{}` found", symbol))?;
-        unsafe { *key = res as libc::size_t };
+        unsafe { *key = res as usize };
         Ok(())
     })
 }
@@ -109,8 +109,8 @@ pub unsafe extern "C" fn symt_find_symbol(
 #[no_mangle]
 pub unsafe extern "C" fn symt_from_path(
     table_ptr: *mut *const CSymbolTable,
-    path_ptr: *const libc::c_char,
-    binary: *const libc::size_t,
+    path_ptr: *const core::ffi::c_char,
+    binary: *const usize,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let path = unsafe { CStr::from_ptr(path_ptr) }.as_rust()?;
@@ -133,8 +133,8 @@ pub unsafe extern "C" fn symt_from_path(
 #[no_mangle]
 pub unsafe extern "C" fn symt_write_file(
     symt: *const CSymbolTable,
-    path_ptr: *const libc::c_char,
-    binary: *const libc::size_t,
+    path_ptr: *const core::ffi::c_char,
+    binary: *const usize,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let symt = get!(CSymbolTable, symt);
@@ -157,12 +157,12 @@ pub unsafe extern "C" fn symt_write_file(
 pub unsafe extern "C" fn symt_member_index(
     symt: *const CSymbolTable,
     key: CStateId,
-    is_present: *mut libc::size_t,
+    is_present: *mut usize,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let symt = get!(CSymbolTable, symt);
         let res = symt.contains_label(key);
-        unsafe { *is_present = res as libc::size_t };
+        unsafe { *is_present = res as usize };
         Ok(())
     })
 }
@@ -173,14 +173,14 @@ pub unsafe extern "C" fn symt_member_index(
 #[no_mangle]
 pub unsafe extern "C" fn symt_member_symbol(
     symt: *const CSymbolTable,
-    symbol: *const libc::c_char,
-    is_present: *mut libc::size_t,
+    symbol: *const core::ffi::c_char,
+    is_present: *mut usize,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let symt = get!(CSymbolTable, symt);
         let symbol = unsafe { CStr::from_ptr(symbol) }.as_rust()?;
         let res = symt.contains_symbol(symbol);
-        unsafe { *is_present = res as libc::size_t };
+        unsafe { *is_present = res as usize };
         Ok(())
     })
 }
@@ -191,11 +191,11 @@ pub unsafe extern "C" fn symt_member_symbol(
 #[no_mangle]
 pub unsafe extern "C" fn symt_num_symbols(
     symt: *const CSymbolTable,
-    num_symbols: *mut libc::size_t,
+    num_symbols: *mut usize,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let symt = get!(CSymbolTable, symt);
-        unsafe { *num_symbols = symt.len() as libc::size_t };
+        unsafe { *num_symbols = symt.len() as usize };
         Ok(())
     })
 }
@@ -224,7 +224,7 @@ pub unsafe extern "C" fn symt_copy(
 pub unsafe fn symt_equals(
     symt: *const CSymbolTable,
     other_symt: *const CSymbolTable,
-    is_equal: *mut libc::size_t,
+    is_equal: *mut usize,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let symt = get!(CSymbolTable, symt);

--- a/rustfst-ffi/src/tr.rs
+++ b/rustfst-ffi/src/tr.rs
@@ -24,7 +24,7 @@ pub struct CTr {
 #[repr(C)]
 #[derive(CDrop, RawPointerConverter)]
 pub struct CTropicalWeight {
-    value: libc::c_float,
+    value: core::ffi::c_float,
 }
 
 impl CReprOf<TropicalWeight> for CTropicalWeight {
@@ -48,7 +48,7 @@ impl AsRust<TropicalWeight> for CTropicalWeight {
 pub unsafe extern "C" fn tr_new(
     ilabel: CLabel,
     olabel: CLabel,
-    weight: libc::c_float,
+    weight: core::ffi::c_float,
     nextstate: CStateId,
     new_struct: *mut *const CTr,
 ) -> RUSTFST_FFI_RESULT {
@@ -121,7 +121,7 @@ pub unsafe extern "C" fn tr_set_olabel(tr: *mut CTr, olabel: *const CLabel) -> R
 #[no_mangle]
 pub unsafe extern "C" fn tr_weight(
     tr: *const CTr,
-    weight: *mut libc::c_float,
+    weight: *mut core::ffi::c_float,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let tr = unsafe { <CTr as ffi_convert::RawBorrow<CTr>>::raw_borrow(tr)? };
@@ -135,7 +135,7 @@ pub unsafe extern "C" fn tr_weight(
 ///
 /// The pointers should be valid.
 #[no_mangle]
-pub unsafe extern "C" fn tr_set_weight(tr: *mut CTr, weight: libc::c_float) -> RUSTFST_FFI_RESULT {
+pub unsafe extern "C" fn tr_set_weight(tr: *mut CTr, weight: core::ffi::c_float) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let tr = &mut unsafe { <CTr as ffi_convert::RawBorrowMut<CTr>>::raw_borrow_mut(tr)? };
         let tropical_weight = TropicalWeight::new(weight);

--- a/rustfst-ffi/src/tr.rs
+++ b/rustfst-ffi/src/tr.rs
@@ -135,7 +135,10 @@ pub unsafe extern "C" fn tr_weight(
 ///
 /// The pointers should be valid.
 #[no_mangle]
-pub unsafe extern "C" fn tr_set_weight(tr: *mut CTr, weight: core::ffi::c_float) -> RUSTFST_FFI_RESULT {
+pub unsafe extern "C" fn tr_set_weight(
+    tr: *mut CTr,
+    weight: core::ffi::c_float,
+) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let tr = &mut unsafe { <CTr as ffi_convert::RawBorrowMut<CTr>>::raw_borrow_mut(tr)? };
         let tropical_weight = TropicalWeight::new(weight);

--- a/rustfst-ffi/src/trs.rs
+++ b/rustfst-ffi/src/trs.rs
@@ -30,7 +30,7 @@ pub unsafe extern "C" fn trs_vec_new(new_struct: *mut *const CTrs) -> RUSTFST_FF
 #[no_mangle]
 pub unsafe extern "C" fn trs_vec_remove(
     trs: *mut CTrs,
-    index: libc::size_t,
+    index: usize,
     removed_tr_ptr: *mut *const CTr,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {
@@ -78,11 +78,11 @@ pub unsafe extern "C" fn trs_vec_shallow_clone(
 #[no_mangle]
 pub unsafe extern "C" fn trs_vec_len(
     trs: *const CTrs,
-    num_trs: *mut libc::size_t,
+    num_trs: *mut usize,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let trs = get!(CTrs, trs);
-        unsafe { *num_trs = trs.len() as libc::size_t };
+        unsafe { *num_trs = trs.len() as usize };
         Ok(())
     })
 }
@@ -93,13 +93,13 @@ pub unsafe extern "C" fn trs_vec_len(
 #[no_mangle]
 pub unsafe extern "C" fn trs_vec_display(
     trs: *const CTrs,
-    string: *mut *const libc::c_char,
+    string: *mut *const core::ffi::c_char,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let trs = get!(CTrs, trs);
         let trs_display = format!("{:?}", trs);
         unsafe {
-            *string = CString::c_repr_of(trs_display)?.into_raw_pointer() as *const libc::c_char
+            *string = CString::c_repr_of(trs_display)?.into_raw_pointer() as *const core::ffi::c_char
         };
         Ok(())
     })

--- a/rustfst-ffi/src/trs.rs
+++ b/rustfst-ffi/src/trs.rs
@@ -76,10 +76,7 @@ pub unsafe extern "C" fn trs_vec_shallow_clone(
 ///
 /// The pointers should be valid.
 #[no_mangle]
-pub unsafe extern "C" fn trs_vec_len(
-    trs: *const CTrs,
-    num_trs: *mut usize,
-) -> RUSTFST_FFI_RESULT {
+pub unsafe extern "C" fn trs_vec_len(trs: *const CTrs, num_trs: *mut usize) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let trs = get!(CTrs, trs);
         unsafe { *num_trs = trs.len() as usize };
@@ -99,7 +96,8 @@ pub unsafe extern "C" fn trs_vec_display(
         let trs = get!(CTrs, trs);
         let trs_display = format!("{:?}", trs);
         unsafe {
-            *string = CString::c_repr_of(trs_display)?.into_raw_pointer() as *const core::ffi::c_char
+            *string =
+                CString::c_repr_of(trs_display)?.into_raw_pointer() as *const core::ffi::c_char
         };
         Ok(())
     })

--- a/rustfst/Cargo.toml
+++ b/rustfst/Cargo.toml
@@ -18,6 +18,7 @@ edition = '2018'
 
 [features]
 default = ["state-label-u32"]
+std = ["rand", "rand_chacha"]
 state-label-u32 = []
 
 [dependencies]
@@ -27,15 +28,14 @@ bitflags = '2.5'
 generic-array = '1'
 itertools = '0.14'
 nom = '7'
-num-traits = '0.2'
-ordered-float = '5'
-rand = '0.9'
-rand_chacha = '0.9'
-serde = { version = '1', features = ['derive'] }
 superslice = '1'
+ordered-float = { version = "5.0", default-features = false }
+rand = { version = '0.9', optional = true }
+rand_chacha = { version = '0.9', optional = true }
 
 [dev-dependencies]
 counter = '0.7'
+serde = { version = '1', features = ['derive'] }
 serde_json = '1.0'
 tempfile = '3.0'
 path_abs = '0.5'

--- a/rustfst/Cargo.toml
+++ b/rustfst/Cargo.toml
@@ -17,7 +17,7 @@ repository = 'https://github.com/Garvys/rustfst'
 edition = '2018'
 
 [features]
-default = ["state-label-u32"]
+default = ["std", "state-label-u32"]
 std = ["rand", "rand_chacha"]
 state-label-u32 = []
 

--- a/rustfst/Cargo.toml
+++ b/rustfst/Cargo.toml
@@ -18,7 +18,7 @@ edition = '2018'
 
 [features]
 default = ["std", "state-label-u32"]
-std = ["rand", "rand_chacha"]
+std = ["rand_chacha/os_rng"]
 state-label-u32 = []
 
 [dependencies]
@@ -30,8 +30,8 @@ itertools = '0.14'
 nom = '7'
 superslice = '1'
 ordered-float = { version = "5.0", default-features = false }
-rand = { version = '0.9', optional = true }
-rand_chacha = { version = '0.9', optional = true }
+rand = { version = '0.9', default-features = false }
+rand_chacha = { version = '0.9', default-features = false }
 
 [dev-dependencies]
 counter = '0.7'

--- a/rustfst/src/algorithms/compose/interval_set.rs
+++ b/rustfst/src/algorithms/compose/interval_set.rs
@@ -1,4 +1,3 @@
-use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::collections::HashSet;
 use std::slice::Iter as IterSlice;
@@ -6,7 +5,7 @@ use std::vec::IntoIter as IntoIterVec;
 use superslice::Ext;
 
 /// Half-open integral interval [a, b) of signed integers of type T.
-#[derive(PartialEq, Clone, Eq, Debug, Serialize, Deserialize)]
+#[derive(PartialEq, Clone, Eq, Debug)] //, Serialize, Deserialize)]
 pub struct IntInterval {
     pub begin: usize,
     pub end: usize,

--- a/rustfst/src/algorithms/mod.rs
+++ b/rustfst/src/algorithms/mod.rs
@@ -59,6 +59,7 @@ mod push;
 mod queue;
 
 /// Functions to randomly generate paths through an Fst. A static and a delayed version are available.
+#[cfg(feature = "std")]
 pub mod randgen;
 mod relabel_pairs;
 /// Functions for lazy replacing transitions in an FST.

--- a/rustfst/src/algorithms/mod.rs
+++ b/rustfst/src/algorithms/mod.rs
@@ -59,7 +59,6 @@ mod push;
 mod queue;
 
 /// Functions to randomly generate paths through an Fst. A static and a delayed version are available.
-#[cfg(feature = "std")]
 pub mod randgen;
 mod relabel_pairs;
 /// Functions for lazy replacing transitions in an FST.

--- a/rustfst/src/algorithms/randgen/tr_selector.rs
+++ b/rustfst/src/algorithms/randgen/tr_selector.rs
@@ -28,9 +28,16 @@ impl Default for UniformTrSelector {
 }
 
 impl UniformTrSelector {
+    #[cfg(feature = "std")]
     pub fn new() -> Self {
         Self {
             rng: ChaCha8Rng::from_os_rng(),
+        }
+    }
+    #[cfg(not(feature = "std"))]
+    pub fn new() -> Self {
+        Self {
+            rng: ChaCha8Rng::seed_from_u64(12345),
         }
     }
     pub fn from_seed(seed: u64) -> Self {


### PR DESCRIPTION
Currently in order to get rustfst to run in the browser it's necessary to build it as WASI and then stub out the imported WASI symbols (using https://github.com/typst-community/wasm-minimal-protocol/tree/main/crates/wasi-stub for instance)

This is suboptimal since it adds an extra build step and retains useless code in the binaries.  But unfortunately it's not actually possible to build `rustfst-ffi` for the bare metal WebAssembly target `wasm32-unknown-unknown` for a couple of reasons:

1. `randgen` requires `getrandom` which doesn't work on wasm32-unknown (there is a way around this but it's discouraged for libraries: https://docs.rs/getrandom/latest/getrandom/#webassembly-support)
2. `ffi-convert` doesn't compile for `wasm32-unknown-unknown` because of a (useless) dependency on `libc` (see https://github.com/sonos/ffi-convert-rs/pull/68), and `libc` is also (uselessly) used in a lot of places in `rustfst-ffi`
3. obviously there are a few file I/O operations for loading and saving symbol tables and FSTs and such!

(I realize using `libc` is probably leftover from when `std::ffi` and `core::ffi` weren't very good, as the now very dated "Rust FFI Omnibus" suggests to do)

This PR adds a `std` default feature which compiles these things that require stdio.  So to build for `wasm32-unknown-unknown` you can omit the default features, the same pattern as we see elsewhere:

```
cargo build --package rustfst-ffi --no-default-features --target wasm32-unknown-unknown
```
(--features rustfst-state-label-u32 is unnecessary since wasm32 is 32)
(doesn't work for the top-level build because Reasons)

Because there isn't yet a version of `ffi-convert` that compiles, and when it will be released it will require Rust 2024, and I'm not sure if you want to require that here, I've simply vendored a fixed version of it since the license is totally compatible.

Note: changing `libc::size_t` to `usize` has revealed that ... why exactly are you using `usize` for all those things in `rustfst-ffi`?  Possibly for some of them it should be the same type as state IDs which I think is either `usize` or `u32` (of course these are the same thing on WebAssembly!)