### PR TITLE
Export LabelLookAheadRelabeler

### DIFF
--- a/rustfst/src/algorithms/compose/lookahead_matchers/mod.rs
+++ b/rustfst/src/algorithms/compose/lookahead_matchers/mod.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use anyhow::Result;
 
 pub use label_lookahead_matcher::LabelLookAheadMatcher;
-pub(super) use label_lookahead_relabeler::LabelLookAheadRelabeler;
+pub use label_lookahead_relabeler::LabelLookAheadRelabeler;
 pub use tr_lookahead_matcher::TrLookAheadMatcher;
 pub use trivial_lookahead_matcher::TrivialLookAheadMatcher;
 


### PR DESCRIPTION
## What

Widen one re-export from `pub(super)` to `pub`.

## Why

`LabelLookAheadRelabeler` has `pub fn init` and `pub fn relabel`, but
`lookahead_matchers/mod.rs` re-exports the type as `pub(super)`, so neither is
callable from outside the crate.

That blocks the natural way to use lookahead composition when one side is static
and the other changes per call:

1. build the lookahead FST (and its `LabelReachableData`) **once**, then
2. relabel each new FST into that index space before composing.

Step 2 needs `LabelLookAheadRelabeler::relabel`. Without it the only reachable
entry point is `MatcherFst::new_with_relabeling`, which fuses "build the
reachability tables" with "relabel the other FST", so the tables are rebuilt on
every composition.

## Impact

Measured on a text-normalization workload: short linear input acceptors composed
against a static 187k-state grammar, then shortest path.

|  | before (plain `compose`) | after (lookahead) |
|---|---|---|
| per input | 14.4 ms | **3.8 ms** |
| throughput | 2.1 chars/ms | **7.9 chars/ms** |

Building the tables moves to startup (~300 ms, one-off). Output is unchanged:
verified byte-for-byte against plain `compose` across a 184-case regression
corpus.

For reference, OpenFST (via pynini) on the same grammar and corpus measures
7.4 ms per input, so this path makes rustfst roughly 2x faster than OpenFST here
— but only if the relabeler is reachable.

## Risk

Should be none: the type and both of its methods are already `pub`; only the
module re-export is widened, matching the other items in that module.

## Note

Assembling lookahead composition currently requires hand-writing the nested
matcher/filter generics, since `ComposeFilterEnum` has no lookahead variant and
`compose_static::create_matcher` always builds a `SortedMatcher`. Happy to
follow up with a convenience entry point and/or docs if that would be welcome.