### PR TITLE
Fix README doctest path so the published crate can be tested

### DIFF
--- a/rustfst/Cargo.toml
+++ b/rustfst/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.3.1"
 authors = ['Alexandre Caulier<alexandre.caulier@protonmail.com>']
 description = 'Library for constructing, combining, optimizing, and searching weighted finite-state transducers (FSTs).'
 documentation = 'https://docs.rs/rustfst'
-readme = '../README.md'
+readme = 'README.md'
 keywords = [
     'FST',
     'graph',

--- a/rustfst/README.md
+++ b/rustfst/README.md
@@ -1,0 +1,1 @@
+../README.md

--- a/rustfst/src/lib.rs
+++ b/rustfst/src/lib.rs
@@ -211,7 +211,7 @@ use doc_comment::doc_comment;
 
 // When running `cargo test`, rustdoc will check this file as well.
 #[cfg(test)]
-doc_comment!(include_str!("../../README.md"));
+doc_comment!(include_str!("../README.md"));
 
 #[cfg(test)]
 mod tests_openfst;


### PR DESCRIPTION
## Problem

`cargo test` fails to **compile** on the crate as published to crates.io:

```
error: couldn't read `.../rustfst-1.3.1/src/../../README.md`:
       No such file or directory (os error 2)
error: could not compile `rustfst` (lib test)
```

Reproduce without a checkout:

```bash
cargo new /tmp/repro && cd /tmp/repro
cargo add rustfst@1.3.1
cargo vendor >/dev/null && cd vendor/rustfst && cargo test
```

## Cause

`rustfst/src/lib.rs` has:

```rust
#[cfg(test)]
doc_comment!(include_str!("../../README.md"));
```

`../../README.md` is correct **in the repository** — from `rustfst/src/` it
resolves to the workspace-root README.

It is wrong **in the published package**. `readme = '../README.md'` makes Cargo
copy that file into the package root, so inside the package the README sits next
to `src/` and `../../README.md` points outside the package.

Normal builds are unaffected because the include is `#[cfg(test)]`, but anyone
vendoring the crate or running its test suite from the registry copy hits it.

## Fix

Add `rustfst/README.md` as a symlink to the workspace README, point `readme` at
it, and include it as `../README.md` — a path that resolves identically in the
repository and in the package. Cargo follows symlinks when packaging, so the
release still ships a real README at the crate root.

## Verification

- `cargo package --list` yields the same `README.md` entry as before the change.
- `cargo test --lib --no-run` compiles in-repo.
- Patching the vendored 1.3.1 package the same way makes its lib test target
  compile (it previously failed at compile time). The remaining `tests_openfst`
  failures there are unrelated and pre-existing — those tests need the
  `rustfst-tests-data` directory, which is not part of the published package.

## One thing to check

`generate_readme_from_rustdoc.sh` runs `cargo sync-readme -f lib` from
`rustfst/`. Writing through the symlink updates the workspace README as before,
but if `cargo-sync-readme` replaces the file rather than writing through it, the
symlink would be clobbered and would need restoring. I could not verify that
behaviour here.

If you would rather avoid a symlink, two alternatives:

- keep `readme = '../README.md'` and move the README doctest into an integration
  test under `rustfst/tests/`, where the packaged path is stable; or
- drop the `doc_comment!` include entirely if the README examples are covered
  elsewhere.

Happy to switch to whichever you prefer.